### PR TITLE
docs: translate evals README to Spanish

### DIFF
--- a/gpt_oss/evals/README.md
+++ b/gpt_oss/evals/README.md
@@ -1,4 +1,4 @@
 # `gpt_oss.evals`
 
-This module is a reincarnation of [simple-evals](https://github.com/openai/simple-evals) adapted for gpt-oss. It lets you
-run GPQA and HealthBench against a runtime that supports Responses API on `localhost:8080/v1`.
+Este módulo es una reencarnación de [simple-evals](https://github.com/openai/simple-evals) adaptada para gpt-oss. Te permite
+ejecutar GPQA y HealthBench contra un runtime que soporta la API Responses en `localhost:8080/v1`.


### PR DESCRIPTION
## Summary
- translate gpt_oss.evals README to Spanish while preserving GPQA and HealthBench references

## Testing
- `pytest tests/test_meta_evaluator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a89dcf13948327bae26b3ec5b67d9e