### PR TITLE
Expose Planner to share goals and mode

### DIFF
--- a/gpt_oss/chat.py
+++ b/gpt_oss/chat.py
@@ -1,5 +1,7 @@
 """
-Harmony chat with tools
+Harmony chat with tools.
+
+Incluye integración con :class:`Planner` para consultar metas y modos del agente.
 """
 
 import atexit
@@ -21,6 +23,7 @@ from gpt_oss.tools import apply_patch
 from gpt_oss.tools.simple_browser import SimpleBrowserTool
 from gpt_oss.tools.simple_browser.backend import ExaBackend
 from gpt_oss.tools.python_docker.docker_tool import PythonTool
+from gpt_oss.planner import Planner  # Gestiona metas y modos del agente
 
 from openai_harmony import (
     Author,
@@ -59,6 +62,8 @@ def get_user_input():
 
 
 def main(args):
+    planner = Planner()  # Punto de integración para metas y modo
+
     match args.backend:
         case "triton":
             from gpt_oss.triton.model import TokenGenerator as TritonGenerator

--- a/gpt_oss/generate.py
+++ b/gpt_oss/generate.py
@@ -2,13 +2,18 @@
 # Note: This script is for demonstration purposes only. It is not designed for production use.
 #       See gpt_oss.chat for a more complete example with the Harmony parser.
 # torchrun --nproc-per-node=4 -m gpt_oss.generate -p "why did the chicken cross the road?" model/
+#
+# Incluye un ``Planner`` que permite consultar metas y modos del agente.
 
 import argparse
 
+from gpt_oss.planner import Planner  # Gestiona metas y modos del agente
 from gpt_oss.tokenizer import get_tokenizer
 
 
 def main(args):
+    planner = Planner()  # Punto de integración para metas y modo
+
     match args.backend:
         case "torch":
             from gpt_oss.torch.utils import init_distributed

--- a/gpt_oss/planner.py
+++ b/gpt_oss/planner.py
@@ -88,6 +88,23 @@ class Planner:
         _, goal = heapq.heappop(self.goals)
         return goal
 
+    def list_goals(self) -> List[str]:
+        """Devuelve las metas ordenadas por prioridad sin modificarlas.
+
+        Returns
+        -------
+        List[str]
+            Lista de metas pendientes de alcanzar, ordenadas de la más a la
+            menos prioritaria.
+        """
+
+        return [goal for _, goal in sorted(self.goals)]
+
+    def get_intention(self) -> Optional[str]:
+        """Recupera la intención global actualmente definida."""
+
+        return self.global_intent
+
     # --- Gestión de modos -------------------------------------------------
     def activate_mode(self, tipo: str) -> None:
         """Activa un modo de operación y configura sus parámetros.
@@ -120,3 +137,15 @@ class Planner:
         """Devuelve el modo actualmente activo, o ``None`` si no hay modo."""
 
         return self.mode
+
+    def get_mode_parameters(self) -> Dict[str, Any]:
+        """Obtiene los parámetros asociados al modo activo.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Diccionario con los parámetros del modo actual (vacío si no hay
+            modo activo).
+        """
+
+        return self.mode_parameters


### PR DESCRIPTION
## Summary
- Add methods to Planner to list goals, expose global intent, and retrieve active mode parameters
- Integrate Planner into chat and generate scripts for goal and mode access
- Document integration points for Planner usage across modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894ee3d119c8327a7b4e6ce33efb65a