### PR TITLE
docs: explicar meta evaluador

### DIFF
--- a/docs/meta_evaluator.md
+++ b/docs/meta_evaluator.md
@@ -3,6 +3,44 @@
 `MetaEvaluator` recopila métricas de los ciclos del núcleo y aprende de ellas
 para proponer mejoras estructurales.
 
+## Instanciación junto a ReasoningKernel
+
+El evaluador se integra en el ciclo principal a través de `ReasoningKernel`.
+A continuación se muestra una configuración mínima que lo instancia junto al
+planificador y el enrutador:
+
+```python
+from agicore_core import Planner, ReasoningKernel, MetaEvaluator
+from meta_router import MetaRouter
+
+router = MetaRouter()
+planner = Planner()
+evaluator = MetaEvaluator()
+kernel = ReasoningKernel(planner, router, evaluator=evaluator)
+```
+
+En cada paso, el kernel envía las métricas al evaluador, que puede proponer
+ajustes y actualizar su conocimiento interno.
+
+## Parámetros y estrategias de reconfiguración
+
+`MetaEvaluator` analiza los resultados de los ciclos buscando indicadores
+numéricos o patrones de error. Sus principales campos de estado son:
+
+- **historial_metricas**: resúmenes numéricos registrados en cada iteración.
+- **metricas_agregadas**: promedios calculados tras llamar a `reflexionar`.
+- **patrones_fallo**: conteo de mensajes de error detectados.
+- **sugerencias**: cambios recomendados para la configuración interna.
+
+La heurística de `sugerir_reconfiguracion` examina métricas como `error` y
+`tiempo` para proponer ajustes. Por defecto:
+
+- Si el error medio supera `0.5`, recomienda **disminuir la tasa de aprendizaje**.
+- Si el tiempo medio es mayor que `1.0`, sugiere **optimizar componentes críticos**.
+
+Estas reglas pueden ampliarse con umbrales y acciones específicos del dominio,
+permitiendo estrategias de reconfiguración adaptadas a cada sistema.
+
 ## Almacenamiento de conocimiento
 
 - **Métricas agregadas**: promedios de los valores numéricos observados en el

--- a/docs/meta_router.md
+++ b/docs/meta_router.md
@@ -102,3 +102,22 @@ results = kernel.execute_plan(plan, task="math", context="cli", goals=["calculat
 
 En este ejemplo, el primer paso será atendido por `sumador` y el segundo por
 `traductor`, demostrando cómo la selección automática depende de los metadatos.
+
+## Meta Evaluación y Reflexión
+
+El flujo `planner → reasoning_kernel → meta_router` puede complementarse con un
+`MetaEvaluator` que registre métricas de cada ciclo y proponga ajustes
+automáticos. Para activarlo basta con instanciarlo junto al
+`ReasoningKernel`:
+
+```python
+from agicore_core import Planner, ReasoningKernel, MetaEvaluator
+
+router = MetaRouter()
+kernel = ReasoningKernel(Planner(), router, evaluator=MetaEvaluator())
+```
+
+El evaluador analiza los resultados devueltos por los expertos y puede sugerir
+reconfiguraciones del estado, como optimizar componentes lentos o reducir la
+tasa de aprendizaje. Más detalles y estrategias avanzadas se describen en
+`docs/meta_evaluator.md`.


### PR DESCRIPTION
## Summary
- ampliar `meta_evaluator.md` con ejemplo de uso junto a `ReasoningKernel`
- documentar parámetros y estrategias de reconfiguración
- añadir sección de "Meta Evaluación y Reflexión" en `meta_router.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895a072c22c8327889b7dc9dfd40a2f