### PR TITLE
Manejar JSON inválido en perfil del planificador

### DIFF
--- a/agicore_core/planner.py
+++ b/agicore_core/planner.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 import json
+import logging
 from pathlib import Path
 
 from agix.orchestrator import VirtualQualia
+
+logger = logging.getLogger(__name__)
 
 
 class Planner:
@@ -34,7 +37,8 @@ class Planner:
         try:
             with config_path.open("r", encoding="utf-8") as f:
                 self.agent_profile = json.load(f)
-        except FileNotFoundError:
+        except (FileNotFoundError, json.JSONDecodeError) as exc:
+            logger.warning("Failed to load agent profile: %s", exc)
             self.agent_profile = {}
 
     def plan(self, state: Dict[str, Any]) -> List[Any]:

--- a/tests/test_planner_agent_profile.py
+++ b/tests/test_planner_agent_profile.py
@@ -1,0 +1,33 @@
+"""Pruebas para la carga del perfil del planificador de :mod:`agicore_core`."""
+
+import logging
+import sys
+import types
+
+import pytest
+
+
+
+def test_inicializacion_con_json_invalido(tmp_path, monkeypatch, caplog):
+    """El planificador debería manejar un JSON inválido."""
+
+    agix = types.ModuleType("agix")
+    agix.orchestrator = types.ModuleType("orchestrator")
+    agix.orchestrator.VirtualQualia = object
+    sys.modules.setdefault("agix", agix)
+    sys.modules.setdefault("agix.orchestrator", agix.orchestrator)
+
+    from agicore_core import planner as planner_module
+
+    module_dir = tmp_path / "agicore_core"
+    config_dir = module_dir / "config"
+    config_dir.mkdir(parents=True)
+    (module_dir / "planner.py").write_text("", encoding="utf-8")
+    (config_dir / "agent_profile.json").write_text("{invalido", encoding="utf-8")
+
+    monkeypatch.setattr(planner_module, "__file__", str(module_dir / "planner.py"))
+
+    with caplog.at_level(logging.WARNING):
+        planificador = planner_module.Planner()
+    assert planificador.agent_profile == {}
+    assert "Failed to load agent profile" in caplog.text


### PR DESCRIPTION
## Resumen
- Manejo robusto de `agent_profile.json` en `Planner`, registrando advertencias y evitando fallos cuando el archivo está ausente o contiene JSON inválido.
- Prueba que asegura la inicialización correcta del planificador ante un perfil con JSON malformado.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895b6e47ae883278b55533baf899b20