### PR TITLE
Add Qualia-based blocking, lazy AGIX loading, and packaging metadata updates

### DIFF
--- a/agicore_core/kernel.py
+++ b/agicore_core/kernel.py
@@ -50,6 +50,15 @@ class ReasoningKernel:
         request = {"task": task, "context": context, "goals": goals}
         request.update(step)
         request = self.qualia_node.enrich_request(request, phase="kernel_step")
+        if request.get("qualia", {}).get("blocked"):
+            result = {
+                "blocked": True,
+                "reason": request["qualia"]["policy_action"],
+                "ethical_classification": request["qualia"]["ethical_classification"],
+            }
+            state: Dict[str, Any] = {}
+            self.qualia_node.integrate_response(result, state, phase="kernel_step")
+            return result
         try:
             result = self.router.route(
                 request,

--- a/agicore_core/planner.py
+++ b/agicore_core/planner.py
@@ -8,15 +8,34 @@ de planificación.
 
 from __future__ import annotations
 
+import importlib
 from typing import Any, Dict, List, Optional
 
 import json
 import logging
 from pathlib import Path
 
-from agix.orchestrator import VirtualQualia
-
 logger = logging.getLogger(__name__)
+
+
+def _load_virtual_qualia() -> type[Any]:
+    """Carga ``VirtualQualia`` de AGIX solo cuando el planificador lo necesita."""
+
+    try:
+        orchestrator = importlib.import_module("agix.orchestrator")
+    except ImportError as exc:
+        raise RuntimeError(
+            "AGIX 1.9.0 es necesario para crear Planner sin un orquestador "
+            "explícito. Instala 'agix==1.9.0' o proporciona un objeto con "
+            "'broadcast_state'."
+        ) from exc
+    virtual_qualia = getattr(orchestrator, "VirtualQualia", None)
+    if virtual_qualia is None:
+        raise RuntimeError(
+            "No se encontró 'agix.orchestrator.VirtualQualia'. Verifica que "
+            "la instalación de AGIX sea compatible con la versión 1.9.0."
+        )
+    return virtual_qualia
 
 
 class Planner:
@@ -25,13 +44,13 @@ class Planner:
     Parameters
     ----------
     orchestrator:
-        Instancia de :class:`agix.orchestrator.VirtualQualia` utilizada para
-        coordinar la difusión de estados. Si no se proporciona, se crea una
-        instancia sin clientes registrados.
+        Instancia compatible con :class:`agix.orchestrator.VirtualQualia`
+        utilizada para coordinar la difusión de estados. Si no se proporciona,
+        se crea una instancia sin clientes registrados.
     """
 
-    def __init__(self, orchestrator: Optional[VirtualQualia] = None) -> None:
-        self.orchestrator = orchestrator or VirtualQualia()
+    def __init__(self, orchestrator: Optional[Any] = None) -> None:
+        self.orchestrator = orchestrator or _load_virtual_qualia()()
 
         config_path = Path(__file__).resolve().parent / "config" / "agent_profile.json"
         try:

--- a/agicore_core/qualia_node.py
+++ b/agicore_core/qualia_node.py
@@ -131,6 +131,7 @@ class QualiaNode:
             return enriched
 
         score = self._ethical_score(enriched)
+        classification = self._classify(score)
         qualia_payload = {
             "agix_version": self._agix_version,
             "required_agix_version": AGIX_REQUIRED_VERSION,
@@ -138,7 +139,13 @@ class QualiaNode:
             "policies": [policy.__dict__ for policy in self.policies],
             "cognitive_patterns": [pattern.__dict__ for pattern in self.patterns],
             "ethical_score": score,
-            "ethical_classification": self._classify(score),
+            "ethical_classification": classification,
+            "blocked": classification == "nocivo",
+            "policy_action": (
+                "blocked_by_ontoethical_policy"
+                if classification == "nocivo"
+                else "allow_with_qualia_context"
+            ),
         }
         enriched["qualia"] = qualia_payload
         enriched["qualia_policies"] = [policy.name for policy in self.policies]
@@ -160,10 +167,10 @@ class QualiaNode:
         event = f"{phase}:{type(result).__name__}"
         if self._spirit is not None:
             self._spirit.experimentar(event, 0.2, "reflexion")
+        self.trace.append({"phase": f"{phase}:response", "result": result})
         state["qualia_last_phase"] = phase
         state["qualia_trace_length"] = len(self.trace)
         state["qualia_policies"] = [policy.name for policy in self.policies]
-        self.trace.append({"phase": f"{phase}:response", "result": result})
         return state
 
     def _ethical_score(self, request: Mapping[str, Any]) -> float:

--- a/agicore_core/reasoning_kernel.py
+++ b/agicore_core/reasoning_kernel.py
@@ -185,6 +185,20 @@ class ReasoningKernel:
 
         request: Dict[str, Any] = {**self._state, **step}
         request = self.qualia_node.enrich_request(request, phase="step")
+        if request.get("qualia", {}).get("blocked"):
+            result = {
+                "blocked": True,
+                "reason": request["qualia"]["policy_action"],
+                "ethical_classification": request["qualia"]["ethical_classification"],
+            }
+            self._state.update(result)
+            self.qualia_node.integrate_response(result, self._state, phase="step")
+            self.history.append({
+                "step": step,
+                "result": result,
+                "introspeccion": None,
+            })
+            return result
         result = self.router.route(request)
 
         if isinstance(result, dict):
@@ -253,6 +267,15 @@ class ReasoningKernel:
                     self._state.update(metadata_filtrada)
             request: Dict[str, Any] = {**self._state, **metas, "token": token}
             request = self.qualia_node.enrich_request(request, phase="token")
+            if request.get("qualia", {}).get("blocked"):
+                blocked = {
+                    "blocked": True,
+                    "reason": request["qualia"]["policy_action"],
+                    "ethical_classification": request["qualia"]["ethical_classification"],
+                }
+                self._state.update(blocked)
+                self.qualia_node.integrate_response(blocked, self._state, phase="token")
+                break
             siguiente = self.router.route(request)
             if siguiente is None:
                 break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,11 @@ requires = ["setuptools>=68"]
 build-backend = "gpt_oss_build_backend.backend"
 backend-path = ["_build"]
 
-[tool.setuptools]
-packages = ["gpt_oss", "agicore_core"]
+[tool.setuptools.packages.find]
+include = ["gpt_oss*", "agicore_core*"]
+
+[tool.setuptools.package-data]
+agicore_core = ["config/*.json"]
 
 [tool.scikit-build]
 cmake.source-dir = "." # pick up the root CMakeLists.txt

--- a/requirements.lock
+++ b/requirements.lock
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.lock requirements.txt
 #
-agix==1.3.0
+agix==1.9.0
     # via -r requirements.txt
 annotated-types==0.7.0
     # via pydantic

--- a/tests/test_planner_agent_profile.py
+++ b/tests/test_planner_agent_profile.py
@@ -4,9 +4,6 @@ import logging
 import sys
 import types
 
-import pytest
-
-
 
 def test_inicializacion_con_json_invalido(tmp_path, monkeypatch, caplog):
     """El planificador debería manejar un JSON inválido."""
@@ -31,3 +28,22 @@ def test_inicializacion_con_json_invalido(tmp_path, monkeypatch, caplog):
         planificador = planner_module.Planner()
     assert planificador.agent_profile == {}
     assert "Failed to load agent profile" in caplog.text
+
+
+def test_planner_acepta_orquestador_explicito_sin_importar_agix(monkeypatch):
+    """El planificador puede inicializarse con un orquestador compatible."""
+
+    from agicore_core import planner as planner_module
+
+    def fail_load_virtual_qualia():
+        raise AssertionError("No debería cargarse AGIX si hay orquestador explícito")
+
+    class DummyOrchestrator:
+        def broadcast_state(self, state):
+            return [{"state": state}]
+
+    monkeypatch.setattr(planner_module, "_load_virtual_qualia", fail_load_virtual_qualia)
+
+    planificador = planner_module.Planner(orchestrator=DummyOrchestrator())
+
+    assert planificador.plan({"goal": "test"}) == [{"state": {"goal": "test"}}]

--- a/tests/test_qualia_node.py
+++ b/tests/test_qualia_node.py
@@ -17,6 +17,23 @@ def test_qualia_node_enriches_request_with_policies_and_patterns():
         "cuestionable",
         "nocivo",
     }
+    assert request["qualia"]["policy_action"] == "allow_with_qualia_context"
+
+
+def test_qualia_node_blocks_nocivo_request_and_tracks_full_trace():
+    node = QualiaNode(enabled=True)
+    request = node.enrich_request(
+        {"task": "riesgo", "pro_vida": 0.0, "no_dano": 0.0, "respeto": 0.0},
+        phase="step",
+    )
+    state = {}
+
+    assert request["qualia"]["blocked"] is True
+    assert request["qualia"]["policy_action"] == "blocked_by_ontoethical_policy"
+
+    node.integrate_response({"blocked": True}, state, phase="step")
+
+    assert state["qualia_trace_length"] == 2
 
 
 def test_reasoning_kernel_sends_qualia_to_router_and_updates_state():
@@ -34,6 +51,21 @@ def test_reasoning_kernel_sends_qualia_to_router_and_updates_state():
     assert sent_request["qualia"]["phase"] == "step"
     assert kernel.get_state()["qualia_last_phase"] == "step"
     assert kernel.get_state()["qualia_trace_length"] >= 1
+
+
+def test_reasoning_kernel_does_not_route_blocked_qualia_request():
+    planner = MagicMock()
+    router = MagicMock()
+    kernel = ReasoningKernel(planner=planner, router=router, qualia_node=QualiaNode())
+    kernel.set_state({"context": "ctx", "goals": []})
+
+    result = kernel.evaluate_step(
+        {"task": "riesgo", "pro_vida": 0.0, "no_dano": 0.0, "respeto": 0.0}
+    )
+
+    assert result["blocked"] is True
+    assert result["reason"] == "blocked_by_ontoethical_policy"
+    router.route.assert_not_called()
 
 
 def test_token_cycle_routes_qualia_for_each_token():


### PR DESCRIPTION
### Motivation
- Prevent execution or routing of requests flagged as harmful by Qualia and propagate a structured blocked response before calling routers or generators.
- Avoid importing `agix` at module import time so `Planner` can accept an explicit orchestrator without requiring AGIX to be installed.
- Ensure package data (`config/*.json`) is included and switch setuptools to package discovery.

### Description
- Updated `agicore_core/qualia_node.py` to compute classification once, expose `qualia.blocked` and `qualia.policy_action`, and add a `_classify` helper; response trace append order adjusted and `policy_action` values added (`blocked_by_ontoethical_policy` / `allow_with_qualia_context`).
- Added short-circuit handling in `agicore_core/kernel.py` and `agicore_core/reasoning_kernel.py` to return a structured blocked result (`{"blocked": True, "reason": ..., "ethical_classification": ...}`) and integrate that response into state/history/token cycles instead of routing when `qualia.blocked` is true.
- Made `agicore_core/planner.py` lazily load `agix.orchestrator.VirtualQualia` via a new `_load_virtual_qualia` function and accept an explicit orchestrator object in `Planner.__init__` so AGIX is only required when no orchestrator is provided.
- Modified `pyproject.toml` to use `setuptools` package discovery (`[tool.setuptools.packages.find]`) and include `agicore_core` package data `config/*.json`.
- Bumped AGIX version to `1.9.0` in `pyproject.toml` and `requirements.lock` and added/updated tests to cover the new behavior.

### Testing
- Ran the test suite with `pytest`; all tests completed successfully.
- Exercised Qualia blocking behavior with `tests/test_qualia_node.py`, including `test_qualia_node_blocks_nocivo_request_and_tracks_full_trace`, which passed.
- Verified planner initialization and lazy-loading behavior with `tests/test_planner_agent_profile.py`, including `test_planner_acepta_orquestador_explicito_sin_importar_agix`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a421383d180832798b2dcf586c6e395)