### PR TITLE
Use official encoding for SimpleBrowserTool

### DIFF
--- a/tests/test_simple_browser_encoding.py
+++ b/tests/test_simple_browser_encoding.py
@@ -1,0 +1,11 @@
+import tiktoken
+
+from gpt_oss.tools.simple_browser.simple_browser_tool import ENC_NAME, get_tokens
+
+
+def test_default_encoding_matches_model():
+    text = "Hola mundo"
+    encoding = tiktoken.encoding_for_model("gpt-4.1-mini")
+    assert ENC_NAME == encoding.name
+    tool_tokens = get_tokens(text)
+    assert tool_tokens.tokens == encoding.encode(text, disallowed_special=())


### PR DESCRIPTION
## Summary
- derive browser token encoding from `tiktoken.encoding_for_model("gpt-4.1-mini")`
- default tokenization helpers to this encoding
- add regression test asserting token compatibility

## Testing
- `pytest tests/test_simple_browser_encoding.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a050364c608327b7a5dc63c8978d6d