### PR TITLE
Escape HTML in simple browser search results

### DIFF
--- a/gpt_oss/tools/simple_browser/backend.py
+++ b/gpt_oss/tools/simple_browser/backend.py
@@ -3,6 +3,7 @@ Simple backend for the simple browser tool.
 """
 
 import functools
+import html
 import logging
 import os
 from abc import abstractmethod
@@ -129,17 +130,24 @@ class ExaBackend(Backend):
         )
         # make a simple HTML page to work with browser format
         titles_and_urls = [
-            (result["title"], result["url"], result["summary"])
+            (
+                html.escape(result["title"]),
+                html.escape(result["url"]),
+                html.escape(result["summary"]),
+            )
             for result in data["results"]
         ]
-        html_page = f"""
-<html><body>
-<h1>Search Results</h1>
-<ul>
-{"".join([f"<li><a href='{url}'>{title}</a> {summary}</li>" for title, url, summary in titles_and_urls])}
-</ul>
-</body></html>
-"""
+        html_page = (
+            "<html><body>"
+            "<h1>Search Results</h1>"
+            "<ul>"
+            + "".join(
+                f"<li><a href='{url}'>{title}</a> {summary}</li>"
+                for title, url, summary in titles_and_urls
+            )
+            + "</ul>"
+            + "</body></html>"
+        )
 
         return process_html(
             html=html_page,


### PR DESCRIPTION
## Summary
- escape title, URL, and summary before building search result page
- ensure SimpleBrowser uses sanitized HTML in `process_html`

## Testing
- `pytest tests/test_simple_browser_encoding.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f4d2a0c0832790adda141b8bd915