### PR TITLE
docs: traducir nota de BadRequestError

### DIFF
--- a/gpt_oss/evals/chat_completion_sampler.py
+++ b/gpt_oss/evals/chat_completion_sampler.py
@@ -59,7 +59,8 @@ class ChatCompletionSampler(SamplerBase):
                     response_metadata={"usage": response.usage},
                     actual_queried_message_list=message_list,
                 )
-            # NOTE: BadRequestError is triggered once for MMMU, please uncomment if you are reruning MMMU
+            # NOTA: durante MMMU la API lanza una BadRequestError una vez;
+            # si vas a repetir MMMU, descomenta este bloque para manejar la excepción
             except openai.BadRequestError as e:
                 print("Bad Request Error", e)
                 return SamplerResponse(


### PR DESCRIPTION
## Summary
- traducir a español la nota que explica la excepción `BadRequestError` en `ChatCompletionSampler`

## Testing
- `pytest gpt_oss/evals/test_*` *(falló: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a97880b5388327820b66376ef3c9d4