### PR TITLE
Add episodic storage and querying to StrategicMemory

### DIFF
--- a/gpt_oss/strategic_memory.py
+++ b/gpt_oss/strategic_memory.py
@@ -1,18 +1,48 @@
-"""Utilities for managing strategic memory."""
+"""Utilities for managing strategic memory and episodic data."""
 
-from typing import Any, Dict
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List
+
+
+@dataclass
+class Episode:
+    """Representa una interacción con información contextual.
+
+    Attributes
+    ----------
+    timestamp:
+        Momento en el que ocurrió el episodio.
+    input:
+        Datos de entrada proporcionados por el usuario u otra fuente.
+    action:
+        Acción realizada en respuesta a la entrada.
+    outcome:
+        Resultado de la acción realizada.
+    metadata:
+        Información adicional asociada al episodio.
+    """
+
+    timestamp: datetime
+    input: Any
+    action: Any
+    outcome: Any
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 class StrategicMemory:
-    """Almacena y gestiona información estratégica en memoria.
+    """Almacena y gestiona información estratégica y episodios.
 
-    Ofrece operaciones básicas para guardar, recuperar y actualizar
-    entradas identificadas por una clave.
+    Proporciona operaciones para guardar, recuperar y actualizar
+    entradas identificadas por una clave, así como registrar
+    interacciones o episodios que se pueden consultar posteriormente.
     """
 
     def __init__(self) -> None:
-        """Inicializa la estructura de almacenamiento interna."""
+        """Inicializa las estructuras de almacenamiento internas."""
         self._storage: Dict[str, Any] = {}
+        self._episodes: List[Episode] = []
 
     def save(self, key: str, value: Any) -> None:
         """Guarda una nueva entrada en la memoria.
@@ -68,3 +98,62 @@ class StrategicMemory:
         if key not in self._storage:
             raise KeyError(f"La clave '{key}' no se encuentra en la memoria.")
         self._storage[key] = value
+
+    def add_episode(self, data: Episode) -> None:
+        """Añade un nuevo episodio a la memoria.
+
+        Parameters
+        ----------
+        data:
+            Instancia de :class:`Episode` que contiene la información
+            del episodio a almacenar.
+        """
+
+        self._episodes.append(data)
+
+    def query(self, pattern: Dict[str, Any]) -> List[Episode]:
+        """Busca episodios que coincidan con los campos proporcionados.
+
+        Cada par clave-valor de ``pattern`` se compara con los atributos
+        del episodio y con su metadato homónimo si el atributo no existe.
+
+        Parameters
+        ----------
+        pattern:
+            Diccionario con los campos y valores a buscar.
+
+        Returns
+        -------
+        list[Episode]
+            Lista de episodios que cumplen con el patrón.
+        """
+
+        resultados: List[Episode] = []
+        for episodio in self._episodes:
+            coincide = True
+            for clave, valor in pattern.items():
+                attr = getattr(episodio, clave, episodio.metadata.get(clave))
+                if attr != valor:
+                    coincide = False
+                    break
+            if coincide:
+                resultados.append(episodio)
+        return resultados
+
+    def summarize(self) -> Dict[str, Any]:
+        """Obtiene estadísticas generales de los episodios almacenados.
+
+        Returns
+        -------
+        dict
+            Diccionario con el total de episodios y las acciones y
+            resultados más frecuentes.
+        """
+
+        acciones = Counter(ep.action for ep in self._episodes)
+        resultados = Counter(ep.outcome for ep in self._episodes)
+        return {
+            "total": len(self._episodes),
+            "actions": acciones.most_common(),
+            "outcomes": resultados.most_common(),
+        }

--- a/tests/test_strategic_memory.py
+++ b/tests/test_strategic_memory.py
@@ -1,6 +1,8 @@
 import pytest
 
-from gpt_oss.strategic_memory import StrategicMemory
+from datetime import datetime
+
+from gpt_oss.strategic_memory import Episode, StrategicMemory
 
 
 def test_save_and_get():
@@ -27,3 +29,40 @@ def test_update_missing_key_raises():
     memoria = StrategicMemory()
     with pytest.raises(KeyError):
         memoria.update("plan", "valor")
+
+
+def test_add_and_query_episode():
+    memoria = StrategicMemory()
+    ep = Episode(
+        timestamp=datetime.utcnow(),
+        input="hola",
+        action="saludo",
+        outcome="ok",
+        metadata={"tema": "prueba"},
+    )
+    memoria.add_episode(ep)
+    assert memoria.query({"action": "saludo"}) == [ep]
+    assert memoria.query({"tema": "prueba"}) == [ep]
+
+
+def test_summarize_episodes():
+    memoria = StrategicMemory()
+    memoria.add_episode(
+        Episode(
+            timestamp=datetime.utcnow(),
+            input="uno",
+            action="a",
+            outcome="exito",
+        )
+    )
+    memoria.add_episode(
+        Episode(
+            timestamp=datetime.utcnow(),
+            input="dos",
+            action="a",
+            outcome="fracaso",
+        )
+    )
+    resumen = memoria.summarize()
+    assert resumen["total"] == 2
+    assert resumen["actions"][0][0] == "a"


### PR DESCRIPTION
## Summary
- add `Episode` dataclass to capture timestamp, input, action, outcome and metadata
- extend `StrategicMemory` with episodic storage, querying, and summarization helpers
- cover new behavior with unit tests

## Testing
- `pytest tests/test_strategic_memory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68957dc0a46c8327982da688d5f5c42c