### PR TITLE
docs: translate usage policy to Spanish

### DIFF
--- a/USAGE_POLICY
+++ b/USAGE_POLICY
@@ -1,1 +1,1 @@
-We aim for our tools to be used safely, responsibly, and democratically, while maximizing your control over how you use them. By using OpenAI gpt-oss-120b and gpt-oss-20b, you agree to comply with all applicable law.
+Aspiramos a que nuestras herramientas se utilicen de forma segura, responsable y democrática, mientras maximizamos su control sobre cómo las utiliza. Al usar OpenAI gpt-oss-120b y gpt-oss-20b, usted se compromete a cumplir con todas las leyes aplicables.


### PR DESCRIPTION
## Summary
- translate usage policy into Spanish with a legal tone
- ensure file ends with a newline character

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'gpt_oss.metal._metal', No module named 'docker')*


------
https://chatgpt.com/codex/tasks/task_e_68a89ea4402c8327b253555ed18b3c61