### PR TITLE
Agrega pruebas de MetaEvaluator

### DIFF
--- a/openai_harmony.py
+++ b/openai_harmony.py
@@ -1,0 +1,68 @@
+"""Stub mínimo de la librería ``openai_harmony`` para las pruebas."""
+from enum import Enum
+from typing import List
+
+class HarmonyEncodingName(str, Enum):
+    HARMONY_GPT_OSS = "harmony-gpt-oss"
+
+class ReasoningEffort(Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+class Author:
+    pass
+
+class Conversation:
+    pass
+
+class DeveloperContent:
+    pass
+
+class HarmonyEncoding:
+    def encode(self, text: str, allowed_special: str = "all") -> List[int]:
+        return []
+
+    def parse_messages_from_completion_tokens(self, tokens: List[int], role: 'Role'):
+        return []
+
+class Message:
+    @classmethod
+    def from_role_and_content(cls, role: 'Role', content: str) -> 'Message':
+        return cls()
+
+    def with_recipient(self, recipient: str) -> 'Message':
+        return self
+
+    def with_channel(self, channel: str) -> 'Message':
+        return self
+
+    def to_dict(self):
+        return {}
+
+class Role(Enum):
+    ASSISTANT = "assistant"
+
+class StreamableParser:
+    pass
+
+class StreamState:
+    pass
+
+class SystemContent:
+    pass
+
+class ToolDescription:
+    pass
+
+def load_harmony_encoding(name: HarmonyEncodingName) -> HarmonyEncoding:
+    raise RuntimeError('openai_harmony no está disponible en el entorno de pruebas')
+
+class Content:
+    pass
+
+class TextContent:
+    pass
+
+class ToolNamespaceConfig:
+    pass

--- a/tests/test_meta_evaluator.py
+++ b/tests/test_meta_evaluator.py
@@ -1,0 +1,74 @@
+"""Pruebas de integración del MetaEvaluator con ReasoningKernel."""
+
+import sys
+import types
+
+# Stub de ``agix`` para aislar las pruebas de dependencias externas.
+agix = types.ModuleType("agix")
+agix.orchestrator = types.ModuleType("orchestrator")
+agix.orchestrator.VirtualQualia = object
+sys.modules.setdefault("agix", agix)
+sys.modules.setdefault("agix.orchestrator", agix.orchestrator)
+
+from agicore_core.reasoning_kernel import ReasoningKernel
+from agicore_core.meta_evaluator import MetaEvaluator
+from meta_router import MetaRouter
+
+
+class DummyExpert:
+    """Experto mínimo que acumula las llamadas recibidas."""
+
+    def __init__(self):
+        self.calls = []
+
+    def handle(self, request):
+        self.calls.append(request)
+        count = request.get("count", 0) + request.get("payload", 0)
+        return {"count": count}
+
+
+class CountingMetaEvaluator(MetaEvaluator):
+    """Extiende ``MetaEvaluator`` registrando invocaciones de ``evaluar_ciclo``."""
+
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+
+    def evaluar_ciclo(self, resultados):  # type: ignore[override]
+        self.calls += 1
+        return super().evaluar_ciclo(resultados)
+
+
+class DummyPlanner:
+    def plan(self, state):
+        return [{"task": "do", "payload": 1}]
+
+
+def test_meta_evaluator_generates_suggestions_and_updates_state():
+    router = MetaRouter()
+    expert = DummyExpert()
+    router.register("dummy", expert, tasks=["do"], contexts=["ctx"], goals=["finish"])
+    evaluator = CountingMetaEvaluator()
+    kernel = ReasoningKernel(planner=DummyPlanner(), router=router, evaluator=evaluator)
+    kernel.set_state({"context": "ctx", "goals": ["finish"], "count": 0})
+
+    # Historial inicial con métricas elevadas para forzar sugerencias.
+    kernel.history = [{"error": 1.0, "tiempo": 2.0} for _ in range(5)]
+
+    final_state = kernel.run(max_iterations=2)
+
+    # ``evaluar_ciclo`` se invoca una vez por iteración.
+    assert evaluator.calls == 2
+
+    # El estado incorpora sugerencias de reconfiguración.
+    assert final_state["error"] == "disminuir tasa de aprendizaje"
+    assert final_state["tiempo"] == "optimizar componentes críticos"
+
+    # Tras ``reflexionar`` se actualizan métricas agregadas y sugerencias internas.
+    assert evaluator.metricas_agregadas == {"error": 1.0, "tiempo": 2.0}
+    assert evaluator.sugerencias == [
+        {
+            "error": "disminuir tasa de aprendizaje",
+            "tiempo": "optimizar componentes críticos",
+        }
+    ]


### PR DESCRIPTION
## Resumen
- Añade pruebas de integración para MetaEvaluator con ReasoningKernel
- Crea stub `openai_harmony` para ejecutar las pruebas en aislamiento

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68959e2b089c83279e87d1a7aaf5e162