### PR TITLE
feat: add episode limit to strategic memory

### DIFF
--- a/gpt_oss/strategic_memory.py
+++ b/gpt_oss/strategic_memory.py
@@ -39,10 +39,18 @@ class StrategicMemory:
     interacciones o episodios que se pueden consultar posteriormente.
     """
 
-    def __init__(self) -> None:
-        """Inicializa las estructuras de almacenamiento internas."""
+    def __init__(self, max_episodes: int | None = None) -> None:
+        """Inicializa las estructuras de almacenamiento internas.
+
+        Parameters
+        ----------
+        max_episodes:
+            Número máximo de episodios a conservar. Si es ``None``,
+            la cantidad de episodios es ilimitada.
+        """
         self._storage: Dict[str, Any] = {}
         self._episodes: List[Episode] = []
+        self._max_episodes = max_episodes
 
     def save(self, key: str, value: Any) -> None:
         """Guarda una nueva entrada en la memoria.
@@ -109,6 +117,9 @@ class StrategicMemory:
             del episodio a almacenar.
         """
 
+        if self._max_episodes is not None:
+            while len(self._episodes) >= self._max_episodes:
+                self._episodes.pop(0)
         self._episodes.append(data)
 
     def query(self, pattern: Dict[str, Any]) -> List[Episode]:

--- a/tests/test_strategic_memory.py
+++ b/tests/test_strategic_memory.py
@@ -94,3 +94,33 @@ def test_add_episode_query_and_summarize_multiple():
     assert resumen["total"] == 2
     assert ("alpha", 1) in resumen["actions"]
     assert ("fail", 1) in resumen["outcomes"]
+
+
+def test_max_episodes_fifo():
+    memoria = StrategicMemory(max_episodes=2)
+    ep1 = Episode(
+        timestamp=datetime.utcnow(),
+        input="i1",
+        action="a1",
+        outcome="o1",
+    )
+    ep2 = Episode(
+        timestamp=datetime.utcnow(),
+        input="i2",
+        action="a2",
+        outcome="o2",
+    )
+    ep3 = Episode(
+        timestamp=datetime.utcnow(),
+        input="i3",
+        action="a3",
+        outcome="o3",
+    )
+    memoria.add_episode(ep1)
+    memoria.add_episode(ep2)
+    memoria.add_episode(ep3)
+
+    assert memoria.query({"action": "a1"}) == []
+    assert memoria.query({"action": "a2"}) == [ep2]
+    assert memoria.query({"action": "a3"}) == [ep3]
+    assert memoria.summarize()["total"] == 2


### PR DESCRIPTION
## Summary
- allow limiting stored episodes with optional `max_episodes`
- trim oldest episodes to respect limit
- test FIFO episode trimming behavior

## Testing
- `python -m pytest tests/test_strategic_memory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6896d3b8b724832788d558ec2b2fcfe1