### PR TITLE
Registrar métricas de tokens y aplicar sugerencias del evaluador

### DIFF
--- a/agicore_core/planner.py
+++ b/agicore_core/planner.py
@@ -56,3 +56,10 @@ class Planner:
         """
 
         return self.orchestrator.broadcast_state(state)
+
+    def aplicar_sugerencias(self, sugerencias: Dict[str, Any]) -> None:
+        """Ajusta el perfil del planificador según recomendaciones externas."""
+
+        if not sugerencias:
+            return
+        self.agent_profile.update(sugerencias)


### PR DESCRIPTION
## Resumen
- Añadida recopilación de métricas e introspección tras cada token procesado
- Se registran resultados de introspección y se propagan sugerencias del evaluador al planner
- Nuevo método `Planner.aplicar_sugerencias` para ajustar configuraciones

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895a9ff7e1883279941e45cdbb88e21