### PR TITLE
feat: add goal prioritization to planner

### DIFF
--- a/gpt_oss/planner.py
+++ b/gpt_oss/planner.py
@@ -9,7 +9,9 @@ compartiendo esta información con componentes como ``ReasoningKernel``.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Tuple
+
+import heapq
 
 
 @dataclass
@@ -27,5 +29,58 @@ class Planner:
     """
 
     global_intent: Optional[str] = None
-    goals: List[str] = field(default_factory=list)
+    goals: List[Tuple[int, str]] = field(default_factory=list)
     active_mode: bool = False
+
+    def set_intention(self, intent: str) -> None:
+        """Define la intención global del agente.
+
+        Parameters
+        ----------
+        intent:
+            Descripción de la intención u objetivo general.
+        """
+
+        self.global_intent = intent
+
+    def add_goal(self, goal: str, prioridad: int) -> None:
+        """Agrega una meta con una prioridad dada.
+
+        Las metas se gestionan internamente con una cola de prioridad para
+        facilitar la extracción de la próxima meta más importante.
+
+        Parameters
+        ----------
+        goal:
+            Descripción de la meta a añadir.
+        prioridad:
+            Valor numérico que indica la importancia de la meta. Valores más
+            altos representan mayor prioridad.
+
+        Raises
+        ------
+        ValueError
+            Si ``prioridad`` es negativa.
+        """
+
+        if prioridad < 0:
+            raise ValueError("La prioridad no puede ser negativa")
+        # heapq implementa una cola de prioridad mínima, por lo que se usa el
+        # negativo de ``prioridad`` para que los números más altos se extraigan
+        # primero.
+        heapq.heappush(self.goals, (-prioridad, goal))
+
+    def get_next_goal(self) -> Optional[str]:
+        """Obtiene la siguiente meta con mayor prioridad.
+
+        Returns
+        -------
+        str or None
+            La descripción de la meta más prioritaria o ``None`` si no hay
+            metas registradas.
+        """
+
+        if not self.goals:
+            return None
+        _, goal = heapq.heappop(self.goals)
+        return goal

--- a/tests/test_goal_planner.py
+++ b/tests/test_goal_planner.py
@@ -1,0 +1,26 @@
+"""Pruebas para el planificador de ``gpt_oss`` con metas prioritarias."""
+
+import pytest
+
+from gpt_oss.planner import Planner
+
+
+def test_set_intention():
+    planner = Planner()
+    planner.set_intention("organizar tareas")
+    assert planner.global_intent == "organizar tareas"
+
+
+def test_add_goal_and_get_next_goal():
+    planner = Planner()
+    planner.add_goal("baja", 1)
+    planner.add_goal("alta", 5)
+    assert planner.get_next_goal() == "alta"
+    assert planner.get_next_goal() == "baja"
+    assert planner.get_next_goal() is None
+
+
+def test_add_goal_negative_priority():
+    planner = Planner()
+    with pytest.raises(ValueError):
+        planner.add_goal("invalida", -1)


### PR DESCRIPTION
## Summary
- allow Planner to set global intention and manage prioritized goals
- cover Planner goal queue with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894e4a54d20832786be9487a8744b39