### PR TITLE
docs: reemplaza awesome guide con versión en español

### DIFF
--- a/awesome-gpt-oss.md
+++ b/awesome-gpt-oss.md
@@ -1,76 +1,76 @@
 ![gpt-oss](./docs/gpt-oss.svg)
 
-# Awesome gpt-oss
+# Lista genial de gpt-oss
 
-This is a list of guides and resources to help you get started with the gpt-oss models.
+Esta es una lista de guías y recursos para ayudarte a comenzar con los modelos gpt-oss.
 
-- [Inference](#inference)
+- [Inferencia](#inferencia)
   - [Local](#local)
-  - [Server](#server)
-  - [Cloud](#cloud)
-- [Examples / Tutorials](#examples--tutorials)
-- [Tools](#tools)
+  - [Servidor](#servidor)
+  - [Nube](#nube)
+- [Ejemplos / Tutoriales](#ejemplos-y-tutoriales)
+- [Herramientas](#herramientas)
 
-## Inference
+## Inferencia
 
 ### Local
 
 - Ollama
-  - [How to run gpt-oss locally with Ollama](https://cookbook.openai.com/articles/gpt-oss/run-locally-ollama)
-  - [Ollama & gpt-oss launch blog](https://ollama.com/blog/gpt-oss)
-  - [Check out the models Ollama](https://ollama.com/library/gpt-oss)
+  - [Cómo ejecutar gpt-oss localmente con Ollama](https://cookbook.openai.com/articles/gpt-oss/run-locally-ollama)
+  - [Entrada de blog del lanzamiento de Ollama y gpt-oss](https://ollama.com/blog/gpt-oss)
+  - [Explora los modelos en Ollama](https://ollama.com/library/gpt-oss)
 - LM Studio
-  - [LM Studio & gpt-oss launch blog](https://lmstudio.ai/blog/gpt-oss)
-  - [Use gpt-oss-20b with LM Studio](https://lmstudio.ai/models/openai/gpt-oss-20b)
-  - [Use gpt-oss-120b with LM Studio](https://lmstudio.ai/models/openai/gpt-oss-120b)
-- Hugging Face & Transformers
-  - [How to run gpt-oss with Transformers](https://cookbook.openai.com/articles/gpt-oss/run-transformers)
-  - [Hugging Face & gpt-oss launch blog](https://huggingface.co/blog/welcome-openai-gpt-oss)
-  - [Collection of Hugging Face examples](https://github.com/huggingface/gpt-oss-recipes)
+  - [Entrada de blog del lanzamiento de LM Studio y gpt-oss](https://lmstudio.ai/blog/gpt-oss)
+  - [Usa gpt-oss-20b con LM Studio](https://lmstudio.ai/models/openai/gpt-oss-20b)
+  - [Usa gpt-oss-120b con LM Studio](https://lmstudio.ai/models/openai/gpt-oss-120b)
+- Hugging Face y Transformers
+  - [Cómo ejecutar gpt-oss con Transformers](https://cookbook.openai.com/articles/gpt-oss/run-transformers)
+  - [Entrada de blog del lanzamiento de Hugging Face y gpt-oss](https://huggingface.co/blog/welcome-openai-gpt-oss)
+  - [Colección de ejemplos de Hugging Face](https://github.com/huggingface/gpt-oss-recipes)
 - NVIDIA
-  - [gpt-oss on RTX](https://blogs.nvidia.com/blog/rtx-ai-garage-openai-oss)
+  - [gpt-oss en RTX](https://blogs.nvidia.com/blog/rtx-ai-garage-openai-oss)
 - AMD
-  - [Running gpt-oss models on AMD Ryzen AI Processors and Radeon Graphics Cards](https://www.amd.com/en/blogs/2025/how-to-run-openai-gpt-oss-20b-120b-models-on-amd-ryzen-ai-radeon.html)
+  - [Ejecución de modelos gpt-oss en procesadores AMD Ryzen AI y tarjetas gráficas Radeon](https://www.amd.com/en/blogs/2025/how-to-run-openai-gpt-oss-20b-120b-models-on-amd-ryzen-ai-radeon.html)
 
-### Server
+### Servidor
 
 - vLLM
-  - [How to run gpt-oss with vLLM](https://cookbook.openai.com/articles/gpt-oss/run-vllm)
+  - [Cómo ejecutar gpt-oss con vLLM](https://cookbook.openai.com/articles/gpt-oss/run-vllm)
 - NVIDIA
-  - [Optimizing gpt-oss with NVIDIA TensorRT-LLM](https://cookbook.openai.com/articles/run-nvidia)
-  - [Deploying gpt-oss on TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/blogs/tech_blog/blog9_Deploying_GPT_OSS_on_TRTLLM.md)
+  - [Optimización de gpt-oss con NVIDIA TensorRT-LLM](https://cookbook.openai.com/articles/run-nvidia)
+  - [Implementación de gpt-oss en TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/blogs/tech_blog/blog9_Deploying_GPT_OSS_on_TRTLLM.md)
 - AMD
-  - [Running the Latest Open Models from OpenAI on AMD AI Hardware](https://rocm.blogs.amd.com/ecosystems-and-partners/openai-day-0/README.html)  
+  - [Ejecutar los últimos modelos abiertos de OpenAI en hardware de IA de AMD](https://rocm.blogs.amd.com/ecosystems-and-partners/openai-day-0/README.html)
 
-### Cloud
+### Nube
 
 - Groq
-  - [Groq & gpt-oss launch blog](https://groq.com/blog/day-zero-support-for-openai-open-models)
-  - [gpt-oss-120b model on the GroqCloud Playground](https://console.groq.com/playground?model=openai/gpt-oss-120b)
-  - [gpt-oss-20b model on the GroqCloud Playground](https://console.groq.com/playground?model=openai/gpt-oss-20b)
-  - [gpt-oss with built-in web search on GroqCloud](https://console.groq.com/docs/browser-search)
-  - [gpt-oss with built-in code execution on GroqCloud](https://console.groq.com/docs/code-execution) 
-  - [Responses API on Groq](https://console.groq.com/docs/responses-api)
+  - [Entrada de blog del lanzamiento de Groq y gpt-oss](https://groq.com/blog/day-zero-support-for-openai-open-models)
+  - [Modelo gpt-oss-120b en el Playground de GroqCloud](https://console.groq.com/playground?model=openai/gpt-oss-120b)
+  - [Modelo gpt-oss-20b en el Playground de GroqCloud](https://console.groq.com/playground?model=openai/gpt-oss-20b)
+  - [gpt-oss con búsqueda web integrada en GroqCloud](https://console.groq.com/docs/browser-search)
+  - [gpt-oss con ejecución de código integrada en GroqCloud](https://console.groq.com/docs/code-execution)
+  - [API de respuestas en Groq](https://console.groq.com/docs/responses-api)
 - NVIDIA
-  - [NVIDIA launch blog post](https://blogs.nvidia.com/blog/openai-gpt-oss/)
-  - [NVIDIA & gpt-oss developer launch blog post](https://developer.nvidia.com/blog/delivering-1-5-m-tps-inference-on-nvidia-gb200-nvl72-nvidia-accelerates-openai-gpt-oss-models-from-cloud-to-edge/)
-  - Use [gpt-oss-120b](https://build.nvidia.com/openai/gpt-oss-120b) and [gpt-oss-20b](https://build.nvidia.com/openai/gpt-oss-20b) on NVIDIA's Cloud
+  - [Entrada de blog del lanzamiento de NVIDIA](https://blogs.nvidia.com/blog/openai-gpt-oss/)
+  - [Entrada de blog del lanzamiento para desarrolladores de NVIDIA y gpt-oss](https://developer.nvidia.com/blog/delivering-1-5-m-tps-inference-on-nvidia-gb200-nvl72-nvidia-accelerates-openai-gpt-oss-models-from-cloud-to-edge/)
+  - Usa [gpt-oss-120b](https://build.nvidia.com/openai/gpt-oss-120b) y [gpt-oss-20b](https://build.nvidia.com/openai/gpt-oss-20b) en la nube de NVIDIA
 - Cloudflare
-  - [Cloudflare & gpt-oss launch blog post](http://blog.cloudflare.com/openai-gpt-oss-on-workers-ai)
-  - [gpt-oss-120b on Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/models/gpt-oss-120b)
-  - [gpt-oss-20b on Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/models/gpt-oss-20b)
+  - [Entrada de blog del lanzamiento de Cloudflare y gpt-oss](http://blog.cloudflare.com/openai-gpt-oss-on-workers-ai)
+  - [gpt-oss-120b en Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/models/gpt-oss-120b)
+  - [gpt-oss-20b en Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/models/gpt-oss-20b)
 - AMD
-  - [gpt-oss-120B on AMD MI300X](https://huggingface.co/spaces/amd/gpt-oss-120b-chatbot) 
+  - [gpt-oss-120B en AMD MI300X](https://huggingface.co/spaces/amd/gpt-oss-120b-chatbot)
 
-## Examples & Tutorials
+## Ejemplos y tutoriales
 
-- [OpenAI harmony response format](https://cookbook.openai.com/articles/openai-harmony)
+- [Formato de respuesta de OpenAI harmony](https://cookbook.openai.com/articles/openai-harmony)
 
-## Tools
+## Herramientas
 
-- [Example `python` tool for gpt-oss](./gpt_oss/tools/python_docker/)
-- [Example `browser` tool for gpt-oss](./gpt_oss/tools/simple_browser/)
+- [Ejemplo de herramienta `python` para gpt-oss](./gpt_oss/tools/python_docker/)
+- [Ejemplo de herramienta `browser` para gpt-oss](./gpt_oss/tools/simple_browser/)
 
-## Contributing
+## Contribuciones
 
-Feel free to open a PR to add your own guides and resources on how to run gpt-oss. We will try to review it and add it here.
+Siéntete libre de abrir un PR para añadir tus propias guías y recursos sobre cómo ejecutar gpt-oss. Intentaremos revisarlo y añadirlo aquí.


### PR DESCRIPTION
## Resumen
- reemplaza `awesome-gpt-oss.md` por su versión en español

## Pruebas
- `pytest` *(falló: ModuleNotFoundError: No module named 'gpt_oss.metal._metal')*

------
https://chatgpt.com/codex/tasks/task_e_68a8a606c5e48327bfc4b97946300350