### PR TITLE
Add stateful run loop to reasoning kernel

### DIFF
--- a/agicore_core/kernel.py
+++ b/agicore_core/kernel.py
@@ -46,12 +46,16 @@ class ReasoningKernel:
 
         request = {"task": task, "context": context, "goals": goals}
         request.update(step)
-        return self.router.route(
-            request,
-            weight_task=weight_task,
-            weight_context=weight_context,
-            weight_goal=weight_goal,
-        )
+        try:
+            return self.router.route(
+                request,
+                weight_task=weight_task,
+                weight_context=weight_context,
+                weight_goal=weight_goal,
+            )
+        except TypeError:
+            # Algunos ``MetaRouter`` de pruebas no aceptan pesos heurísticos
+            return self.router.route(request)
 
     def execute_plan(
         self,


### PR DESCRIPTION
## Summary
- Implement `ReasoningKernel.run` to iterate planning and execution with goal checking and history
- Handle routers without heuristic weights in `execute_step`
- Extend tests for stateful kernel run and iteration limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894d0749140832794ba6bab69489f59