### PR TITLE
feat: add mode management to planner

### DIFF
--- a/gpt_oss/planner.py
+++ b/gpt_oss/planner.py
@@ -9,7 +9,7 @@ compartiendo esta información con componentes como ``ReasoningKernel``.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import heapq
 
@@ -24,13 +24,16 @@ class Planner:
         Intención general u objetivo principal del agente.
     goals:
         Lista de metas específicas que se deben alcanzar.
-    active_mode:
-        Indica si el planificador está actualmente en modo activo.
+    mode:
+        Modo operativo actualmente activo (`creative`, `analytic` o `deductive`).
+    mode_parameters:
+        Conjunto de parámetros asociados al modo activo (temperatura, heurísticas, etc.).
     """
 
     global_intent: Optional[str] = None
     goals: List[Tuple[int, str]] = field(default_factory=list)
-    active_mode: bool = False
+    mode: Optional[str] = None
+    mode_parameters: Dict[str, Any] = field(default_factory=dict)
 
     def set_intention(self, intent: str) -> None:
         """Define la intención global del agente.
@@ -84,3 +87,36 @@ class Planner:
             return None
         _, goal = heapq.heappop(self.goals)
         return goal
+
+    # --- Gestión de modos -------------------------------------------------
+    def activate_mode(self, tipo: str) -> None:
+        """Activa un modo de operación y configura sus parámetros.
+
+        Parameters
+        ----------
+        tipo:
+            Cadena que identifica el modo a activar. Los valores aceptados son
+            ``"creative"``, ``"analytic"`` y ``"deductive"``.
+
+        Raises
+        ------
+        ValueError
+            Si el modo solicitado no está soportado.
+        """
+
+        estrategias = {
+            "creative": {"temperature": 1.0, "heuristic": "divergent"},
+            "analytic": {"temperature": 0.5, "heuristic": "critical"},
+            "deductive": {"temperature": 0.2, "heuristic": "logical"},
+        }
+
+        if tipo not in estrategias:
+            raise ValueError(f"Modo no soportado: {tipo}")
+
+        self.mode = tipo
+        self.mode_parameters = estrategias[tipo]
+
+    def current_mode(self) -> Optional[str]:
+        """Devuelve el modo actualmente activo, o ``None`` si no hay modo."""
+
+        return self.mode

--- a/tests/test_goal_planner.py
+++ b/tests/test_goal_planner.py
@@ -24,3 +24,16 @@ def test_add_goal_negative_priority():
     planner = Planner()
     with pytest.raises(ValueError):
         planner.add_goal("invalida", -1)
+
+
+def test_activate_mode_and_current_mode():
+    planner = Planner()
+    planner.activate_mode("creative")
+    assert planner.current_mode() == "creative"
+    assert planner.mode_parameters["temperature"] == 1.0
+
+
+def test_activate_mode_invalid():
+    planner = Planner()
+    with pytest.raises(ValueError):
+        planner.activate_mode("unknown")


### PR DESCRIPTION
## Summary
- add `activate_mode` and `current_mode` to planner for creative, analytic and deductive modes
- support mode-specific temperature and heuristic parameters
- cover new mode logic with dedicated tests

## Testing
- `pytest tests/test_goal_planner.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894eab2091083278d68635f2d53caa1