### PR TITLE
Refactoriza Ollama a clase con endpoint configurable

### DIFF
--- a/gpt_oss/responses_api/inference/ollama.py
+++ b/gpt_oss/responses_api/inference/ollama.py
@@ -1,10 +1,11 @@
 """
 NOTE: this is a stiched together implementation that uses Ollama for inference. It's primarily used
-for testing and development. It does not leverage any prompt caching or other optimizations and 
+for testing and development. It does not leverage any prompt caching or other optimizations and
 can therefore be slow between turns.
 """
 
 import json
+import os
 import threading
 import time
 from typing import Callable, Optional
@@ -19,15 +20,12 @@ POLL_INTERVAL_S = 0.01           # 10ms between buffer checks
 CALL_MAX_WAIT_S = 0.250          # max time to block inside a single infer call
 NO_TOKEN_TIMEOUT_S = 15.0        # overall inactivity timeout before emitting EOS
 FIRST_BYTE_TIMEOUT_S = 30.0      # time to wait for first token before EOS
+DEFAULT_ENDPOINT_URL = "http://localhost:11434/api/generate"
 
-# Shared state
-_token_buffer: list[int] = []
-_buffer_lock = threading.Lock()
-_stream_thread: Optional[threading.Thread] = None
-_stream_done = threading.Event()
-_stream_error: Optional[Exception] = None
-_last_progress_ts: float = 0.0    # updated whenever we enqueue or dequeue tokens
-_previous_request_tokens: list[int] = []
+
+def _now() -> float:
+    return time.monotonic()
+
 
 def lcp(cache: list[int], inp: list[int]) -> list[int]:
     i = 0
@@ -36,49 +34,54 @@ def lcp(cache: list[int], inp: list[int]) -> list[int]:
         i += 1
     return cache[:i]
 
-def _now():
-    return time.monotonic()
 
-def _touch_progress():
-    global _last_progress_ts
-    _last_progress_ts = _now()
+class OllamaStreamer:
+    """Handle streaming state for a single Ollama model instance."""
 
-def _reset_stream_state():
-    global _token_buffer, _stream_thread, _stream_error
-    with _buffer_lock:
-        _token_buffer = []
-    _stream_done.clear()
-    _stream_thread = None
-    _stream_error = None
-    _touch_progress()
+    def __init__(self, model_name: str, endpoint_url: Optional[str] = None):
+        self.encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
+        self.model_name = model_name
+        self.endpoint_url = endpoint_url or os.environ.get("OLLAMA_ENDPOINT", DEFAULT_ENDPOINT_URL)
 
-def setup_model(checkpoint: str) -> Callable[[list[int], float, bool], int]:
-    encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
-    model_name = checkpoint
+        # Per-instance state
+        self._token_buffer: list[int] = []
+        self._buffer_lock = threading.Lock()
+        self._stream_thread: Optional[threading.Thread] = None
+        self._stream_done = threading.Event()
+        self._stream_error: Optional[Exception] = None
+        self._last_progress_ts: float = 0.0
+        self._previous_request_tokens: list[int] = []
 
-    def _start_stream(token_ids: list[int], temperature: float):
-        prompt_text = encoding.decode(token_ids)
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _touch_progress(self) -> None:
+        self._last_progress_ts = _now()
+
+    def _reset_stream_state(self) -> None:
+        with self._buffer_lock:
+            self._token_buffer = []
+        self._stream_done.clear()
+        self._stream_thread = None
+        self._stream_error = None
+        self._touch_progress()
+
+    def _start_stream(self, token_ids: list[int], temperature: float):
+        prompt_text = self.encoding.decode(token_ids)
+
         def run():
             nonlocal prompt_text, temperature
-            global _stream_error
-            global _previous_request_tokens
 
             accum_text = ""
             last_len = 0  # number of tokens already emitted
 
             try:
-                url = "http://localhost:11434/api/generate"
+                url = self.endpoint_url
                 context = None
-                if len(_previous_request_tokens) > 0:
-                    context = _previous_request_tokens
-                    # cache_hit = lcp(_previous_request_tokens, token_ids)
-                    # if len(cache_hit) > 0:
-                    #     context = cache_hit
-                    #     print(f"Cache hit: {encoding.decode(context)}")
-                    #     prompt_text = encoding.decode(token_ids[len(context):])
+                if len(self._previous_request_tokens) > 0:
+                    context = self._previous_request_tokens
 
                 payload = {
-                    "model": model_name,
+                    "model": self.model_name,
                     "prompt": prompt_text,
                     "stream": True,
                     "context": context,
@@ -94,79 +97,78 @@ def setup_model(checkpoint: str) -> Callable[[list[int], float, bool], int]:
 
                         if isinstance(obj.get("response"), str):
                             accum_text += obj["response"]
-                            toks = encoding.encode(accum_text, allowed_special="all")
+                            toks = self.encoding.encode(accum_text, allowed_special="all")
                             if len(toks) > last_len:
                                 new_toks = toks[last_len:]
-                                with _buffer_lock:
-                                    _token_buffer.extend(new_toks)
+                                with self._buffer_lock:
+                                    self._token_buffer.extend(new_toks)
                                 last_len = len(toks)
-                                _touch_progress()
+                                self._touch_progress()
 
                         if obj.get("done", False):
-                            _token_buffer.append(EOS_TOKEN)
+                            with self._buffer_lock:
+                                self._token_buffer.append(EOS_TOKEN)
                             last_len = len(toks)
-                            _touch_progress()
+                            self._touch_progress()
                             context = obj.get("context")
                             if context and len(context) > 0:
-                                _previous_request_tokens = context
+                                with self._buffer_lock:
+                                    self._previous_request_tokens = context
                             break
 
-                _stream_done.set()
+                self._stream_done.set()
 
             except Exception as e:
-                _stream_error = e
-                _stream_done.set()
+                self._stream_error = e
+                self._stream_done.set()
 
         t = threading.Thread(target=run, name="ollama-stream", daemon=True)
         t.start()
         return t
 
+    # ------------------------------------------------------------------
+    # Public API
     def infer_next_token(
-        tokens: list[int], temperature: float = 0.0, new_request: bool = False
+        self, tokens: list[int], temperature: float = 0.0, new_request: bool = False
     ) -> int:
-        """
-        - Starts a new Ollama stream on new_request.
-        - Forwards tokens as they arrive.
-        - Only emits EOS_TOKEN if we exceed an inactivity timeout.
-        """
-        global _stream_thread
+        """Infer the next token using the Ollama backend."""
 
         if new_request:
-            _reset_stream_state()
-            _stream_thread = _start_stream(token_ids=tokens, temperature=temperature)
+            self._reset_stream_state()
+            self._stream_thread = self._start_stream(token_ids=tokens, temperature=temperature)
             # Wait for first byte within FIRST_BYTE_TIMEOUT_S (without emitting EOS early)
             start = _now()
             while _now() - start < FIRST_BYTE_TIMEOUT_S:
-                with _buffer_lock:
-                    if _token_buffer:
-                        tok = _token_buffer.pop(0)
-                        _touch_progress()
+                with self._buffer_lock:
+                    if self._token_buffer:
+                        tok = self._token_buffer.pop(0)
+                        self._touch_progress()
                         return tok
-                if _stream_error is not None:
-                    raise RuntimeError(f"Ollama stream error: {_stream_error!r}")
+                if self._stream_error is not None:
+                    raise RuntimeError(f"Ollama stream error: {self._stream_error!r}")
                 # If Ollama finished instantly with no output, continue loop until timeout
                 time.sleep(POLL_INTERVAL_S)
             # Hard first-byte timeout -> emit EOS so the server can stop this request
             return EOS_TOKEN
 
-        if _stream_error is not None:
-            raise RuntimeError(f"Ollama stream error: {_stream_error!r}")
+        if self._stream_error is not None:
+            raise RuntimeError(f"Ollama stream error: {self._stream_error!r}")
 
         # Normal path: wait up to CALL_MAX_WAIT_S for a token to arrive
         wait_start = _now()
         while _now() - wait_start < CALL_MAX_WAIT_S:
-            with _buffer_lock:
-                if _token_buffer:
-                    tok = _token_buffer.pop(0)
-                    _touch_progress()
+            with self._buffer_lock:
+                if self._token_buffer:
+                    tok = self._token_buffer.pop(0)
+                    self._touch_progress()
                     return tok
             # No token yet; if we've been idle too long overall, end with EOS
-            if _now() - _last_progress_ts > NO_TOKEN_TIMEOUT_S:
+            if _now() - self._last_progress_ts > NO_TOKEN_TIMEOUT_S:
                 return EOS_TOKEN
             time.sleep(POLL_INTERVAL_S)
 
         # Still no token in this call slice. Do NOT send EOS unless we've timed out.
-        if _now() - _last_progress_ts > NO_TOKEN_TIMEOUT_S:
+        if _now() - self._last_progress_ts > NO_TOKEN_TIMEOUT_S:
             return EOS_TOKEN
 
         # Tell caller to call us again; block minimally by returning *nothing new*.
@@ -174,14 +176,14 @@ def setup_model(checkpoint: str) -> Callable[[list[int], float, bool], int]:
         # If still none, keep returning only after short waits. Avoid EOS here.
         # One more short wait to reduce hot-looping:
         time.sleep(POLL_INTERVAL_S)
-        with _buffer_lock:
-            if _token_buffer:
-                tok = _token_buffer.pop(0)
-                _touch_progress()
+        with self._buffer_lock:
+            if self._token_buffer:
+                tok = self._token_buffer.pop(0)
+                self._touch_progress()
                 return tok
 
         # As a last resort for this call slice, return EOS only on true inactivity timeout.
-        if _now() - _last_progress_ts > NO_TOKEN_TIMEOUT_S:
+        if _now() - self._last_progress_ts > NO_TOKEN_TIMEOUT_S:
             return EOS_TOKEN
 
         # If we reach here, we still haven't got a token—ask the caller to call again soon.
@@ -189,4 +191,8 @@ def setup_model(checkpoint: str) -> Callable[[list[int], float, bool], int]:
         # If your interface does NOT allow a sentinel, keep the short-blocking behavior above.
         return EOS_TOKEN if False else 0  # replace `0` with a PAD/NOOP token your server ignores
 
-    return infer_next_token
+
+def setup_model(checkpoint: str, endpoint_url: Optional[str] = None) -> Callable[[list[int], float, bool], int]:
+    """Create a streaming model callable for the given checkpoint."""
+    streamer = OllamaStreamer(checkpoint, endpoint_url=endpoint_url)
+    return streamer.infer_next_token

--- a/gpt_oss/responses_api/serve.py
+++ b/gpt_oss/responses_api/serve.py
@@ -35,24 +35,34 @@ if __name__ == "__main__":
         # default to metal on macOS, triton on other platforms
         default="metal" if __import__("platform").system() == "Darwin" else "triton",
     )
+    parser.add_argument(
+        "--ollama-url",
+        metavar="URL",
+        type=str,
+        default=None,
+        help="URL del endpoint Ollama cuando se usa el backend 'ollama'",
+    )
     args = parser.parse_args()
-
     if args.inference_backend == "triton":
         from .inference.triton import setup_model
+        infer_next_token = setup_model(args.checkpoint)
     elif args.inference_backend == "stub":
         from .inference.stub import setup_model
+        infer_next_token = setup_model(args.checkpoint)
     elif args.inference_backend == "metal":
         from .inference.metal import setup_model
+        infer_next_token = setup_model(args.checkpoint)
     elif args.inference_backend == "ollama":
         from .inference.ollama import setup_model
+        infer_next_token = setup_model(args.checkpoint, endpoint_url=args.ollama_url)
     elif args.inference_backend == "vllm":
         from .inference.vllm import setup_model
+        infer_next_token = setup_model(args.checkpoint)
     elif args.inference_backend == "transformers":
         from .inference.transformers import setup_model
+        infer_next_token = setup_model(args.checkpoint)
     else:
         raise ValueError(f"Invalid inference backend: {args.inference_backend}")
 
     encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
-
-    infer_next_token = setup_model(args.checkpoint)
     uvicorn.run(create_api_server(infer_next_token, encoding), port=args.port)

--- a/tests_ollama/test_ollama_inference.py
+++ b/tests_ollama/test_ollama_inference.py
@@ -1,0 +1,106 @@
+import json as json_module
+import threading
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from gpt_oss.responses_api.inference.ollama import setup_model, EOS_TOKEN
+
+
+class DummyEncoding:
+    def encode(self, text, allowed_special="all"):
+        return [ord(c) for c in text]
+
+    def decode(self, tokens):
+        return ''.join(chr(t) for t in tokens)
+
+
+def fake_load_harmony_encoding(name):
+    return DummyEncoding()
+
+
+class FakeResponse:
+    def __init__(self, lines):
+        self._lines = lines
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def raise_for_status(self):
+        pass
+
+    def iter_lines(self, decode_unicode=True):
+        for line in self._lines:
+            yield line
+
+
+def test_multiple_instances_independent(monkeypatch):
+    monkeypatch.setattr(
+        "gpt_oss.responses_api.inference.ollama.load_harmony_encoding",
+        fake_load_harmony_encoding,
+    )
+
+    def fake_post(url, json, stream, timeout):
+        token = "A" if "custom1" in url else "B"
+        lines = [
+            json_module.dumps({"response": token, "done": False}),
+            json_module.dumps({"done": True, "context": [1, 2, 3]}),
+        ]
+        return FakeResponse(lines)
+
+    monkeypatch.setattr(
+        "gpt_oss.responses_api.inference.ollama.requests.post", fake_post
+    )
+
+    infer1 = setup_model("model1", endpoint_url="http://custom1/api/generate")
+    infer2 = setup_model("model2", endpoint_url="http://custom2/api/generate")
+
+    results = {}
+
+    def run_infer(name, infer):
+        tokens = []
+        tok = infer([1], 0.0, new_request=True)
+        while tok not in (EOS_TOKEN, 0):
+            tokens.append(tok)
+            tok = infer([], 0.0)
+        results[name] = tokens
+
+    t1 = threading.Thread(target=run_infer, args=("m1", infer1))
+    t2 = threading.Thread(target=run_infer, args=("m2", infer2))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert results["m1"] == [ord("A")]
+    assert results["m2"] == [ord("B")]
+
+
+def test_env_url(monkeypatch):
+    monkeypatch.setenv("OLLAMA_ENDPOINT", "https://env.example/api/generate")
+    monkeypatch.setattr(
+        "gpt_oss.responses_api.inference.ollama.load_harmony_encoding",
+        fake_load_harmony_encoding,
+    )
+    captured = {}
+
+    def fake_post(url, json, stream, timeout):
+        captured["url"] = url
+        lines = [
+            json_module.dumps({"response": "X", "done": False}),
+            json_module.dumps({"done": True}),
+        ]
+        return FakeResponse(lines)
+
+    monkeypatch.setattr(
+        "gpt_oss.responses_api.inference.ollama.requests.post", fake_post
+    )
+
+    infer = setup_model("model_env")
+    tok = infer([1], 0.0, new_request=True)
+    assert captured["url"] == "https://env.example/api/generate"
+    assert tok == ord("X")


### PR DESCRIPTION
## Resumen
- Encapsula el estado de streaming de Ollama en una clase por instancia y soporta URL configurable vía argumento o variable de entorno
- Añade soporte de línea de comandos para pasar `--ollama-url`
- Agrega pruebas para instancias simultáneas y configuración personalizada de URL

## Pruebas
- `pytest tests_ollama/test_ollama_inference.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895e80feff483279017fc5fb79e9484