### PR TITLE
Validate Ollama endpoint URL scheme

### DIFF
--- a/gpt_oss/responses_api/inference/ollama.py
+++ b/gpt_oss/responses_api/inference/ollama.py
@@ -10,6 +10,7 @@ import threading
 import time
 from typing import Callable, Optional
 import requests
+from urllib.parse import urlparse
 
 from openai_harmony import load_harmony_encoding, HarmonyEncodingName
 
@@ -45,7 +46,13 @@ class OllamaStreamer:
     def __init__(self, model_name: str, endpoint_url: Optional[str] = None):
         self.encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
         self.model_name = model_name
-        self.endpoint_url = endpoint_url or os.environ.get("OLLAMA_ENDPOINT", DEFAULT_ENDPOINT_URL)
+        url = endpoint_url or os.environ.get("OLLAMA_ENDPOINT", DEFAULT_ENDPOINT_URL)
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(
+                f"Ollama endpoint must use HTTP or HTTPS, got: {url}"
+            )
+        self.endpoint_url = url
 
         # Per-instance state
         self._token_buffer: list[int] = []

--- a/tests_ollama/test_ollama_inference.py
+++ b/tests_ollama/test_ollama_inference.py
@@ -3,10 +3,16 @@ import threading
 import os
 import sys
 import time
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from gpt_oss.responses_api.inference.ollama import setup_model, EOS_TOKEN, PAD_TOKEN
+from gpt_oss.responses_api.inference.ollama import (
+    setup_model,
+    EOS_TOKEN,
+    PAD_TOKEN,
+    OllamaStreamer,
+)
 
 
 class DummyEncoding:
@@ -132,3 +138,25 @@ def test_pad_token_on_no_output(monkeypatch):
 
     tok = infer([], 0.0)
     assert tok == PAD_TOKEN
+
+
+def test_endpoint_validation_valid(monkeypatch):
+    monkeypatch.setattr(
+        "gpt_oss.responses_api.inference.ollama.load_harmony_encoding",
+        fake_load_harmony_encoding,
+    )
+
+    streamer = OllamaStreamer(
+        "model", endpoint_url="https://valid.example/api/generate"
+    )
+    assert streamer.endpoint_url == "https://valid.example/api/generate"
+
+
+def test_endpoint_validation_invalid(monkeypatch):
+    monkeypatch.setattr(
+        "gpt_oss.responses_api.inference.ollama.load_harmony_encoding",
+        fake_load_harmony_encoding,
+    )
+
+    with pytest.raises(ValueError):
+        OllamaStreamer("model", endpoint_url="ftp://invalid.example/api")


### PR DESCRIPTION
## Summary
- validate Ollama endpoint URLs to ensure http/https scheme
- add tests for valid and invalid Ollama endpoints

## Testing
- `pytest tests_ollama/test_ollama_inference.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a875fdf168832794022265c52fc500