### PR TITLE
refactor: conectar kernel con meta router

### DIFF
--- a/agicore_core/kernel.py
+++ b/agicore_core/kernel.py
@@ -1,59 +1,58 @@
-"""Ejecución de planes paso a paso mediante `agix`.
+"""Ejecución de planes paso a paso mediante un ``MetaRouter``.
 
-Este módulo proporciona la clase :class:`ReasoningKernel` que
-interpreta un plan y difunde cada paso a través del orquestador de
-`agix`.
+Este módulo proporciona la clase :class:`ReasoningKernel` que interpreta un
+plan y delega cada paso en una instancia de :class:`meta_router.MetaRouter`.
 """
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
-from agix.orchestrator import VirtualQualia
+from meta_router import MetaRouter
 
 
 class ReasoningKernel:
-    """Ejecuta pasos de razonamiento usando la API de :mod:`agix`.
+    """Ejecuta pasos de razonamiento usando un enrutador externo."""
 
-    Parameters
-    ----------
-    orchestrator:
-        Instancia de :class:`agix.orchestrator.VirtualQualia` utilizada para
-        coordinar la difusión de cada paso. Si no se proporciona, se crea una
-        instancia sin clientes registrados.
-    """
+    def __init__(self, router: MetaRouter) -> None:
+        self.router = router
 
-    def __init__(self, orchestrator: Optional[VirtualQualia] = None) -> None:
-        self.orchestrator = orchestrator or VirtualQualia()
-
-    def execute_step(self, state: Dict[str, Any]) -> List[Any]:
-        """Difunde un único paso del plan y devuelve la respuesta.
-
-        Parameters
-        ----------
-        state:
-            Descripción del paso a ejecutar.
-
-        Returns
-        -------
-        list
-            Respuestas proporcionadas por los clientes registrados.
-        """
-
-        return self.orchestrator.broadcast_state(state)
-
-    def execute_plan(self, plan: List[Dict[str, Any]]) -> List[List[Any]]:
-        """Ejecuta secuencialmente todos los pasos de ``plan``.
+    def execute_step(
+        self,
+        step: Dict[str, Any],
+        *,
+        task: str,
+        context: str,
+        goals: List[str],
+    ) -> Any:
+        """Envía ``step`` al experto adecuado mediante ``router``.
 
         Parameters
         ----------
-        plan:
-            Lista de descripciones de pasos a ejecutar.
-
-        Returns
-        -------
-        list of lists
-            Cada elemento contiene las respuestas obtenidas para un paso.
+        step:
+            Descripción del paso a ejecutar. Se fusiona con la información
+            de ``task``, ``context`` y ``goals`` para construir la solicitud
+            final.
+        task, context, goals:
+            Metadatos utilizados por :class:`MetaRouter` para seleccionar el
+            experto más adecuado.
         """
 
-        return [self.execute_step(step) for step in plan]
+        request = {"task": task, "context": context, "goals": goals}
+        request.update(step)
+        return self.router.route(request)
+
+    def execute_plan(
+        self,
+        plan: List[Dict[str, Any]],
+        *,
+        task: str,
+        context: str,
+        goals: List[str],
+    ) -> List[Any]:
+        """Ejecuta secuencialmente todos los pasos del plan."""
+
+        return [
+            self.execute_step(step, task=task, context=context, goals=goals)
+            for step in plan
+        ]

--- a/docs/meta_router.md
+++ b/docs/meta_router.md
@@ -1,15 +1,14 @@
 # Flujo de enrutamiento
 
 El archivo `meta_router.py` introduce la clase `MetaRouter`, un punto central
-para enviar solicitudes a distintos módulos.
+para enviar solicitudes a distintos módulos basándose en metadatos declarados.
 
-1. El cliente construye un diccionario con la clave `module` que identifica el
-   destino.
-2. `MetaRouter` busca el módulo en su registro interno.
-3. Si el módulo es `reasoning`, se invoca a `ReasoningKernel.execute_plan` con
-   el plan provisto en `plan`.
-4. Para cualquier otro módulo registrado se llama a su método `handle` y se
-   le entrega el diccionario original.
+1. El cliente construye un diccionario con las claves `task`, `context` y
+   `goals` (lista de metas) describiendo su petición.
+2. `MetaRouter` calcula una puntuación para cada experto registrado según las
+   coincidencias con esos metadatos.
+3. El experto con mayor puntuación recibe la solicitud completa mediante su
+   método `handle`.
 
-Este diseño permite ampliar el sistema registrando nuevos módulos sin modificar
-el núcleo del enrutador.
+Este diseño permite ampliar el sistema registrando nuevos expertos sin
+modificar el núcleo del enrutador.

--- a/meta_router.py
+++ b/meta_router.py
@@ -1,16 +1,9 @@
 from __future__ import annotations
 
-"""Enrutador central para delegar solicitudes entre módulos.
-
-La clase :class:`MetaRouter` mantiene un registro de módulos y dirige cada
-solicitud al destino adecuado. Por defecto se registra el
-:class:`agicore_core.ReasoningKernel` bajo la clave ``"reasoning"``.
-"""
+"""Enrutador central para delegar solicitudes entre módulos."""
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
-
-from agicore_core import ReasoningKernel
 
 
 @dataclass
@@ -24,22 +17,6 @@ class Expert:
     priority: int = 0
 
 
-class ReasoningExpert:
-    """Pequeño adaptador para :class:`ReasoningKernel`.
-
-    Provee un método :meth:`handle` que delega en
-    :meth:`ReasoningKernel.execute_plan` para mantener una interfaz común
-    entre todos los expertos registrados.
-    """
-
-    def __init__(self, kernel: ReasoningKernel) -> None:
-        self._kernel = kernel
-
-    def handle(self, request: Dict[str, Any]) -> Any:  # pragma: no cover - delega
-        plan = request.get("plan", [])
-        return self._kernel.execute_plan(plan)
-
-
 class MetaRouter:
     """Enrutador de solicitudes basado en expertos.
 
@@ -51,12 +28,6 @@ class MetaRouter:
 
     def __init__(self) -> None:
         self._experts: Dict[str, Expert] = {}
-        # Registro por defecto del kernel de razonamiento con un adaptador.
-        self.register(
-            "reasoning",
-            ReasoningExpert(ReasoningKernel()),
-            tasks=["reasoning"],
-        )
 
     def register(
         self,

--- a/tests/test_meta_router.py
+++ b/tests/test_meta_router.py
@@ -13,20 +13,6 @@ class DummyModule:
         return "ok"
 
 
-def test_routes_to_reasoning_kernel():
-    router = MetaRouter()
-    plan = [{"step": 1}]
-    request = {
-        "task": "reasoning",
-        "context": "test",
-        "goals": [],
-        "plan": plan,
-    }
-    result = router.route(request)
-    assert isinstance(result, list)
-    assert len(result) == len(plan)
-
-
 def test_routes_to_custom_module():
     router = MetaRouter()
     dummy = DummyModule()

--- a/tests/test_reasoning_kernel.py
+++ b/tests/test_reasoning_kernel.py
@@ -1,17 +1,46 @@
 """Pruebas para el módulo :mod:`agicore_core.kernel`."""
 
+"""Pruebas para el módulo :mod:`agicore_core.kernel`."""
+
 from agicore_core import ReasoningKernel
+from meta_router import MetaRouter
 
 
-def test_execute_step_returns_list():
-    kernel = ReasoningKernel()
-    result = kernel.execute_step({"task": "demo"})
-    assert isinstance(result, list)
+class DummyExpert:
+    def __init__(self):
+        self.calls = []
+
+    def handle(self, request):
+        self.calls.append(request)
+        return request.get("payload")
+
+
+def make_kernel():
+    router = MetaRouter()
+    expert = DummyExpert()
+    router.register(
+        "dummy",
+        expert,
+        tasks=["task"],
+        contexts=["ctx"],
+        goals=["g"],
+    )
+    return ReasoningKernel(router), expert
+
+
+def test_execute_step_returns_payload():
+    kernel, expert = make_kernel()
+    result = kernel.execute_step(
+        {"payload": 1}, task="task", context="ctx", goals=["g"]
+    )
+    assert result == 1
+    assert expert.calls[0]["payload"] == 1
 
 
 def test_execute_plan_runs_all_steps():
-    kernel = ReasoningKernel()
-    plan = [{"step": 1}, {"step": 2}]
-    results = kernel.execute_plan(plan)
-    assert isinstance(results, list)
-    assert len(results) == len(plan)
+    kernel, expert = make_kernel()
+    plan = [{"payload": 1}, {"payload": 2}]
+    results = kernel.execute_plan(plan, task="task", context="ctx", goals=["g"])
+    assert results == [1, 2]
+    assert len(expert.calls) == 2
+


### PR DESCRIPTION
## Summary
- connect ReasoningKernel with MetaRouter routing
- simplify MetaRouter to only score and route experts
- adjust tests for new kernel-router design

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894303e29d48327be2b33fd78271756