### PR TITLE
Add conditional step evaluation to ReasoningKernel

### DIFF
--- a/agicore_core/reasoning_kernel.py
+++ b/agicore_core/reasoning_kernel.py
@@ -26,3 +26,42 @@ class ReasoningKernel:
         """Devuelve el estado interno actual."""
 
         return self._state
+
+    def evaluate_step(self, step: Dict[str, Any]) -> Any:
+        """Evalúa un ``step`` con ramificación condicional.
+
+        Cada ``step`` puede incluir las claves opcionales ``if``, ``then`` y
+        ``else``. La condición indicada en ``if`` se evalúa en el contexto del
+        estado actual. Dependiendo de su resultado se selecciona la rama
+        ``then`` o ``else`` y se fusiona con el resto del paso y con el estado
+        antes de delegar la ejecución al :class:`MetaRouter`.
+
+        El resultado devuelto por el enrutador se incorpora al estado: si es un
+        ``dict`` se combina mediante :py:meth:`dict.update`; en caso contrario se
+        almacena bajo la clave ``"result"``.
+        """
+
+        step = dict(step)  # evitar mutaciones externas
+        condition = step.pop("if", None)
+        then_branch = step.pop("then", {})
+        else_branch = step.pop("else", {})
+
+        if condition is not None:
+            if isinstance(condition, str):
+                try:
+                    condition_value = bool(eval(condition, {}, self._state))
+                except Exception:
+                    condition_value = False
+            else:
+                condition_value = bool(condition)
+            branch = then_branch if condition_value else else_branch
+            step.update(branch)
+
+        request: Dict[str, Any] = {**self._state, **step}
+        result = self.router.route(request)
+
+        if isinstance(result, dict):
+            self._state.update(result)
+        else:
+            self._state["result"] = result
+        return result

--- a/tests/test_stateful_reasoning_kernel.py
+++ b/tests/test_stateful_reasoning_kernel.py
@@ -1,0 +1,65 @@
+"""Pruebas para ReasoningKernel con estado y condicionales."""
+
+import sys
+import types
+
+# ``ReasoningKernel`` depende de ``agix`` para el planificador. Para aislar las
+# pruebas y evitar dependencias externas, se inserta un stub mínimo en
+# ``sys.modules`` antes de realizar la importación real.
+agix = types.ModuleType("agix")
+agix.orchestrator = types.ModuleType("orchestrator")
+agix.orchestrator.VirtualQualia = object
+sys.modules.setdefault("agix", agix)
+sys.modules.setdefault("agix.orchestrator", agix.orchestrator)
+
+from agicore_core.reasoning_kernel import ReasoningKernel
+from meta_router import MetaRouter
+
+
+class RecordingExpert:
+    def __init__(self):
+        self.calls = []
+
+    def handle(self, request):
+        self.calls.append(request)
+        if request["task"] == "inc":
+            return {"count": request["count"] + request["payload"]}
+        return {"count": request["count"] - request["payload"]}
+
+
+def make_kernel():
+    router = MetaRouter()
+    inc = RecordingExpert()
+    dec = RecordingExpert()
+    router.register("inc", inc, tasks=["inc"], contexts=["ctx"], goals=["g"])
+    router.register("dec", dec, tasks=["dec"], contexts=["ctx"], goals=["g"])
+    kernel = ReasoningKernel(planner=None, router=router)
+    return kernel, inc, dec
+
+
+def test_evaluate_step_then_branch_updates_state():
+    kernel, inc, _ = make_kernel()
+    kernel.set_state({"context": "ctx", "goals": ["g"], "count": 1})
+    step = {
+        "if": "count > 0",
+        "then": {"task": "inc", "payload": 2},
+        "else": {"task": "dec", "payload": 3},
+    }
+    result = kernel.evaluate_step(step)
+    assert result == {"count": 3}
+    assert kernel.get_state()["count"] == 3
+    assert inc.calls[0]["payload"] == 2
+
+
+def test_evaluate_step_else_branch():
+    kernel, _, dec = make_kernel()
+    kernel.set_state({"context": "ctx", "goals": ["g"], "count": 0})
+    step = {
+        "if": "count > 0",
+        "then": {"task": "inc", "payload": 2},
+        "else": {"task": "dec", "payload": 3},
+    }
+    result = kernel.evaluate_step(step)
+    assert result == {"count": -3}
+    assert kernel.get_state()["count"] == -3
+    assert dec.calls[0]["payload"] == 3


### PR DESCRIPTION
## Summary
- add `evaluate_step` supporting `if`/`then`/`else` branching
- update state with routed results
- cover conditional logic with new tests

## Testing
- `pytest tests/test_stateful_reasoning_kernel.py -q` *(fails: No module named 'openai_harmony')*

------
https://chatgpt.com/codex/tasks/task_e_6894cdd8e1b883278037dc342422c809