### PR TITLE
Add Spanish translation of license

### DIFF
--- a/LICENSE.es
+++ b/LICENSE.es
@@ -1,0 +1,203 @@
+                                 Licencia Apache
+                           Versión 2.0, enero de 2004
+                        http://www.apache.org/licenses/
+   Esta es una traducción al español de la licencia original en inglés.
+   En caso de discrepancia, prevalecerá la versión en inglés.
+
+   TÉRMINOS Y CONDICIONES PARA EL USO, REPRODUCCIÓN Y DISTRIBUCIÓN
+
+   1. Definiciones.
+
+      "Licencia" se refiere a los términos y condiciones para el uso, la
+      reproducción y la distribución definidos en las secciones 1 a 9 de este
+      documento.
+
+      "Licenciante" se refiere al propietario de los derechos de autor o la
+      entidad autorizada por el propietario de los derechos de autor que concede
+      la Licencia.
+
+      "Entidad legal" se refiere a la unión de la entidad actuante y todas las
+      otras entidades que controlan, son controladas por, o están bajo control
+      común con dicha entidad. A los efectos de esta definición, "control" significa
+      (i) el poder, directo o indirecto, de dirigir o gestionar dicha entidad,
+      ya sea mediante contrato u otro modo, o (ii) la propiedad de un cincuenta por
+      ciento (50 %) o más de las acciones en circulación, o (iii) la titularidad
+      beneficiaria de dicha entidad.
+
+      "Tú" (o "Tu") se refiere a una persona o Entidad legal que ejerce permisos
+      concedidos por esta Licencia.
+
+      "Forma de fuente" se refiere a la forma preferida para realizar
+      modificaciones, incluyendo, entre otros, el código fuente del software, la
+      fuente de la documentación y archivos de configuración.
+
+      "Forma objeto" se refiere a cualquier forma resultante de una transformación
+      mecánica o traducción de una forma de fuente, incluyendo, entre otros, el
+      código objeto compilado, la documentación generada y las conversiones a
+      otros tipos de medios.
+
+      "Obra" se refiere al trabajo de autoría, ya sea en forma de fuente u objeto,
+      puesto a disposición bajo la Licencia, según lo indicado por un aviso de
+      derechos de autor incluido o adjunto al trabajo (un ejemplo se proporciona en
+      el Apéndice a continuación).
+
+      "Trabajos derivados" se refiere a cualquier trabajo, ya sea en forma de
+      fuente u objeto, que se base en (o derive de) la Obra y para el cual las
+      revisiones editoriales, anotaciones, elaboraciones u otras modificaciones
+      representen, en conjunto, una obra original de autoría. A los efectos de esta
+      Licencia, los Trabajos derivados no incluyen trabajos que permanezcan
+      separables de, o que simplemente enlacen (o se vinculen por nombre) a las
+      interfaces de la Obra y sus Trabajos derivados.
+
+      "Contribución" se refiere a cualquier trabajo de autoría, incluyendo la
+      versión original de la Obra y cualquier modificación o adición a dicha Obra o
+      a sus Trabajos derivados, que se envíe deliberadamente al Licenciante para su
+      inclusión en la Obra por el propietario de los derechos de autor o por una
+      persona o Entidad legal autorizada para enviar en nombre del propietario de
+      los derechos de autor. Para los fines de esta definición, "enviado" significa
+      cualquier forma de comunicación electrónica, verbal o escrita enviada al
+      Licenciante o a sus representantes, incluyendo, entre otros, la comunicación
+      en listas de correo electrónico, sistemas de control de código fuente y
+      sistemas de seguimiento de incidencias administrados por, o en nombre de, el
+      Licenciante con el propósito de discutir y mejorar la Obra, pero excluyendo la
+      comunicación que esté marcada de manera conspicua o que de otro modo se
+      designe por escrito por el propietario de los derechos de autor como "No una
+      Contribución".
+
+      "Colaborador" se refiere al Licenciante y a cualquier persona o Entidad legal
+      en cuyo nombre se haya recibido una Contribución por parte del Licenciante y
+      posteriormente incorporada a la Obra.
+
+   2. Concesión de licencia de derechos de autor. Sujeto a los términos y
+      condiciones de esta Licencia, cada Colaborador concede por la presente a Ti
+      una licencia perpetua, mundial, no exclusiva, libre de regalías, irrevocable
+      para derechos de autor a reproducir, preparar Trabajos derivados, exhibir
+      públicamente, realizar públicamente, sublicenciar y distribuir la Obra y
+      dichos Trabajos derivados en forma de fuente u objeto.
+
+   3. Concesión de licencia de patentes. Sujeto a los términos y condiciones de
+      esta Licencia, cada Colaborador concede por la presente a Ti una licencia
+      perpetua, mundial, no exclusiva, libre de regalías, irrevocable (excepto según
+      se establece en esta sección) de patentes para fabricar, hacer fabricar, usar,
+      ofrecer para la venta, vender, importar y de otro modo transferir la Obra,
+      donde dicha licencia se aplica únicamente a las reclamaciones de patentes
+      licenciables por dicho Colaborador que sean necesariamente infringidas por su
+      (sus) Contribución(es) sola(s) o por combinación de su(s) Contribución(es) con
+      la Obra a la cual se envió tal Contribución. Si Tú inicias litigios por
+      patentes contra cualquier entidad (incluyendo una demanda cruzada o
+      contrademanda en una demanda) alegando que la Obra o una Contribución
+      incorporada dentro de la Obra constituye una infracción directa o
+      contributiva de patentes, entonces cualquier licencia de patentes concedida a
+      Ti bajo esta Licencia para esa Obra terminará a partir de la fecha en que se
+      presente dicha litigación.
+
+   4. Redistribución. Puedes reproducir y distribuir copias de la Obra o de
+      Trabajos derivados de ella en cualquier medio, con o sin modificaciones, y en
+      forma de fuente u objeto, siempre que cumplas con las siguientes condiciones:
+
+      (a) Debes dar a cualquier otro destinatario de la Obra o de los Trabajos
+          derivados una copia de esta Licencia; y
+
+      (b) Debes hacer que cualquier archivo modificado lleve avisos destacados
+          indicando que Tú has cambiado los archivos; y
+
+      (c) Debes conservar, en la forma de fuente de cualquier Trabajo derivado que
+          distribuyas, todos los avisos de derechos de autor, patente, marca
+          registrada y atribución de la forma de fuente de la Obra, excluyendo
+          aquellos avisos que no se refieran a ninguna parte de los Trabajos
+          derivados; y
+
+      (d) Si la Obra incluye un archivo de texto "NOTICE" como parte de su
+          distribución, entonces cualquier Trabajo derivado que distribuyas debe
+          incluir una copia legible de los avisos de atribución contenidos en dicho
+          archivo NOTICE, excluyendo aquellos avisos que no se refieran a ninguna
+          parte de los Trabajos derivados, en al menos uno de los siguientes
+          lugares: dentro de un archivo de texto NOTICE distribuido como parte de
+          los Trabajos derivados; dentro de la forma de fuente o en la
+          documentación, si se proporciona junto con los Trabajos derivados; o,
+          dentro de una visualización generada por los Trabajos derivados, si y
+          donde tales avisos de terceros aparezcan normalmente. El contenido del
+          archivo NOTICE es solo para fines informativos y no modifica la Licencia.
+          Puedes agregar tus propios avisos de atribución dentro de los Trabajos
+          derivados que distribuyas, junto con o como un anexo al texto NOTICE de la
+          Obra, siempre que dichos avisos de atribución adicionales no se puedan
+          interpretar como una modificación de la Licencia.
+
+      Puedes agregar tu propia declaración de derechos de autor a tus
+      modificaciones y puedes proporcionar términos y condiciones de licencia
+      adicionales o diferentes para el uso, la reproducción o la distribución de
+      tus modificaciones, o para dichos Trabajos derivados en su conjunto,
+      siempre que tu uso, reproducción y distribución de la Obra de otro modo
+      cumpla con las condiciones establecidas en esta Licencia.
+
+   5. Presentación de Contribuciones. A menos que indiques expresamente lo
+      contrario, cualquier Contribución enviada intencionalmente para su inclusión
+      en la Obra por Ti al Licenciante estará bajo los términos y condiciones de
+      esta Licencia, sin términos o condiciones adicionales. No obstante lo
+      anterior, nada de lo aquí dispuesto reemplazará o modificará los términos de
+      ningún acuerdo de licencia separado que puedas haber ejecutado con el
+      Licenciante respecto a dichas Contribuciones.
+
+   6. Marcas registradas. Esta Licencia no concede permiso para usar los nombres
+      comerciales, marcas registradas, marcas de servicio o nombres de productos del
+      Licenciante, excepto cuando sea necesario para el uso razonable y habitual al
+      describir el origen de la Obra y reproducir el contenido del archivo NOTICE.
+
+   7. Exclusión de garantías. A menos que lo exija la ley aplicable o se acuerde
+      por escrito, el Licenciante proporciona la Obra (y cada Colaborador proporciona
+      sus Contribuciones) "TAL COMO ESTÁN", SIN GARANTÍAS NI CONDICIONES DE NINGÚN
+      TIPO, ya sean expresas o implícitas, incluyendo, entre otras, cualesquiera
+      garantías o condiciones de TÍTULO, NO INFRACCIÓN, COMERCIABILIDAD o IDONEIDAD
+      PARA UN PROPÓSITO PARTICULAR. Tú eres el único responsable de determinar la
+      idoneidad de utilizar o redistribuir la Obra y asumes cualquier riesgo
+      asociado con el ejercicio de los permisos bajo esta Licencia.
+
+   8. Limitación de responsabilidad. En ningún caso y bajo ninguna teoría legal,
+      ya sea por agravio (incluyendo negligencia), contrato o de otra manera, a
+      menos que lo exija la ley aplicable (como actos deliberados y gravemente
+      negligentes) o se acuerde por escrito, ningún Colaborador será responsable
+      ante Ti por daños, incluyendo cualquier daño directo, indirecto, especial,
+      incidental o consecuente de cualquier tipo que surja como resultado de esta
+      Licencia o del uso o la incapacidad de usar la Obra (incluyendo, pero no
+      limitándose a, daños por pérdida de buena voluntad, interrupción del trabajo,
+      fallo o mal funcionamiento de la computadora, o cualquier otro daño o pérdida
+      comercial), incluso si dicho Colaborador ha sido advertido de la posibilidad
+      de tales daños.
+
+   9. Aceptación de garantía o responsabilidad adicional. Al redistribuir la
+      Obra o los Trabajos derivados de ella, puedes optar por ofrecer y cobrar una
+      tarifa por la aceptación de soporte, garantía, indemnización u otras
+      obligaciones y/o derechos consistentes con esta Licencia. Sin embargo, al
+      aceptar tales obligaciones, solo puedes actuar en tu propio nombre y bajo tu
+      propia responsabilidad, no en nombre de ningún otro Colaborador, y únicamente
+      si aceptas indemnizar, defender y mantener indemne a cada Colaborador por
+      cualquier responsabilidad incurrida por, o reclamaciones hechas contra, dicho
+      Colaborador como resultado de tu aceptación de cualquier garantía o
+      responsabilidad adicional.
+
+   FIN DE LOS TÉRMINOS Y CONDICIONES
+
+   APÉNDICE: Cómo aplicar la Licencia Apache a tu trabajo.
+
+      Para aplicar la Licencia Apache a tu trabajo, adjunta el siguiente
+      aviso de exención de responsabilidad, con los campos entre corchetes
+      "[]" reemplazados con tu propia información de identificación. (¡No
+      incluyas los corchetes!) El texto debe estar incluido en la sintaxis de
+      comentarios apropiada para el formato del archivo. También recomendamos
+      que se incluya el nombre del archivo o de la clase y una descripción de
+      su propósito en la misma "página impresa" que el aviso de derechos de
+      autor para facilitar la identificación dentro de archivos de terceros.
+
+   Copyright [yyyy] [nombre del propietario del copyright]
+
+   Licenciado bajo la Licencia Apache, Versión 2.0 (la "Licencia");
+   no puedes usar este archivo excepto en cumplimiento con la Licencia.
+   Puedes obtener una copia de la Licencia en
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   A menos que lo exija la ley aplicable o se acuerde por escrito, el
+   software distribuido bajo la Licencia se distribuye "TAL COMO ESTÁ", SIN
+   GARANTÍAS NI CONDICIONES DE NINGÚN TIPO, ya sean expresas o implícitas.
+   Consulta la Licencia para conocer el idioma específico que rige los
+   permisos y las limitaciones bajo la Licencia.

--- a/README.md
+++ b/README.md
@@ -67,4 +67,8 @@ Para información sobre vLLM, PyTorch/Triton/Metal, Ollama, LM Studio y otros te
 
 Visita también la lista [awesome-gpt-oss](awesome-gpt-oss.es.md) para encontrar herramientas y proyectos de la comunidad.
 
+### Licencia
+
+Este proyecto se distribuye bajo la Licencia Apache 2.0. Puedes encontrar el texto original en `LICENSE` y una traducción al español en `LICENSE.es`.
+
 [harmony]: https://github.com/openai/harmony


### PR DESCRIPTION
## Summary
- add `LICENSE.es` with Spanish translation of Apache 2.0 license
- note the Spanish translation in `README.md`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'gpt_oss.metal._metal`)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ac075a348327ba06c3e5d4c71241