### PR TITLE
Valida tipo de goals en MetaRouter

### DIFF
--- a/meta_router.py
+++ b/meta_router.py
@@ -88,6 +88,9 @@ class MetaRouter:
     ) -> Dict[str, int]:
         """Calcula un puntaje para cada experto registrado.
 
+        Asume que ``goals`` es una lista de cadenas previamente validada
+        por :meth:`route`.
+
         Antes de evaluar a cada experto, se consultan los episodios
         almacenados en memoria que coincidan con los parámetros recibidos.
         Los resultados previos influyen en el puntaje final de cada experto
@@ -167,6 +170,8 @@ class MetaRouter:
             raise ValueError(
                 "La solicitud debe incluir 'task', 'context' y 'goals'",
             )
+        if not isinstance(goals, list) or not all(isinstance(g, str) for g in goals):
+            raise ValueError("La clave 'goals' debe ser una lista de cadenas")
 
         scores = self.select_expert(
             task,

--- a/tests/test_meta_router.py
+++ b/tests/test_meta_router.py
@@ -44,6 +44,26 @@ def test_unknown_task_raises_error():
         router.route({"task": "missing", "context": "", "goals": []})
 
 
+def test_route_accepts_goals_list_of_strings():
+    router = MetaRouter()
+    dummy = DummyModule()
+    router.register("dummy", dummy, tasks=["t"], contexts=["c"], goals=["g"])
+    request = {"task": "t", "context": "c", "goals": ["g"]}
+    assert router.route(request) == "ok"
+
+
+def test_route_rejects_non_list_goals():
+    router = MetaRouter()
+    with pytest.raises(ValueError):
+        router.route({"task": "t", "context": "c", "goals": "g"})
+
+
+def test_route_rejects_non_string_items_in_goals():
+    router = MetaRouter()
+    with pytest.raises(ValueError):
+        router.route({"task": "t", "context": "c", "goals": [1, "g"]})
+
+
 def test_selects_correct_expert_among_multiple():
     router = MetaRouter()
     first = DummyModule()


### PR DESCRIPTION
## Resumen
- Valida que `goals` sea lista de cadenas y lanza `ValueError` con mensaje claro
- Ajusta `select_expert` para asumir `goals` pre-validadas
- Añade pruebas unitarias para entradas de `goals` válidas e inválidas

## Pruebas
- `pytest tests/test_meta_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68961b94354883278e7613eb0d950ee3