### PR TITLE
feat: enrutar solicitudes según expertos

### DIFF
--- a/meta_router.py
+++ b/meta_router.py
@@ -7,50 +7,132 @@ solicitud al destino adecuado. Por defecto se registra el
 :class:`agicore_core.ReasoningKernel` bajo la clave ``"reasoning"``.
 """
 
-from typing import Any, Dict
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
 
 from agicore_core import ReasoningKernel
 
 
-class MetaRouter:
-    """Enrutador minimalista de solicitudes.
+@dataclass
+class Expert:
+    """Contenedor de metadatos para cada experto registrado."""
 
-    Los módulos adicionales deben proporcionar un método ``handle`` que reciba
-    un diccionario con la solicitud. Para el caso del módulo ``"reasoning"`` se
-    utiliza :class:`ReasoningKernel` y se espera una clave ``"plan"`` con los
-    pasos a ejecutar.
+    module: Any
+    tasks: List[str] = field(default_factory=list)
+    contexts: List[str] = field(default_factory=list)
+    goals: List[str] = field(default_factory=list)
+    priority: int = 0
+
+
+class ReasoningExpert:
+    """Pequeño adaptador para :class:`ReasoningKernel`.
+
+    Provee un método :meth:`handle` que delega en
+    :meth:`ReasoningKernel.execute_plan` para mantener una interfaz común
+    entre todos los expertos registrados.
+    """
+
+    def __init__(self, kernel: ReasoningKernel) -> None:
+        self._kernel = kernel
+
+    def handle(self, request: Dict[str, Any]) -> Any:  # pragma: no cover - delega
+        plan = request.get("plan", [])
+        return self._kernel.execute_plan(plan)
+
+
+class MetaRouter:
+    """Enrutador de solicitudes basado en expertos.
+
+    Los expertos registrados deben implementar un método ``handle`` que reciba
+    un diccionario con la solicitud completa. Cada experto puede declarar las
+    tareas, contextos y metas que soporta para que el enrutador seleccione el
+    más adecuado.
     """
 
     def __init__(self) -> None:
-        self._modules: Dict[str, Any] = {}
-        # Registro por defecto del kernel de razonamiento.
-        self.register("reasoning", ReasoningKernel())
+        self._experts: Dict[str, Expert] = {}
+        # Registro por defecto del kernel de razonamiento con un adaptador.
+        self.register(
+            "reasoning",
+            ReasoningExpert(ReasoningKernel()),
+            tasks=["reasoning"],
+        )
 
-    def register(self, name: str, module: Any) -> None:
-        """Registra un ``module`` bajo el identificador ``name``."""
+    def register(
+        self,
+        name: str,
+        module: Any,
+        *,
+        tasks: List[str] | None = None,
+        contexts: List[str] | None = None,
+        goals: List[str] | None = None,
+        priority: int = 0,
+    ) -> None:
+        """Registra un nuevo ``module`` bajo ``name`` con metadatos opcionales."""
 
-        self._modules[name] = module
+        self._experts[name] = Expert(
+            module=module,
+            tasks=tasks or [],
+            contexts=contexts or [],
+            goals=goals or [],
+            priority=priority,
+        )
+
+    def select_expert(
+        self, task: str, context: str, goals: List[str]
+    ) -> Dict[str, int]:
+        """Calcula un puntaje para cada experto registrado.
+
+        La heurística otorga puntos por coincidencia exacta entre la solicitud y
+        los metadatos de cada experto. Cada tarea o contexto coincidente suma un
+        punto y cada meta coincidente suma otro. Además se añade la ``priority``
+        declarada por el experto.
+        """
+
+        scores: Dict[str, int] = {}
+        goals_set = set(goals)
+        for name, expert in self._experts.items():
+            score = expert.priority
+            if task in expert.tasks:
+                score += 1
+            if context in expert.contexts:
+                score += 1
+            score += len(goals_set.intersection(expert.goals))
+            scores[name] = score
+        return scores
 
     def route(self, request: Dict[str, Any]) -> Any:
-        """Envía ``request`` al módulo adecuado.
+        """Envía ``request`` al experto más adecuado.
 
         Parameters
         ----------
         request:
-            Diccionario que contiene al menos la clave ``"module"`` que indica
-            el destino.
+            Diccionario que debe contener las claves ``"task"``, ``"context"``
+            y ``"goals"`` (lista de metas). Otros campos se pasan directamente
+            al experto seleccionado.
         """
 
-        module_name = request.get("module")
-        if module_name not in self._modules:
-            raise ValueError(f"Módulo no registrado: {module_name}")
+        task = request.get("task")
+        context = request.get("context")
+        goals = request.get("goals")
+        if task is None or context is None or goals is None:
+            raise ValueError(
+                "La solicitud debe incluir 'task', 'context' y 'goals'"
+            )
 
-        module = self._modules[module_name]
-        if isinstance(module, ReasoningKernel):
-            plan = request.get("plan", [])
-            return module.execute_plan(plan)
+        scores = self.select_expert(task, context, goals)
+        if not scores:
+            raise ValueError("No hay expertos registrados")
 
-        if hasattr(module, "handle"):
-            return module.handle(request)
+        max_score = max(scores.values())
+        if max_score <= 0:
+            raise ValueError("Ningún experto coincide con la solicitud")
 
-        raise ValueError(f"Módulo {module_name} incompatible")
+        candidates = [name for name, score in scores.items() if score == max_score]
+        # Regla de desempate: orden alfabético del nombre del experto.
+        selected_name = sorted(candidates)[0]
+        expert = self._experts[selected_name].module
+        if hasattr(expert, "handle"):
+            return expert.handle(request)
+
+        raise ValueError(f"Experto {selected_name} incompatible")

--- a/tests/test_meta_router.py
+++ b/tests/test_meta_router.py
@@ -16,7 +16,13 @@ class DummyModule:
 def test_routes_to_reasoning_kernel():
     router = MetaRouter()
     plan = [{"step": 1}]
-    result = router.route({"module": "reasoning", "plan": plan})
+    request = {
+        "task": "reasoning",
+        "context": "test",
+        "goals": [],
+        "plan": plan,
+    }
+    result = router.route(request)
     assert isinstance(result, list)
     assert len(result) == len(plan)
 
@@ -24,13 +30,25 @@ def test_routes_to_reasoning_kernel():
 def test_routes_to_custom_module():
     router = MetaRouter()
     dummy = DummyModule()
-    router.register("dummy", dummy)
-    result = router.route({"module": "dummy", "payload": 123})
+    router.register(
+        "dummy",
+        dummy,
+        tasks=["dummy_task"],
+        contexts=["dummy_ctx"],
+        goals=["dgoal"],
+    )
+    request = {
+        "task": "dummy_task",
+        "context": "dummy_ctx",
+        "goals": ["dgoal"],
+        "payload": 123,
+    }
+    result = router.route(request)
     assert result == "ok"
     assert dummy.received["payload"] == 123
 
 
-def test_unknown_module_raises_error():
+def test_unknown_task_raises_error():
     router = MetaRouter()
     with pytest.raises(ValueError):
-        router.route({"module": "missing"})
+        router.route({"task": "missing", "context": "", "goals": []})


### PR DESCRIPTION
## Summary
- add expert metadata registry and selection logic
- route requests to highest scoring expert with tie-breaking
- update tests for new routing behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68942ed3f6688327ab091751969c5a4d