### PR TITLE
Handle gptoss errors in Python bindings

### DIFF
--- a/gpt_oss/metal/python/context.c
+++ b/gpt_oss/metal/python/context.c
@@ -28,7 +28,7 @@ static int PyGPTOSSContext_init(PyGPTOSSContext* self, PyObject* args, PyObject*
         (size_t) context_length,
         &self->handle);
     if (status != gptoss_status_success) {
-        // TODO: set exception
+        PyErr_SetString(PyExc_RuntimeError, "gptoss_context_create failed");
         goto error;
     }
 
@@ -68,7 +68,7 @@ static PyObject* PyGPTOSSContext_append(PyGPTOSSContext* self, PyObject* arg) {
         const enum gptoss_status status = gptoss_context_append_chars(
             self->handle, string_ptr, string_size, /*num_tokens_out=*/NULL);
         if (status != gptoss_status_success) {
-            // TODO: set exception
+            PyErr_SetString(PyExc_RuntimeError, "gptoss_context_append_chars failed");
             return NULL;
         }
 
@@ -83,7 +83,7 @@ static PyObject* PyGPTOSSContext_append(PyGPTOSSContext* self, PyObject* arg) {
         const enum gptoss_status status = gptoss_context_append_chars(
             self->handle, string_ptr, string_size, /*num_tokens_out=*/NULL);
         if (status != gptoss_status_success) {
-            // TODO: set exception
+            PyErr_SetString(PyExc_RuntimeError, "gptoss_context_append_chars failed");
             return NULL;
         }
 
@@ -98,7 +98,7 @@ static PyObject* PyGPTOSSContext_append(PyGPTOSSContext* self, PyObject* arg) {
         const enum gptoss_status status = gptoss_context_append_tokens(
             self->handle, /*num_tokens=*/1, &token);
         if (status != gptoss_status_success) {
-            // TODO: set exception
+            PyErr_SetString(PyExc_RuntimeError, "gptoss_context_append_tokens failed");
             return NULL;
         }
 
@@ -112,7 +112,7 @@ static PyObject* PyGPTOSSContext_append(PyGPTOSSContext* self, PyObject* arg) {
 static PyObject* PyGPTOSSContext_process(PyGPTOSSContext* self) {
     const enum gptoss_status status = gptoss_context_process(self->handle);
     if (status != gptoss_status_success) {
-        // TODO: set exception
+        PyErr_SetString(PyExc_RuntimeError, "gptoss_context_process failed");
         return NULL;
     }
 
@@ -134,7 +134,7 @@ static PyObject* PyGPTOSSContext_sample(PyGPTOSSContext* self, PyObject* args, P
     enum gptoss_status status = gptoss_context_sample(
         self->handle, temperature, (uint64_t) seed, &token_out);
     if (status != gptoss_status_success) {
-        // TODO: set exception
+        PyErr_SetString(PyExc_RuntimeError, "gptoss_context_sample failed");
         return NULL;
     }
 
@@ -144,7 +144,7 @@ static PyObject* PyGPTOSSContext_sample(PyGPTOSSContext* self, PyObject* args, P
 static PyObject* PyGPTOSSContext_reset(PyGPTOSSContext* self) {
     const enum gptoss_status status = gptoss_context_reset(self->handle);
     if (status != gptoss_status_success) {
-        // TODO: set exception
+        PyErr_SetString(PyExc_RuntimeError, "gptoss_context_reset failed");
         return NULL;
     }
 
@@ -164,7 +164,7 @@ static PyObject* PyGPTOSSContext_get_num_tokens(PyGPTOSSContext* self, void* clo
     size_t num_tokens = 0;
     const enum gptoss_status status = gptoss_context_get_num_tokens(self->handle, &num_tokens);
     if (status != gptoss_status_success) {
-        // TODO: set exception
+        PyErr_SetString(PyExc_RuntimeError, "gptoss_context_get_num_tokens failed");
         return NULL;
     }
 
@@ -175,7 +175,7 @@ static PyObject* PyGPTOSSContext_get_max_tokens(PyGPTOSSContext* self, void* clo
     size_t max_tokens = 0;
     const enum gptoss_status status = gptoss_context_get_max_tokens(self->handle, &max_tokens);
     if (status != gptoss_status_success) {
-        // TODO: set exception
+        PyErr_SetString(PyExc_RuntimeError, "gptoss_context_get_max_tokens failed");
         return NULL;
     }
 
@@ -193,13 +193,13 @@ static PyObject* PyGPTOSSContext_get_tokens(PyGPTOSSContext* self, void* closure
     if (num_tokens != 0) {
         token_ptr = (uint32_t*) PyMem_Malloc(num_tokens * sizeof(uint32_t));
         if (token_ptr == NULL) {
-            // TODO: set exception
+            PyErr_NoMemory();
             goto error;
         }
 
         enum gptoss_status status = gptoss_context_get_tokens(self->handle, token_ptr, /*max_tokens=*/num_tokens, &num_tokens);
         if (status != gptoss_status_success) {
-            // TODO: set exception
+            PyErr_SetString(PyExc_RuntimeError, "gptoss_context_get_tokens failed");
             goto error;
         }
     }

--- a/gpt_oss/metal/python/model.c
+++ b/gpt_oss/metal/python/model.c
@@ -14,7 +14,7 @@ static int PyGPTOSSModel_init(PyGPTOSSModel* self, PyObject* args, PyObject* kwa
     }
     status = gptoss_model_create_from_file(filepath, &self->handle);
     if (status != gptoss_status_success) {
-        // TODO: set exception
+        PyErr_SetString(PyExc_RuntimeError, "gptoss_model_create_from_file failed");
         return -1;
     }
     return 0;
@@ -46,7 +46,7 @@ static PyObject *PyGPTOSSModel_get_max_context_length(PyGPTOSSModel* self, void*
     size_t max_context_length = 0;
     const enum gptoss_status status = gptoss_model_get_max_context_length(self->handle, &max_context_length);
     if (status != gptoss_status_success) {
-        // TODO: set exception
+        PyErr_SetString(PyExc_RuntimeError, "gptoss_model_get_max_context_length failed");
         return NULL;
     }
 

--- a/gpt_oss/metal/python/tokenizer.c
+++ b/gpt_oss/metal/python/tokenizer.c
@@ -20,7 +20,10 @@ static PyObject* PyGPTOSSTokenizer_new(PyTypeObject* subtype, PyObject* args, Py
         ((const PyGPTOSSModel*) model)->handle,
         &self->handle);
     if (status != gptoss_status_success) {
-        // TODO: set exception
+        PyErr_SetString(PyExc_RuntimeError, "gptoss_model_get_tokenizer failed");
+        gptoss_tokenizer_release(self->handle);
+        self->handle = NULL;
+        Py_DECREF(self);
         return NULL;
     }
 
@@ -104,7 +107,7 @@ static PyObject* PyGPTOSSTokenizer_decode(PyGPTOSSTokenizer* self, PyObject* arg
     size_t token_size = 0;
     const enum gptoss_status status = gptoss_tokenizer_decode(self->handle, (uint32_t) token, &token_ptr, &token_size);
     if (status != gptoss_status_success) {
-        // TODO: set exception
+        PyErr_SetString(PyExc_RuntimeError, "gptoss_tokenizer_decode failed");
         return NULL;
     }
 
@@ -122,7 +125,7 @@ static PyObject* PyGPTOSSTokenizer_get_num_text_tokens(PyGPTOSSTokenizer* self, 
     uint32_t num_text_tokens = 0;
     const enum gptoss_status status = gptoss_tokenizer_get_num_text_tokens(self->handle, &num_text_tokens);
     if (status != gptoss_status_success) {
-        // TODO: set exception
+        PyErr_SetString(PyExc_RuntimeError, "gptoss_tokenizer_get_num_text_tokens failed");
         return NULL;
     }
 
@@ -133,7 +136,7 @@ static PyObject* PyGPTOSSTokenizer_get_num_special_tokens(PyGPTOSSTokenizer* sel
     uint32_t num_special_tokens = 0;
     const enum gptoss_status status = gptoss_tokenizer_get_num_special_tokens(self->handle, &num_special_tokens);
     if (status != gptoss_status_success) {
-        // TODO: set exception
+        PyErr_SetString(PyExc_RuntimeError, "gptoss_tokenizer_get_num_special_tokens failed");
         return NULL;
     }
 
@@ -144,7 +147,7 @@ static PyObject* PyGPTOSSTokenizer_get_num_tokens(PyGPTOSSTokenizer* self, void*
     uint32_t num_tokens = 0;
     const enum gptoss_status status = gptoss_tokenizer_get_num_tokens(self->handle, &num_tokens);
     if (status != gptoss_status_success) {
-        // TODO: set exception
+        PyErr_SetString(PyExc_RuntimeError, "gptoss_tokenizer_get_num_tokens failed");
         return NULL;
     }
 

--- a/tests/test_metal_exceptions.py
+++ b/tests/test_metal_exceptions.py
@@ -1,0 +1,32 @@
+import pytest
+from gpt_oss import metal
+
+
+def test_model_init_failure():
+    with pytest.raises(RuntimeError):
+        metal.Model("nonexistent-file")
+
+
+def test_tokenizer_init_failure():
+    dummy_model = object.__new__(metal.Model)
+    with pytest.raises(RuntimeError):
+        metal.Tokenizer(dummy_model)
+
+
+def test_tokenizer_decode_failure():
+    dummy_tokenizer = object.__new__(metal.Tokenizer)
+    with pytest.raises(RuntimeError):
+        dummy_tokenizer.decode(0)
+
+
+def test_context_init_failure():
+    dummy_model = object.__new__(metal.Model)
+    with pytest.raises(RuntimeError):
+        metal.Context(dummy_model)
+
+
+def test_context_append_failure():
+    dummy_context = object.__new__(metal.Context)
+    with pytest.raises(RuntimeError):
+        dummy_context.append(b"data")
+


### PR DESCRIPTION
## Summary
- raise Python exceptions when gptoss functions fail in model, tokenizer and context wrappers
- ensure resources are freed on error paths
- add unit tests simulating gptoss failures

## Testing
- `pytest tests/test_metal_exceptions.py -q` *(fails: No module named 'gpt_oss.metal._metal')*


------
https://chatgpt.com/codex/tasks/task_e_68a085fb19e88327a5d0e7791e8c710b