### PR TITLE
Traducir nota de OOM en triton model

### DIFF
--- a/gpt_oss/triton/model.py
+++ b/gpt_oss/triton/model.py
@@ -462,7 +462,7 @@ class Transformer(torch.nn.Module):
             else:
                 param.data.copy_(loaded_tensor)
 
-        # NOTE: Required to avoid OOM errors
+        # NOTA: Necesario para evitar errores de falta de memoria (OOM)
         torch.cuda.empty_cache()
         return model
 


### PR DESCRIPTION
## Summary
- traducir comentario sobre vaciado de caché de CUDA para evitar errores OOM

## Testing
- `pytest -q -k triton` *(falló: ModuleNotFoundError: No module named 'gpt_oss.metal._metal' y 'docker')*
- `PYTHONPATH=. pytest /tmp/test_triton_import.py -q` *(falló: ModuleNotFoundError: No module named 'triton_kernels')*

------
https://chatgpt.com/codex/tasks/task_e_68a9bd506d5c832796c6883df5ab87df