### PR TITLE
Add agicore_core package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ build-backend = "gpt_oss_build_backend.backend"
 backend-path = ["_build"]
 
 [tool.setuptools]
-packages = ["gpt_oss"]
+packages = ["gpt_oss", "agicore_core"]
 
 [tool.scikit-build]
 cmake.source-dir = "." # pick up the root CMakeLists.txt


### PR DESCRIPTION
## Summary
- add empty agicore_core package
- include agicore_core in setuptools packages

## Testing
- `pytest` *(fails: openai_harmony.HarmonyError: error downloading or loading vocab file)*

------
https://chatgpt.com/codex/tasks/task_e_6894123f09448327a23562a920f02f03