### PR TITLE
Traduce secciones de docstrings a español

### DIFF
--- a/gpt_oss/planner.py
+++ b/gpt_oss/planner.py
@@ -42,7 +42,7 @@ class Planner:
     def set_intention(self, intent: str) -> None:
         """Define la intención global del agente.
 
-        Parameters
+        Parámetros
         ----------
         intent:
             Descripción de la intención u objetivo general.
@@ -56,7 +56,7 @@ class Planner:
         Las metas se gestionan internamente con una cola de prioridad para
         facilitar la extracción de la próxima meta más importante.
 
-        Parameters
+        Parámetros
         ----------
         goal:
             Descripción de la meta a añadir.
@@ -64,7 +64,7 @@ class Planner:
             Valor numérico que indica la importancia de la meta. Valores más
             altos representan mayor prioridad.
 
-        Raises
+        Errores
         ------
         ValueError
             Si ``prioridad`` es negativa.
@@ -80,7 +80,7 @@ class Planner:
     def get_next_goal(self) -> Optional[str]:
         """Obtiene la siguiente meta con mayor prioridad.
 
-        Returns
+        Devuelve
         -------
         str or None
             La descripción de la meta más prioritaria o ``None`` si no hay
@@ -95,7 +95,7 @@ class Planner:
     def list_goals(self) -> List[str]:
         """Devuelve las metas ordenadas por prioridad sin modificarlas.
 
-        Returns
+        Devuelve
         -------
         List[str]
             Lista de metas pendientes de alcanzar, ordenadas de la más a la
@@ -117,13 +117,13 @@ class Planner:
         mismo modo para ajustar parámetros como la temperatura en función de los
         resultados observados.
 
-        Parameters
+        Parámetros
         ----------
         tipo:
             Cadena que identifica el modo a activar. Los valores aceptados son
             ``"creative"``, ``"analytic"`` y ``"deductive"``.
 
-        Raises
+        Errores
         ------
         ValueError
             Si el modo solicitado no está soportado.
@@ -162,7 +162,7 @@ class Planner:
         El episodio incluye el modo activo y sus parámetros para que futuras
         activaciones puedan ajustar dichos valores según el desempeño previo.
 
-        Parameters
+        Parámetros
         ----------
         entrada:
             Información de entrada procesada.
@@ -194,7 +194,7 @@ class Planner:
     def get_mode_parameters(self) -> Dict[str, Any]:
         """Obtiene los parámetros asociados al modo activo.
 
-        Returns
+        Devuelve
         -------
         Dict[str, Any]
             Diccionario con los parámetros del modo actual (vacío si no hay

--- a/gpt_oss/strategic_memory.py
+++ b/gpt_oss/strategic_memory.py
@@ -42,7 +42,7 @@ class StrategicMemory:
     def __init__(self, max_episodes: int | None = None) -> None:
         """Inicializa las estructuras de almacenamiento internas.
 
-        Parameters
+        Parámetros
         ----------
         max_episodes:
             Número máximo de episodios a conservar. Si es ``None``,
@@ -55,14 +55,14 @@ class StrategicMemory:
     def save(self, key: str, value: Any) -> None:
         """Guarda una nueva entrada en la memoria.
 
-        Parameters
+        Parámetros
         ----------
         key:
             Clave con la que se identificará la entrada.
         value:
             Valor asociado a la clave.
 
-        Raises
+        Errores
         ------
         ValueError
             Si la clave ya existe en la memoria.
@@ -74,14 +74,14 @@ class StrategicMemory:
     def get(self, key: str, default: Any | None = None) -> Any:
         """Recupera la entrada asociada a ``key``.
 
-        Parameters
+        Parámetros
         ----------
         key:
             Clave de la entrada a recuperar.
         default:
             Valor por defecto a devolver si la clave no existe.
 
-        Returns
+        Devuelve
         -------
         Any
             El valor asociado a la clave o ``default`` si no se encuentra.
@@ -91,14 +91,14 @@ class StrategicMemory:
     def update(self, key: str, value: Any) -> None:
         """Actualiza una entrada existente en la memoria.
 
-        Parameters
+        Parámetros
         ----------
         key:
             Clave de la entrada a actualizar.
         value:
             Nuevo valor para la entrada.
 
-        Raises
+        Errores
         ------
         KeyError
             Si la clave no existe en la memoria.
@@ -110,7 +110,7 @@ class StrategicMemory:
     def add_episode(self, data: Episode) -> None:
         """Añade un nuevo episodio a la memoria.
 
-        Parameters
+        Parámetros
         ----------
         data:
             Instancia de :class:`Episode` que contiene la información
@@ -128,12 +128,12 @@ class StrategicMemory:
         Cada par clave-valor de ``pattern`` se compara con los atributos
         del episodio y con su metadato homónimo si el atributo no existe.
 
-        Parameters
+        Parámetros
         ----------
         pattern:
             Diccionario con los campos y valores a buscar.
 
-        Returns
+        Devuelve
         -------
         list[Episode]
             Lista de episodios que cumplen con el patrón.
@@ -154,7 +154,7 @@ class StrategicMemory:
     def summarize(self) -> Dict[str, Any]:
         """Obtiene estadísticas generales de los episodios almacenados.
 
-        Returns
+        Devuelve
         -------
         dict
             Diccionario con el total de episodios y las acciones y


### PR DESCRIPTION
## Resumen
- Localiza docstrings del planificador y la memoria estratégica y traduce las secciones `Parameters`, `Returns` y `Raises` a `Parámetros`, `Devuelve` y `Errores`.

## Pruebas
- `pytest tests/test_planner.py tests/test_goal_planner.py tests/test_planner_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8b24d83c88327a99b551a319e9b30