### PR TITLE
Handle broadcast errors in planner

### DIFF
--- a/agicore_core/planner.py
+++ b/agicore_core/planner.py
@@ -58,8 +58,11 @@ class Planner:
             Lista de respuestas proporcionadas por los clientes del
             orquestador.
         """
-
-        return self.orchestrator.broadcast_state(state)
+        try:
+            return self.orchestrator.broadcast_state(state)
+        except Exception:  # pragma: no cover - logging side effect
+            logger.exception("Error al difundir el estado")
+            return []
 
     def aplicar_sugerencias(self, sugerencias: Dict[str, Any]) -> None:
         """Ajusta el perfil del planificador según recomendaciones externas."""


### PR DESCRIPTION
## Summary
- guard `VirtualQualia.broadcast_state` in planner with try/except
- log broadcast errors and return an empty list as a safe fallback

## Testing
- `pytest --ignore=tests/test_python_docker.py`


------
https://chatgpt.com/codex/tasks/task_e_68963d618694832793587edd7e8d8bdb