### PR TITLE
Add basic Planner using agix

### DIFF
--- a/agicore_core/__init__.py
+++ b/agicore_core/__init__.py
@@ -1,0 +1,5 @@
+"""Componentes básicos del núcleo de planificación."""
+
+from .planner import Planner
+
+__all__ = ["Planner"]

--- a/agicore_core/planner.py
+++ b/agicore_core/planner.py
@@ -1,0 +1,48 @@
+"""Herramientas de planificación usando `agix`.
+
+Este módulo expone la clase :class:`Planner` que genera planes
+sencillos mediante la API de `agix`. Su objetivo es mostrar cómo
+integrar las capacidades de orquestación de `agix` en componentes
+de planificación.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from agix.orchestrator import VirtualQualia
+
+
+class Planner:
+    """Genera planes utilizando la API de :mod:`agix`.
+
+    Parameters
+    ----------
+    orchestrator:
+        Instancia de :class:`agix.orchestrator.VirtualQualia` utilizada para
+        coordinar la difusión de estados. Si no se proporciona, se crea una
+        instancia sin clientes registrados.
+    """
+
+    def __init__(self, orchestrator: Optional[VirtualQualia] = None) -> None:
+        self.orchestrator = orchestrator or VirtualQualia()
+
+    def plan(self, state: Dict[str, Any]) -> List[Any]:
+        """Genera un plan basado en el ``state`` dado.
+
+        El estado se difunde a través del orquestador de `agix` y las
+        respuestas obtenidas representan el plan resultante.
+
+        Parameters
+        ----------
+        state:
+            Descripción del objetivo o estado inicial.
+
+        Returns
+        -------
+        list
+            Lista de respuestas proporcionadas por los clientes del
+            orquestador.
+        """
+
+        return self.orchestrator.broadcast_state(state)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,9 @@
+"""Pruebas para el módulo :mod:`agicore_core.planner`."""
+
+from agicore_core import Planner
+
+
+def test_plan_returns_list():
+    planner = Planner()
+    result = planner.plan({"task": "demo"})
+    assert isinstance(result, list)


### PR DESCRIPTION
## Summary
- add Planner class leveraging agix VirtualQualia orchestrator
- expose Planner from agicore_core
- test Planner returns a list of responses

## Testing
- `pytest` *(fails: openai_harmony.HarmonyError: error downloading or loading vocab file)*
- `pytest tests/test_planner.py`


------
https://chatgpt.com/codex/tasks/task_e_6894151ce29483279f44487d730a1420