### PR TITLE
Prevent duplicate MetaRouter registrations

### DIFF
--- a/meta_router.py
+++ b/meta_router.py
@@ -67,6 +67,8 @@ class MetaRouter:
         priority: int = 0,
     ) -> None:
         """Registra un nuevo ``module`` bajo ``name`` con metadatos opcionales."""
+        if name in self._experts:
+            raise ValueError(f"El nombre '{name}' ya está registrado")
 
         self._experts[name] = Expert(
             module=module,

--- a/tests/test_meta_router.py
+++ b/tests/test_meta_router.py
@@ -17,6 +17,14 @@ class DummyModule:
         return "ok"
 
 
+def test_register_duplicate_name_raises_error():
+    router = MetaRouter()
+    dummy = DummyModule()
+    router.register("dup", dummy, tasks=["t"], contexts=["c"], goals=["g"])
+    with pytest.raises(ValueError):
+        router.register("dup", dummy, tasks=["t"], contexts=["c"], goals=["g"])
+
+
 def test_routes_to_custom_module():
     router = MetaRouter()
     dummy = DummyModule()


### PR DESCRIPTION
## Summary
- Raise `ValueError` when attempting to register an expert name that already exists
- Add regression test ensuring duplicate registration is rejected

## Testing
- `pytest tests/test_meta_router.py tests/test_planner_reasoning_meta.py tests/test_meta_evaluator.py tests/test_reasoning_kernel.py tests/test_token_cycle_reasoning_kernel.py tests/test_stateful_reasoning_kernel.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6896b40d4dc88327befcd96eae8d69b8