### PR TITLE
feat: add meta router

### DIFF
--- a/docs/meta_router.md
+++ b/docs/meta_router.md
@@ -1,0 +1,15 @@
+# Flujo de enrutamiento
+
+El archivo `meta_router.py` introduce la clase `MetaRouter`, un punto central
+para enviar solicitudes a distintos módulos.
+
+1. El cliente construye un diccionario con la clave `module` que identifica el
+   destino.
+2. `MetaRouter` busca el módulo en su registro interno.
+3. Si el módulo es `reasoning`, se invoca a `ReasoningKernel.execute_plan` con
+   el plan provisto en `plan`.
+4. Para cualquier otro módulo registrado se llama a su método `handle` y se
+   le entrega el diccionario original.
+
+Este diseño permite ampliar el sistema registrando nuevos módulos sin modificar
+el núcleo del enrutador.

--- a/meta_router.py
+++ b/meta_router.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Enrutador central para delegar solicitudes entre módulos.
+
+La clase :class:`MetaRouter` mantiene un registro de módulos y dirige cada
+solicitud al destino adecuado. Por defecto se registra el
+:class:`agicore_core.ReasoningKernel` bajo la clave ``"reasoning"``.
+"""
+
+from typing import Any, Dict
+
+from agicore_core import ReasoningKernel
+
+
+class MetaRouter:
+    """Enrutador minimalista de solicitudes.
+
+    Los módulos adicionales deben proporcionar un método ``handle`` que reciba
+    un diccionario con la solicitud. Para el caso del módulo ``"reasoning"`` se
+    utiliza :class:`ReasoningKernel` y se espera una clave ``"plan"`` con los
+    pasos a ejecutar.
+    """
+
+    def __init__(self) -> None:
+        self._modules: Dict[str, Any] = {}
+        # Registro por defecto del kernel de razonamiento.
+        self.register("reasoning", ReasoningKernel())
+
+    def register(self, name: str, module: Any) -> None:
+        """Registra un ``module`` bajo el identificador ``name``."""
+
+        self._modules[name] = module
+
+    def route(self, request: Dict[str, Any]) -> Any:
+        """Envía ``request`` al módulo adecuado.
+
+        Parameters
+        ----------
+        request:
+            Diccionario que contiene al menos la clave ``"module"`` que indica
+            el destino.
+        """
+
+        module_name = request.get("module")
+        if module_name not in self._modules:
+            raise ValueError(f"Módulo no registrado: {module_name}")
+
+        module = self._modules[module_name]
+        if isinstance(module, ReasoningKernel):
+            plan = request.get("plan", [])
+            return module.execute_plan(plan)
+
+        if hasattr(module, "handle"):
+            return module.handle(request)
+
+        raise ValueError(f"Módulo {module_name} incompatible")

--- a/tests/test_meta_router.py
+++ b/tests/test_meta_router.py
@@ -1,0 +1,36 @@
+"""Pruebas para :mod:`meta_router`."""
+
+from meta_router import MetaRouter
+import pytest
+
+
+class DummyModule:
+    def __init__(self):
+        self.received = None
+
+    def handle(self, request):
+        self.received = request
+        return "ok"
+
+
+def test_routes_to_reasoning_kernel():
+    router = MetaRouter()
+    plan = [{"step": 1}]
+    result = router.route({"module": "reasoning", "plan": plan})
+    assert isinstance(result, list)
+    assert len(result) == len(plan)
+
+
+def test_routes_to_custom_module():
+    router = MetaRouter()
+    dummy = DummyModule()
+    router.register("dummy", dummy)
+    result = router.route({"module": "dummy", "payload": 123})
+    assert result == "ok"
+    assert dummy.received["payload"] == 123
+
+
+def test_unknown_module_raises_error():
+    router = MetaRouter()
+    with pytest.raises(ValueError):
+        router.route({"module": "missing"})


### PR DESCRIPTION
## Summary
- add MetaRouter to delegate requests to ReasoningKernel or custom handlers
- document routing flow
- cover routing scenarios with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689426a9ee2c8327a1d1037124422a45