### PR TITLE
Add strategic memory tests and documentation

### DIFF
--- a/docs/strategic_memory.md
+++ b/docs/strategic_memory.md
@@ -1,0 +1,98 @@
+# Memoria episódica estratégica
+
+La memoria estratégica permite al agente recordar episodios pasados y
+usar esa información para tomar mejores decisiones. Cada episodio incluye
+el momento en el que ocurrió, la entrada procesada, la acción realizada,
+el resultado obtenido y metadatos asociados.
+
+## API básica
+
+### Almacenamiento de claves
+```python
+from gpt_oss.strategic_memory import StrategicMemory
+
+mem = StrategicMemory()
+mem.save("plan", "inicial")
+mem.update("plan", "actualizado")
+print(mem.get("plan"))
+```
+
+### Episodios
+```python
+from datetime import datetime
+from gpt_oss.strategic_memory import Episode, StrategicMemory
+
+mem = StrategicMemory()
+mem.add_episode(
+    Episode(
+        timestamp=datetime.now(),
+        input="hola",
+        action="saludo",
+        outcome="success",
+        metadata={"tema": "demo"},
+    )
+)
+print(mem.query({"tema": "demo"}))
+print(mem.summarize())
+```
+
+## Integración con `MetaRouter`
+
+`MetaRouter` puede consultar los episodios almacenados para ajustar la
+puntuación de cada experto según su historial.
+
+```python
+from datetime import datetime
+from meta_router import MetaRouter
+from gpt_oss.strategic_memory import Episode, StrategicMemory
+
+memory = StrategicMemory()
+router = MetaRouter(memory=memory)
+router.register("traductor", Translator(), tasks=["translate"], contexts=["cli"], goals=["en-es"])
+
+# Registrar un fallo previo del experto "traductor"
+memory.add_episode(
+    Episode(
+        timestamp=datetime.now(),
+        input={},
+        action="traductor",
+        outcome="error",
+        metadata={
+            "task": "translate",
+            "context": "cli",
+            "goals": ["en-es"],
+            "expert": "traductor",
+            "status": "failure",
+            "latency": 0,
+        },
+    )
+)
+
+router.route({"task": "translate", "context": "cli", "goals": ["en-es"], "text": "hola"})
+```
+
+## Integración con `Planner`
+
+El `Planner` consulta la memoria para ajustar automáticamente los
+parámetros del modo activo en función de episodios previos.
+
+```python
+from datetime import datetime
+from gpt_oss.planner import Planner
+from gpt_oss.strategic_memory import Episode, StrategicMemory
+
+memory = StrategicMemory()
+memory.add_episode(
+    Episode(
+        timestamp=datetime.now(),
+        input="i",
+        action="a",
+        outcome="success",
+        metadata={"mode": "creative", "temperature": 0.8},
+    )
+)
+
+planner = Planner(memory=memory)
+planner.activate_mode("creative")
+print(planner.get_mode_parameters())
+```

--- a/tests/test_planner_memory.py
+++ b/tests/test_planner_memory.py
@@ -2,6 +2,8 @@
 
 from datetime import datetime
 
+import pytest
+
 from gpt_oss.planner import Planner
 from gpt_oss.strategic_memory import Episode, StrategicMemory
 
@@ -32,3 +34,28 @@ def test_record_episode_guarda_modo_y_temperatura() -> None:
     ep = episodios[0]
     assert ep.outcome == "success"
     assert ep.metadata["temperature"] == planner.get_mode_parameters()["temperature"]
+
+
+def test_activate_mode_promedia_temperaturas_memoria() -> None:
+    memory = StrategicMemory()
+    memory.add_episode(
+        Episode(
+            timestamp=datetime.now(),
+            input="i1",
+            action="a1",
+            outcome="success",
+            metadata={"mode": "analytic", "temperature": 0.4},
+        )
+    )
+    memory.add_episode(
+        Episode(
+            timestamp=datetime.now(),
+            input="i2",
+            action="a2",
+            outcome="success",
+            metadata={"mode": "analytic", "temperature": 0.6},
+        )
+    )
+    planner = Planner(memory=memory)
+    planner.activate_mode("analytic")
+    assert planner.get_mode_parameters()["temperature"] == pytest.approx(0.5)

--- a/tests/test_strategic_memory.py
+++ b/tests/test_strategic_memory.py
@@ -66,3 +66,31 @@ def test_summarize_episodes():
     resumen = memoria.summarize()
     assert resumen["total"] == 2
     assert resumen["actions"][0][0] == "a"
+
+
+def test_add_episode_query_and_summarize_multiple():
+    memoria = StrategicMemory()
+    ep1 = Episode(
+        timestamp=datetime.utcnow(),
+        input="i1",
+        action="alpha",
+        outcome="ok",
+        metadata={"tag": 1},
+    )
+    ep2 = Episode(
+        timestamp=datetime.utcnow(),
+        input="i2",
+        action="beta",
+        outcome="fail",
+        metadata={"tag": 2},
+    )
+    memoria.add_episode(ep1)
+    memoria.add_episode(ep2)
+
+    assert memoria.query({"tag": 1}) == [ep1]
+    assert memoria.query({"action": "beta"}) == [ep2]
+
+    resumen = memoria.summarize()
+    assert resumen["total"] == 2
+    assert ("alpha", 1) in resumen["actions"]
+    assert ("fail", 1) in resumen["outcomes"]


### PR DESCRIPTION
## Summary
- expand strategic memory test coverage for episodic queries and summaries
- ensure MetaRouter scoring adapts to episodic history
- document strategic episodic memory API and integration examples

## Testing
- `pytest tests/test_strategic_memory.py tests/test_meta_router.py tests/test_planner_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_68958c4acd7c8327a2b889d5755bafcf