### PR TITLE
feat: persist evaluator knowledge

### DIFF
--- a/agicore_core/meta_evaluator.py
+++ b/agicore_core/meta_evaluator.py
@@ -12,6 +12,8 @@ class MetaEvaluator:
         """Inicializa el evaluador sin historial previo."""
         self.historial_metricas: List[Dict[str, Any]] = []
         self.sugerencias: List[Dict[str, Any]] = []
+        self.metricas_agregadas: Dict[str, float] = {}
+        self.patrones_fallo: Dict[str, int] = {}
 
     def evaluar_ciclo(self, resultados: Dict[str, Any]) -> Dict[str, Any]:
         """Procesa las métricas de un ciclo de ejecución.
@@ -66,6 +68,48 @@ class MetaEvaluator:
         historial:
             Registro de métricas sobre el que se desea reflexionar.
         """
+        if not historial:
+            return
+
+        # Actualiza métricas agregadas calculando promedios de valores numéricos
+        totales: Dict[str, float] = {}
+        cuentas: Dict[str, int] = {}
+        patrones: Dict[str, int] = {}
+        for entrada in historial:
+            for clave, valor in entrada.items():
+                if isinstance(valor, (int, float)):
+                    totales[clave] = totales.get(clave, 0.0) + float(valor)
+                    cuentas[clave] = cuentas.get(clave, 0) + 1
+            if "error" in entrada:
+                err = str(entrada["error"])
+                patrones[err] = patrones.get(err, 0) + 1
+
+        if totales:
+            self.metricas_agregadas = {
+                clave: totales[clave] / cuentas[clave] for clave in totales
+            }
+        if patrones:
+            for err, cuenta in patrones.items():
+                self.patrones_fallo[err] = self.patrones_fallo.get(err, 0) + cuenta
+
         sugerencia = self.sugerir_reconfiguracion(historial)
         if sugerencia:
             self.sugerencias.append(sugerencia)
+
+    def exportar_estado(self) -> Dict[str, Any]:
+        """Devuelve un ``dict`` con el conocimiento acumulado."""
+
+        return {
+            "historial_metricas": self.historial_metricas,
+            "sugerencias": self.sugerencias,
+            "metricas_agregadas": self.metricas_agregadas,
+            "patrones_fallo": self.patrones_fallo,
+        }
+
+    def cargar_estado(self, estado: Dict[str, Any]) -> None:
+        """Restaura el conocimiento previamente serializado."""
+
+        self.historial_metricas = estado.get("historial_metricas", [])
+        self.sugerencias = estado.get("sugerencias", [])
+        self.metricas_agregadas = estado.get("metricas_agregadas", {})
+        self.patrones_fallo = estado.get("patrones_fallo", {})

--- a/agicore_core/reasoning_kernel.py
+++ b/agicore_core/reasoning_kernel.py
@@ -119,6 +119,7 @@ class ReasoningKernel:
                         sugerencia = self.evaluator.sugerir_reconfiguracion(self.history)
                         if sugerencia:
                             self._state.update(sugerencia)
+                        self.evaluator.reflexionar(self.history)
                     return self._state
 
                 goals = self._state.get("goals", [])
@@ -127,11 +128,15 @@ class ReasoningKernel:
                         sugerencia = self.evaluator.sugerir_reconfiguracion(self.history)
                         if sugerencia:
                             self._state.update(sugerencia)
+                        self.evaluator.reflexionar(self.history)
                     return self._state
 
             if self.evaluator is not None:
                 sugerencia = self.evaluator.sugerir_reconfiguracion(self.history)
                 if sugerencia:
                     self._state.update(sugerencia)
+
+        if self.evaluator is not None:
+            self.evaluator.reflexionar(self.history)
 
         return self._state

--- a/docs/meta_evaluator.md
+++ b/docs/meta_evaluator.md
@@ -1,0 +1,34 @@
+# MetaEvaluator
+
+`MetaEvaluator` recopila métricas de los ciclos del núcleo y aprende de ellas
+para proponer mejoras estructurales.
+
+## Almacenamiento de conocimiento
+
+- **Métricas agregadas**: promedios de los valores numéricos observados en el
+  historial.
+- **Patrones de fallos**: recuento de mensajes de error detectados.
+- **Sugerencias**: recomendaciones generadas tras cada reflexión.
+
+La llamada a `ReasoningKernel.run` finaliza con
+`evaluator.reflexionar(history)`, lo que actualiza estos registros.
+
+## Persistencia entre sesiones
+
+El evaluador permite serializar su estado para reutilizar lo aprendido:
+
+```python
+import json
+from agicore_core.meta_evaluator import MetaEvaluator
+
+# Guardar
+with open("evaluator_state.json", "w", encoding="utf8") as fh:
+    json.dump(evaluator.exportar_estado(), fh)
+
+# Cargar
+with open("evaluator_state.json", encoding="utf8") as fh:
+    evaluator.cargar_estado(json.load(fh))
+```
+
+Así, el conocimiento acumulado (métricas, patrones y sugerencias) puede
+recuperarse en una nueva ejecución del sistema.


### PR DESCRIPTION
## Summary
- update ReasoningKernel to call evaluator.reflexionar after execution
- extend MetaEvaluator with aggregated metrics, failure patterns and export/import helpers
- document state persistence for MetaEvaluator

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68959ce3d30083278bc516e7d97e44ac