### PR TITLE
Filtrar temperaturas inválidas en Planner

### DIFF
--- a/gpt_oss/planner.py
+++ b/gpt_oss/planner.py
@@ -142,11 +142,11 @@ class Planner:
         parametros = estrategias[tipo].copy()
         if self.memory is not None:
             episodios = self.memory.query({"mode": tipo, "outcome": "success"})
-            temps = [
-                ep.metadata.get("temperature")
-                for ep in episodios
-                if "temperature" in ep.metadata
-            ]
+            temps = []
+            for ep in episodios:
+                valor = ep.metadata.get("temperature")
+                if isinstance(valor, (int, float)):
+                    temps.append(valor)
             if temps:
                 parametros["temperature"] = sum(temps) / len(temps)
         self.mode_parameters = parametros

--- a/tests/test_planner_memory.py
+++ b/tests/test_planner_memory.py
@@ -59,3 +59,44 @@ def test_activate_mode_promedia_temperaturas_memoria() -> None:
     planner = Planner(memory=memory)
     planner.activate_mode("analytic")
     assert planner.get_mode_parameters()["temperature"] == pytest.approx(0.5)
+
+
+def test_activate_mode_ignora_valores_de_temperatura_invalidos() -> None:
+    memory = StrategicMemory()
+    memory.add_episode(
+        Episode(
+            timestamp=datetime.now(),
+            input="i1",
+            action="a1",
+            outcome="success",
+            metadata={"mode": "analytic", "temperature": 0.6},
+        )
+    )
+    memory.add_episode(
+        Episode(
+            timestamp=datetime.now(),
+            input="i2",
+            action="a2",
+            outcome="success",
+            metadata={"mode": "analytic", "temperature": "fría"},
+        )
+    )
+    planner = Planner(memory=memory)
+    planner.activate_mode("analytic")
+    assert planner.get_mode_parameters()["temperature"] == pytest.approx(0.6)
+
+
+def test_activate_mode_sin_valores_validos_mantiene_default() -> None:
+    memory = StrategicMemory()
+    memory.add_episode(
+        Episode(
+            timestamp=datetime.now(),
+            input="i",
+            action="a",
+            outcome="success",
+            metadata={"mode": "analytic", "temperature": "alta"},
+        )
+    )
+    planner = Planner(memory=memory)
+    planner.activate_mode("analytic")
+    assert planner.get_mode_parameters()["temperature"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- filtrar temperaturas no numéricas al activar modo en Planner
- agregar pruebas que cubren temperaturas inválidas y casos sin valores válidos

## Testing
- `pytest`
- `pytest tests/test_planner_memory.py`


------
https://chatgpt.com/codex/tasks/task_e_68962ba124248327b8e25820c15c0bce