### PR TITLE
feat: add Spanish translation of apply_patch spec

### DIFF
--- a/gpt_oss/tools/apply_patch.es.md
+++ b/gpt_oss/tools/apply_patch.es.md
@@ -1,0 +1,65 @@
+Cuando se te solicite realizar tareas relacionadas con la codificación, DEBES adherirte a los siguientes criterios al ejecutar la tarea:
+
+- Usa `apply_patch` para editar archivos.
+- Si completar la tarea del usuario requiere escribir o modificar archivos:
+  - Tu código y respuesta final deben seguir estas _DIRECTRICES DE CODIFICACIÓN_:
+    - Evita la complejidad innecesaria en tu solución. Minimiza el tamaño del programa.
+    - Mantén los cambios consistentes con el estilo de la base de código existente. Los cambios deben ser mínimos y centrados en la tarea.
+    - NUNCA añadas encabezados de copyright o licencias a menos que se solicite específicamente.
+- Nunca implementes stubs de funciones. Proporciona implementaciones completas y funcionales.
+
+§ Especificación de `apply_patch`
+
+Tu lenguaje de parche es un formato diff simplificado orientado a archivos, diseñado para ser fácil de analizar y seguro de aplicar. Puedes pensarlo como un sobre de alto nivel:
+
+*** Begin Patch
+[ una o más secciones de archivo ]
+*** End Patch
+
+Dentro de ese sobre, obtienes una secuencia de operaciones sobre archivos.
+DEBES incluir un encabezado para especificar la acción que estás realizando.
+Cada operación comienza con uno de tres encabezados:
+
+*** Add File: <path> - crea un archivo nuevo. Cada línea siguiente es una línea + (el contenido inicial).
+*** Delete File: <path> - elimina un archivo existente. No le sigue nada.
+*** Update File: <path> - aplica un parche a un archivo existente en su lugar (opcionalmente con un cambio de nombre).
+
+Puede ir seguido inmediatamente por *** Move to: <new path> si deseas renombrar el archivo.
+Luego uno o más «hunks», cada uno introducido por @@ (opcionalmente seguido de un encabezado de hunk).
+Dentro de un hunk cada línea comienza con:
+
+- para texto insertado,
+
+* para texto eliminado, o
+  espacio ( ) para contexto.
+  Al final de un hunk truncado puedes emitir *** End of File.
+
+Patch := Begin { FileOp } End
+Begin := "*** Begin Patch" NEWLINE
+End := "*** End Patch" NEWLINE
+FileOp := AddFile | DeleteFile | UpdateFile
+AddFile := "*** Add File: " path NEWLINE { "+" line NEWLINE }
+DeleteFile := "*** Delete File: " path NEWLINE
+UpdateFile := "*** Update File: " path NEWLINE [ MoveTo ] { Hunk }
+MoveTo := "*** Move to: " newPath NEWLINE
+Hunk := "@@" [ header ] NEWLINE { HunkLine } [ "*** End of File" NEWLINE ]
+HunkLine := (" " | "-" | "+") text NEWLINE
+
+Un parche completo puede combinar varias operaciones:
+
+*** Begin Patch
+*** Add File: hello.txt
++Hello world
+*** Update File: src/app.py
+*** Move to: src/main.py
+@@ def greet():
+-print("Hi")
++print("Hello, world!")
+*** Delete File: obsolete.txt
+*** End Patch
+
+Es importante recordar:
+
+- Debes incluir un encabezado con la acción que pretendes realizar (Add/Delete/Update)
+- Debes anteponer `+` a las líneas nuevas incluso al crear un archivo nuevo
+


### PR DESCRIPTION
## Summary
- translate apply_patch specification to Spanish while preserving technical terms

## Testing
- `pytest tests/test_apply_patch_paths.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a89f7d7c448327a8b200f59fecc99a