### PR TITLE
feat: harden python docker tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ To improve performance the tool caches requests so that the model can revisit a 
 The model was trained to use a python tool to perform calculations and other actions as part of its chain-of-thought. During the training the model used a stateful tool which makes running tools between CoT loops easier. This reference implementation, however, uses a stateless mode. As a result the PythonTool defines its own tool description to override the definition in [`openai-harmony`][harmony].
 
 > [!WARNING]
-> This reference runs user code in a Docker container restricted to 1 CPU, ~256MB of memory, a PID limit of 64 and a 5 second execution timeout. It is still only an example; further hardening is recommended for production use.
+> This reference runs user code in a Docker container restricted to 1 CPU, ~256MB of memory, a PID limit of 64 and a 5 second execution timeout. The container runs as the `nobody` user with a read-only root filesystem, all Linux capabilities dropped and the `no-new-privileges` security option set. It is still only an example; further hardening is recommended for production use.
 
 #### Usage
 

--- a/gpt_oss/tools/python_docker/docker_tool.py
+++ b/gpt_oss/tools/python_docker/docker_tool.py
@@ -64,6 +64,11 @@ def call_python_script(script: str) -> str:
             nano_cpus=int(_CPU_LIMIT * 1e9),
             pids_limit=_PIDS_LIMIT,
             network_disabled=True,
+            user="nobody",
+            read_only=True,
+            security_opt=["no-new-privileges"],
+            cap_drop=["ALL"],
+            tmpfs={"/tmp": ""},
         )
         try:
             container.start()

--- a/tests/test_python_docker.py
+++ b/tests/test_python_docker.py
@@ -1,6 +1,14 @@
 import docker
+import pytest
 
 from gpt_oss.tools.python_docker.docker_tool import call_python_script
+
+
+try:
+    _client = docker.from_env()
+    _client.ping()
+except Exception:
+    pytest.skip("Docker is not available", allow_module_level=True)
 
 
 def test_infinite_script_times_out_and_cleans_up():
@@ -13,3 +21,20 @@ def test_infinite_script_times_out_and_cleans_up():
 
     assert "Execution timed out" in output
     assert before == after
+
+
+def test_container_runs_as_nobody_and_is_read_only():
+    script = (
+        "import os, pwd\n"
+        "print(pwd.getpwuid(os.getuid()).pw_name)\n"
+        "try:\n"
+        "    with open('/root_file', 'w') as f:\n"
+        "        f.write('x')\n"
+        "    print('writable')\n"
+        "except Exception as e:\n"
+        "    print(type(e).__name__)\n"
+    )
+    output = call_python_script(script)
+    lines = [line.strip() for line in output.strip().splitlines() if line.strip()]
+    assert lines[0] == 'nobody'
+    assert lines[1] != 'writable'


### PR DESCRIPTION
## Summary
- run Python container as `nobody` in read-only mode and drop capabilities
- document container security restrictions
- test python docker tool runs unprivileged and skip when Docker is unavailable

## Testing
- `PYTHONPATH=. pytest --noconftest tests/test_python_docker.py -q` *(fails: Docker is not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a874cba9f4832785db6e9adbd918ec