### PR TITLE
Add stateful reasoning kernel

### DIFF
--- a/agicore_core/reasoning_kernel.py
+++ b/agicore_core/reasoning_kernel.py
@@ -1,0 +1,28 @@
+"""Núcleo de razonamiento con gestión de estado."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from meta_router import MetaRouter
+
+from .planner import Planner
+
+
+class ReasoningKernel:
+    """Coordina un planificador y un enrutador manteniendo estado interno."""
+
+    def __init__(self, planner: Planner, router: MetaRouter) -> None:
+        self.planner = planner
+        self.router = router
+        self._state: Dict[str, Any] = {}
+
+    def set_state(self, state: Dict[str, Any]) -> None:
+        """Establece el ``state`` inicial para el planificador."""
+
+        self._state = state
+
+    def get_state(self) -> Dict[str, Any]:
+        """Devuelve el estado interno actual."""
+
+        return self._state


### PR DESCRIPTION
## Summary
- add `ReasoningKernel` in `agicore_core` that stores planner, router and state

## Testing
- `pytest` *(fails: RecordingRouter.route() got an unexpected keyword argument 'weight_task')*

------
https://chatgpt.com/codex/tasks/task_e_6894cb3d2e048327a73612133725e224