### PR TITLE
Integrate StrategicMemory into planner

### DIFF
--- a/docs/planner.md
+++ b/docs/planner.md
@@ -25,10 +25,35 @@ print(planner.current_mode())
 print(planner.get_mode_parameters())
 ```
 
+## Uso con memoria estratégica
+
+El `Planner` puede aprovechar `StrategicMemory` para ajustar automáticamente
+los parámetros del modo en función de experiencias previas. Al activar un modo
+se consultan episodios anteriores exitosos del mismo tipo y se promedia la
+temperatura registrada en ellos.
+
+```python
+from gpt_oss.strategic_memory import StrategicMemory, Episode
+from datetime import datetime
+
+memory = StrategicMemory()
+memory.add_episode(
+    Episode(timestamp=datetime.now(), input="i", action="a", outcome="success",
+            metadata={"mode": "creative", "temperature": 0.8})
+)
+
+planner = Planner(memory=memory)
+planner.activate_mode("creative")
+print(planner.get_mode_parameters())  # temperatura ajustada ~0.8
+
+# Registrar un nuevo episodio
+planner.record_episode("pregunta", "respuesta", "success")
+```
+
 ## Tests
 
 Para ejecutar las pruebas relacionadas con el `Planner`:
 
 ```bash
-pytest tests/test_planner.py tests/test_goal_planner.py
+pytest tests/test_planner.py tests/test_goal_planner.py tests/test_planner_memory.py
 ```

--- a/tests/test_planner_memory.py
+++ b/tests/test_planner_memory.py
@@ -1,0 +1,34 @@
+"""Pruebas de integración entre Planner y StrategicMemory."""
+
+from datetime import datetime
+
+from gpt_oss.planner import Planner
+from gpt_oss.strategic_memory import Episode, StrategicMemory
+
+
+def test_activate_mode_ajusta_parametros_desde_memoria() -> None:
+    memory = StrategicMemory()
+    memory.add_episode(
+        Episode(
+            timestamp=datetime.now(),
+            input="i",
+            action="a",
+            outcome="success",
+            metadata={"mode": "analytic", "temperature": 0.7},
+        )
+    )
+    planner = Planner(memory=memory)
+    planner.activate_mode("analytic")
+    assert planner.get_mode_parameters()["temperature"] == 0.7
+
+
+def test_record_episode_guarda_modo_y_temperatura() -> None:
+    memory = StrategicMemory()
+    planner = Planner(memory=memory)
+    planner.activate_mode("creative")
+    planner.record_episode("pregunta", "respuesta", "success")
+    episodios = memory.query({"mode": "creative"})
+    assert len(episodios) == 1
+    ep = episodios[0]
+    assert ep.outcome == "success"
+    assert ep.metadata["temperature"] == planner.get_mode_parameters()["temperature"]


### PR DESCRIPTION
## Summary
- Allow Planner to attach a StrategicMemory instance and record episodic data
- Adjust mode parameters based on past successful episodes
- Document memory-driven behavior and add dedicated tests

## Testing
- `pytest tests/test_planner.py tests/test_goal_planner.py tests/test_planner_memory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689581c09074832788afcef84618221f