### PR TITLE
Traduce comentarios y ayuda de argparse al español

### DIFF
--- a/gpt_oss/generate.py
+++ b/gpt_oss/generate.py
@@ -1,7 +1,8 @@
-# Model parallel inference
-# Note: This script is for demonstration purposes only. It is not designed for production use.
-#       See gpt_oss.chat for a more complete example with the Harmony parser.
-# torchrun --nproc-per-node=4 -m gpt_oss.generate -p "why did the chicken cross the road?" model/
+# Inferencia paralela de modelos
+# Nota: Este script es solo para fines de demostración. No está diseñado para uso en producción.
+#       Consulte gpt_oss.chat para un ejemplo más completo con el parser Harmony.
+# Ejemplo de uso:
+# torchrun --nproc-per-node=4 -m gpt_oss.generate -p "¿por qué cruzó la carretera la gallina?" model/
 #
 # Incluye un ``Planner`` que permite consultar metas y modos del agente.
 
@@ -42,20 +43,20 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Text generation example")
+    parser = argparse.ArgumentParser(description="Ejemplo de generación de texto")
     parser.add_argument(
         "checkpoint",
-        metavar="FILE",
+        metavar="ARCHIVO",
         type=str,
-        help="Path to the SafeTensors checkpoint",
+        help="Ruta al checkpoint de SafeTensors",
     )
     parser.add_argument(
         "-p",
         "--prompt",
         metavar="PROMPT",
         type=str,
-        default="How are you?",
-        help="LLM prompt",
+        default="¿Cómo estás?",
+        help="Prompt para el LLM",
     )
     parser.add_argument(
         "-t",
@@ -63,15 +64,15 @@ if __name__ == "__main__":
         metavar="TEMP",
         type=float,
         default=0.0,
-        help="Sampling temperature",
+        help="Temperatura de muestreo",
     )
     parser.add_argument(
         "-l",
         "--limit",
-        metavar="LIMIT",
+        metavar="LIMITE",
         type=int,
         default=0,
-        help="Limit on the number of tokens (0 to disable)",
+        help="Límite en el número de tokens (0 para desactivar)",
     )
     parser.add_argument(
         "-b",
@@ -80,7 +81,7 @@ if __name__ == "__main__":
         type=str,
         default="torch",
         choices=["triton", "torch", "vllm"],
-        help="Inference backend",
+        help="Backend de inferencia",
     )
     args = parser.parse_args()
 

--- a/gpt_oss/responses_api/serve.py
+++ b/gpt_oss/responses_api/serve.py
@@ -1,4 +1,4 @@
-# torchrun --nproc-per-node=4 serve.py
+# Ejemplo: torchrun --nproc-per-node=4 serve.py
 
 import argparse
 
@@ -11,27 +11,27 @@ from openai_harmony import (
 from .api_server import create_api_server
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Responses API server")
+    parser = argparse.ArgumentParser(description="Servidor de API de respuestas")
     parser.add_argument(
         "--checkpoint",
-        metavar="FILE",
+        metavar="ARCHIVO",
         type=str,
-        help="Path to the SafeTensors checkpoint",
+        help="Ruta al checkpoint de SafeTensors",
         default="~/model",
         required=False,
     )
     parser.add_argument(
         "--port",
-        metavar="PORT",
+        metavar="PUERTO",
         type=int,
         default=8000,
-        help="Port to run the server on",
+        help="Puerto para ejecutar el servidor",
     )
     parser.add_argument(
         "--inference-backend",
         metavar="BACKEND",
         type=str,
-        help="Inference backend to use",
+        help="Backend de inferencia a utilizar",
         # default to metal on macOS, triton on other platforms
         default="metal" if __import__("platform").system() == "Darwin" else "triton",
     )


### PR DESCRIPTION
## Summary
- Traduce comentarios y textos de argparse en scripts de generación y del servidor de respuestas

## Testing
- `PYTHONPATH=. python gpt_oss/generate.py --help`
- `python -m gpt_oss.responses_api.serve --help`
- `pytest` *(falla: ModuleNotFoundError: gpt_oss.metal._metal)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b13466108327a75a4e52b131f649