### PR TITLE
Require explicit allowed domains for ExaBackend

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
 # Exa backend requires you to have set the EXA_API_KEY environment variable
 backend = ExaBackend(
     source="web",
+    allowed_domains={"openai.com"},
 )
 browser_tool = SimpleBrowserTool(backend=backend)
 

--- a/gpt-oss-mcp-server/browser_server.py
+++ b/gpt-oss-mcp-server/browser_server.py
@@ -7,6 +7,8 @@ from mcp.server.fastmcp import Context, FastMCP
 from gpt_oss.tools.simple_browser import SimpleBrowserTool
 from gpt_oss.tools.simple_browser.backend import ExaBackend
 
+SAFE_DOMAINS = {"openai.com"}
+
 
 @dataclass
 class AppContext:
@@ -14,7 +16,7 @@ class AppContext:
 
     def create_or_get_browser(self, session_id: str) -> SimpleBrowserTool:
         if session_id not in self.browsers:
-            backend = ExaBackend(source="web")
+            backend = ExaBackend(source="web", allowed_domains=SAFE_DOMAINS)
             self.browsers[session_id] = SimpleBrowserTool(backend=backend)
         return self.browsers[session_id]
 

--- a/gpt-oss-mcp-server/reference-system-prompt.py
+++ b/gpt-oss-mcp-server/reference-system-prompt.py
@@ -2,6 +2,8 @@ import datetime
 
 from gpt_oss.tools.simple_browser import SimpleBrowserTool
 from gpt_oss.tools.simple_browser.backend import ExaBackend
+
+SAFE_DOMAINS = {"openai.com"}
 from gpt_oss.tools.python_docker.docker_tool import PythonTool
 from gpt_oss.tokenizer import tokenizer
 
@@ -22,7 +24,7 @@ system_message_content = (SystemContent.new().with_reasoning_effort(
     ReasoningEffort.LOW).with_conversation_start_date(
         datetime.datetime.now().strftime("%Y-%m-%d")))
 
-backend = ExaBackend(source="web", )
+backend = ExaBackend(source="web", allowed_domains=SAFE_DOMAINS)
 browser_tool = SimpleBrowserTool(backend=backend)
 system_message_content = system_message_content.with_tools(
     browser_tool.tool_config)

--- a/gpt_oss/chat.py
+++ b/gpt_oss/chat.py
@@ -22,6 +22,8 @@ import termcolor
 from gpt_oss.tools import apply_patch
 from gpt_oss.tools.simple_browser import SimpleBrowserTool
 from gpt_oss.tools.simple_browser.backend import ExaBackend
+
+SAFE_DOMAINS = {"openai.com"}
 from gpt_oss.tools.python_docker.docker_tool import PythonTool
 from gpt_oss.planner import Planner  # Gestiona metas y modos del agente
 
@@ -92,6 +94,7 @@ def main(args):
     if args.browser:
         backend = ExaBackend(
             source="web",
+            allowed_domains=SAFE_DOMAINS,
         )
         browser_tool = SimpleBrowserTool(backend=backend)
         system_message_content = system_message_content.with_tools(browser_tool.tool_config)

--- a/gpt_oss/responses_api/api_server.py
+++ b/gpt_oss/responses_api/api_server.py
@@ -23,6 +23,8 @@ from openai_harmony import (
 from gpt_oss.tools.simple_browser import SimpleBrowserTool
 from gpt_oss.tools.simple_browser.backend import ExaBackend
 
+SAFE_DOMAINS = {"openai.com"}
+
 from .events import (
     ResponseCompletedEvent,
     ResponseCreatedEvent,
@@ -750,6 +752,7 @@ def create_api_server(
         if use_browser_tool:
             backend = ExaBackend(
                 source="web",
+                allowed_domains=SAFE_DOMAINS,
             )
             browser_tool = SimpleBrowserTool(backend=backend)
         else:

--- a/gpt_oss/tools/simple_browser/backend.py
+++ b/gpt_oss/tools/simple_browser/backend.py
@@ -100,9 +100,9 @@ class ExaBackend(Backend):
     )
 
     BASE_URL: str = "https://api.exa.ai"
-    allowed_domains: set[str] | None = chz.field(
-        doc="Set of allowed domains. If provided, only URLs from these domains will be fetched.",
-        default=None,
+    allowed_domains: set[str] = chz.field(
+        doc="Set of allowed domains. Only URLs from these domains will be fetched.",
+        default_factory=set,
     )
     timeout: float = chz.field(
         doc="Timeout for HTTP requests in seconds.",
@@ -116,6 +116,11 @@ class ExaBackend(Backend):
         doc="Maximum wait time between retries in seconds.",
         default=60.0,
     )
+
+    @chz.validate
+    def _validate_allowed_domains(self) -> None:
+        if not self.allowed_domains:
+            raise BackendError("allowed_domains must be provided")
 
     def _get_api_key(self) -> str:
         key = self.api_key or os.environ.get("EXA_API_KEY")


### PR DESCRIPTION
## Summary
- Enforce providing a safe `allowed_domains` set for `ExaBackend`
- Pass safe domain list where `ExaBackend` is instantiated
- Document the new requirement in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gpt_oss.metal._metal'; ModuleNotFoundError: No module named 'docker')*


------
https://chatgpt.com/codex/tasks/task_e_68a870777de48327b3308aed80eae36f