### PR TITLE
Traduce encabezado del chat de Harmony con herramientas

### DIFF
--- a/gpt_oss/chat.py
+++ b/gpt_oss/chat.py
@@ -1,5 +1,5 @@
 """
-Harmony chat with tools.
+Chat de Harmony con herramientas.
 
 Incluye integración con :class:`Planner` para consultar metas y modos del agente.
 """


### PR DESCRIPTION
## Resumen
- Traduce al español la descripción inicial de `gpt_oss/chat.py`

## Pruebas
- `pytest tests/test_chat_tool_disable.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8b0156e2c832797770cd1c5818a48