### PR TITLE
Add heuristic weighting to expert routing

### DIFF
--- a/agicore_core/kernel.py
+++ b/agicore_core/kernel.py
@@ -24,6 +24,9 @@ class ReasoningKernel:
         task: str,
         context: str,
         goals: List[str],
+        weight_task: int = 1,
+        weight_context: int = 1,
+        weight_goal: int = 1,
     ) -> Any:
         """Envía ``step`` al experto adecuado mediante ``router``.
 
@@ -36,11 +39,19 @@ class ReasoningKernel:
         task, context, goals:
             Metadatos utilizados por :class:`MetaRouter` para seleccionar el
             experto más adecuado.
+        weight_task, weight_context, weight_goal:
+            Pesos que se pasan a :meth:`meta_router.MetaRouter.route` para
+            ajustar la heurística de selección.
         """
 
         request = {"task": task, "context": context, "goals": goals}
         request.update(step)
-        return self.router.route(request)
+        return self.router.route(
+            request,
+            weight_task=weight_task,
+            weight_context=weight_context,
+            weight_goal=weight_goal,
+        )
 
     def execute_plan(
         self,
@@ -49,10 +60,21 @@ class ReasoningKernel:
         task: str,
         context: str,
         goals: List[str],
+        weight_task: int = 1,
+        weight_context: int = 1,
+        weight_goal: int = 1,
     ) -> List[Any]:
         """Ejecuta secuencialmente todos los pasos del plan."""
 
         return [
-            self.execute_step(step, task=task, context=context, goals=goals)
+            self.execute_step(
+                step,
+                task=task,
+                context=context,
+                goals=goals,
+                weight_task=weight_task,
+                weight_context=weight_context,
+                weight_goal=weight_goal,
+            )
             for step in plan
         ]

--- a/tests/test_meta_router.py
+++ b/tests/test_meta_router.py
@@ -79,6 +79,19 @@ def test_selects_correct_expert_among_multiple():
     assert third.received is None
 
 
+def test_heuristic_weights_affect_selection():
+    router = MetaRouter()
+    task_expert = DummyModule()
+    ctx_expert = DummyModule()
+    router.register("task", task_expert, tasks=["t"], contexts=[], goals=[])
+    router.register("ctx", ctx_expert, tasks=[], contexts=["c"], goals=[])
+    request = {"task": "t", "context": "c", "goals": []}
+    result = router.route(request, weight_task=1, weight_context=2)
+    assert result == "ok"
+    assert ctx_expert.received is not None
+    assert task_expert.received is None
+
+
 def test_no_expert_matches_raises_error():
     router = MetaRouter()
     dummy = DummyModule()

--- a/tests/test_reasoning_kernel.py
+++ b/tests/test_reasoning_kernel.py
@@ -1,7 +1,5 @@
 """Pruebas para el módulo :mod:`agicore_core.kernel`."""
 
-"""Pruebas para el módulo :mod:`agicore_core.kernel`."""
-
 from agicore_core import ReasoningKernel
 from meta_router import MetaRouter
 
@@ -44,3 +42,21 @@ def test_execute_plan_runs_all_steps():
     assert results == [1, 2]
     assert len(expert.calls) == 2
 
+
+def test_execute_step_uses_heuristic_weights():
+    router = MetaRouter()
+    task_exp = DummyExpert()
+    ctx_exp = DummyExpert()
+    router.register("task", task_exp, tasks=["t"], contexts=[], goals=[])
+    router.register("ctx", ctx_exp, tasks=[], contexts=["c"], goals=[])
+    kernel = ReasoningKernel(router)
+    kernel.execute_step(
+        {"payload": None},
+        task="t",
+        context="c",
+        goals=[],
+        weight_task=1,
+        weight_context=2,
+        weight_goal=1,
+    )
+    assert ctx_exp.calls and not task_exp.calls


### PR DESCRIPTION
## Summary
- Allow MetaRouter to score experts using weighted heuristics
- Expose heuristic weights through ReasoningKernel
- Cover weighted routing with new tests

## Testing
- `python -m black --check meta_router.py agicore_core/kernel.py tests/test_meta_router.py tests/test_reasoning_kernel.py`
- `python -m ruff check meta_router.py agicore_core/kernel.py tests/test_meta_router.py tests/test_reasoning_kernel.py`
- `pytest tests/test_meta_router.py tests/test_reasoning_kernel.py`


------
https://chatgpt.com/codex/tasks/task_e_6894aa1a20bc83278173260d5ab2c0ff