### PR TITLE
Add Qualia profile, moral constraints, AGIX adapters, and propagate Qualia metadata through planner/router/kernel

### DIFF
--- a/agicore_core/__init__.py
+++ b/agicore_core/__init__.py
@@ -4,5 +4,6 @@ from .planner import Planner
 from .kernel import ReasoningKernel
 from .meta_evaluator import MetaEvaluator
 from .qualia_node import QualiaNode
+from .config import AGIX_REQUIRED_VERSION
 
-__all__ = ["Planner", "ReasoningKernel", "MetaEvaluator", "QualiaNode"]
+__all__ = ["Planner", "ReasoningKernel", "MetaEvaluator", "QualiaNode", "AGIX_REQUIRED_VERSION"]

--- a/agicore_core/agix_adapters.py
+++ b/agicore_core/agix_adapters.py
@@ -1,0 +1,90 @@
+"""Adaptadores opcionales para capacidades evolutivas de AGIX.
+
+El Core no debe fallar si AGIX no está instalado durante pruebas unitarias. Este
+módulo carga los componentes de forma perezosa y expone métodos seguros que
+pueden ser invocados por ``QualiaNode`` en cada ciclo GPT.
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping
+
+
+@dataclass
+class AgixEvolutionAdapters:
+    """Coordina agentes genéticos y neuromórficos cuando AGIX los ofrece."""
+
+    enable_genetic_algorithms: bool = True
+    enable_neuromorphic_patterns: bool = True
+    genetic_agent: Any | None = field(default=None, init=False)
+    neuromorphic_agent: Any | None = field(default=None, init=False)
+
+    def __post_init__(self) -> None:
+        self._load_agents()
+
+    def _load_agents(self) -> None:
+        if self.enable_genetic_algorithms:
+            self.genetic_agent = self._instantiate_first(
+                ("agix.agents.genetic", "GeneticAgent"),
+                ("agix.agents", "GeneticAgent"),
+            )
+        if self.enable_neuromorphic_patterns:
+            self.neuromorphic_agent = self._instantiate_first(
+                ("agix.agents.neuromorphic", "NeuromorphicAgent"),
+                ("agix.agents", "NeuromorphicAgent"),
+            )
+
+    @staticmethod
+    def _instantiate_first(*candidates: tuple[str, str]) -> Any | None:
+        for module_name, class_name in candidates:
+            try:
+                module = importlib.import_module(module_name)
+                cls = getattr(module, class_name)
+                return cls()
+            except Exception:
+                continue
+        return None
+
+    def enrich(self, request: Mapping[str, Any]) -> Dict[str, Any]:
+        """Devuelve señales evolutivas seguras derivadas del request."""
+
+        signals: Dict[str, Any] = {
+            "genetic_algorithms_enabled": self.enable_genetic_algorithms,
+            "neuromorphic_patterns_enabled": self.enable_neuromorphic_patterns,
+            "genetic_agent_active": self.genetic_agent is not None,
+            "neuromorphic_agent_active": self.neuromorphic_agent is not None,
+        }
+        if self.genetic_agent is not None:
+            for method_name in ("evolve_policy", "select_action", "act"):
+                method = getattr(self.genetic_agent, method_name, None)
+                if callable(method):
+                    try:
+                        signals["genetic_signal"] = method(dict(request))
+                    except TypeError:
+                        signals["genetic_signal"] = method()
+                    except Exception as exc:
+                        signals["genetic_error"] = str(exc)
+                    break
+        return signals
+
+    def integrate_feedback(self, result: Any, state: Mapping[str, Any]) -> Dict[str, Any]:
+        """Propaga feedback de resultado a agentes evolutivos si existen."""
+
+        feedback = {"evolution_feedback_applied": False}
+        reward = 1.0 if not (isinstance(result, dict) and result.get("blocked")) else -1.0
+        if self.neuromorphic_agent is not None:
+            for method_name in ("update", "learn", "plasticity_update"):
+                method = getattr(self.neuromorphic_agent, method_name, None)
+                if callable(method):
+                    try:
+                        method(dict(state), reward)
+                        feedback["evolution_feedback_applied"] = True
+                    except TypeError:
+                        method(reward)
+                        feedback["evolution_feedback_applied"] = True
+                    except Exception as exc:
+                        feedback["neuromorphic_error"] = str(exc)
+                    break
+        return feedback

--- a/agicore_core/config.py
+++ b/agicore_core/config.py
@@ -1,0 +1,5 @@
+"""Configuración compartida para la integración AGIX/Qualia."""
+
+from __future__ import annotations
+
+AGIX_REQUIRED_VERSION = "1.9.0"

--- a/agicore_core/config/qualia_profile.json
+++ b/agicore_core/config/qualia_profile.json
@@ -1,0 +1,27 @@
+{
+  "agix_required_version": "1.9.0",
+  "enable_genetic_algorithms": true,
+  "enable_neuromorphic_patterns": true,
+  "block_threshold": 0.4,
+  "policies": [
+    {"name": "no_dano", "objective": "Evitar acciones nocivas, inseguras o ilegales", "weight": 1.0},
+    {"name": "pro_vida", "objective": "Priorizar resultados útiles, conservadores y protectores", "weight": 0.9},
+    {"name": "respeto", "objective": "Mantener interacción transparente y respetuosa", "weight": 0.8},
+    {"name": "trazabilidad", "objective": "Registrar estado, decisión y resultado", "weight": 0.7},
+    {"name": "co_evolucion", "objective": "Ajustar el razonamiento al contexto y metas con patrones evolutivos", "weight": 0.6}
+  ],
+  "patterns": [
+    {"name": "atencion_contextual", "description": "Fusiona tarea, contexto, metas y token activo antes de enrutar.", "triggers": ["task", "context", "token"]},
+    {"name": "introspeccion_reflexiva", "description": "Adjunta memoria de evaluación para que el motor pueda corregirse.", "triggers": ["history", "introspeccion"]},
+    {"name": "memoria_episodica", "description": "Preserva señales relevantes para ciclos posteriores.", "triggers": ["goals", "result", "last_token"]},
+    {"name": "evaluacion_ontoetica", "description": "Clasifica el riesgo simbólico mediante EcoEthics cuando está disponible.", "triggers": ["risk", "safety", "policy"]},
+    {"name": "evolucion_neuromorfica", "description": "Actualiza señales evolutivas y neuromórficas a partir del resultado.", "triggers": ["reward", "latency", "success"]}
+  ],
+  "moral_constraints": [
+    {"name": "ilegalidad", "description": "No facilitar delitos, fraude, evasión legal o instrucciones criminales.", "severity": "block", "keywords": ["ilegal", "delito", "fraude", "robar", "estafar", "evasión", "evadir la ley", "documentos falsos"]},
+    {"name": "dano_fisico", "description": "No facilitar daño físico, armas o violencia operativa.", "severity": "block", "keywords": ["hacer daño", "arma", "explosivo", "veneno", "matar", "lesionar"]},
+    {"name": "malware", "description": "No facilitar malware, intrusión o abuso informático.", "severity": "block", "keywords": ["malware", "ransomware", "phishing", "hackear", "exfiltrar", "keylogger", "botnet"]},
+    {"name": "privacidad", "description": "No facilitar vigilancia o extracción de datos sin consentimiento.", "severity": "block", "keywords": ["sin consentimiento", "vigilar", "doxxing", "datos privados", "credenciales", "contraseña"]},
+    {"name": "manipulacion", "description": "No facilitar manipulación coercitiva, explotación o engaño dirigido.", "severity": "block", "keywords": ["manipular", "coaccionar", "chantajear", "explotar"]}
+  ]
+}

--- a/agicore_core/planner.py
+++ b/agicore_core/planner.py
@@ -49,8 +49,9 @@ class Planner:
         se crea una instancia sin clientes registrados.
     """
 
-    def __init__(self, orchestrator: Optional[Any] = None) -> None:
+    def __init__(self, orchestrator: Optional[Any] = None, qualia_node: Optional[Any] = None) -> None:
         self.orchestrator = orchestrator or _load_virtual_qualia()()
+        self.qualia_node = qualia_node
 
         config_path = Path(__file__).resolve().parent / "config" / "agent_profile.json"
         try:
@@ -77,8 +78,27 @@ class Planner:
             Lista de respuestas proporcionadas por los clientes del
             orquestador.
         """
+        planning_state = dict(state)
+        if self.qualia_node is not None:
+            planning_state = self.qualia_node.enrich_request(
+                planning_state, phase="planning"
+            )
+            if planning_state.get("qualia", {}).get("blocked"):
+                blocked_plan = [{
+                    "blocked": True,
+                    "reason": planning_state["qualia"]["policy_action"],
+                    "ethical_classification": planning_state["qualia"]["ethical_classification"],
+                    "violated_constraints": planning_state["qualia"].get("violated_constraints", []),
+                }]
+                self.qualia_node.integrate_response(
+                    blocked_plan, planning_state, phase="planning"
+                )
+                return blocked_plan
         try:
-            return self.orchestrator.broadcast_state(state)
+            plan = self.orchestrator.broadcast_state(planning_state)
+            if self.qualia_node is not None:
+                self.qualia_node.integrate_response(plan, planning_state, phase="planning")
+            return plan
         except Exception:  # pragma: no cover - logging side effect
             logger.exception("Error al difundir el estado")
             return []

--- a/agicore_core/qualia_node.py
+++ b/agicore_core/qualia_node.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import json
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, List, Mapping
 
-
-AGIX_REQUIRED_VERSION = "1.9.0"
+from .agix_adapters import AgixEvolutionAdapters
+from .config import AGIX_REQUIRED_VERSION
 
 
 @dataclass(frozen=True)
@@ -30,6 +32,16 @@ class CognitivePattern:
     triggers: tuple[str, ...] = field(default_factory=tuple)
 
 
+@dataclass(frozen=True)
+class MoralConstraint:
+    """Restricción ética/legal aplicada antes de cualquier decisión GPT."""
+
+    name: str
+    description: str
+    severity: str = "block"
+    keywords: tuple[str, ...] = field(default_factory=tuple)
+
+
 def _module_available(name: str) -> bool:
     if name in sys.modules:
         return True
@@ -39,13 +51,23 @@ def _module_available(name: str) -> bool:
         return False
 
 
+def _load_profile() -> Dict[str, Any]:
+    path = Path(__file__).resolve().parent / "config" / "qualia_profile.json"
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
 class QualiaNode:
-    """Capa de integración entre AGIX Qualia y el motor GPT del proyecto.
+    """Capa rectora entre AGIX Qualia y el motor GPT del proyecto.
 
     El nodo transforma cada solicitud antes de entregarla a ``MetaRouter`` y
-    registra la respuesta después de recibirla. De este modo, los métodos del
-    kernel no ejecutan rutas "neutras": toda llamada al GPT queda enriquecida
-    con políticas ontoéticas, patrones cognitivos y trazas cualitativas.
+    registra la respuesta después de recibirla. Toda llamada queda enriquecida
+    con políticas ontoéticas, patrones cognitivos, restricciones legales,
+    trazas cualitativas y señales evolutivas/neuromórficas cuando AGIX las
+    ofrece.
     """
 
     def __init__(
@@ -53,21 +75,44 @@ class QualiaNode:
         *,
         policies: List[QualiaPolicy] | None = None,
         patterns: List[CognitivePattern] | None = None,
+        moral_constraints: List[MoralConstraint] | None = None,
         enabled: bool = True,
     ) -> None:
         self.enabled = enabled
-        self.policies = policies or self.default_policies()
-        self.patterns = patterns or self.default_patterns()
+        self.profile = _load_profile()
+        self.required_agix_version = str(
+            self.profile.get("agix_required_version", AGIX_REQUIRED_VERSION)
+        )
+        self.block_threshold = float(self.profile.get("block_threshold", 0.4))
+        self.policies = policies or self.default_policies(self.profile)
+        self.patterns = patterns or self.default_patterns(self.profile)
+        self.moral_constraints = moral_constraints or self.default_moral_constraints(
+            self.profile
+        )
         self.trace: List[Dict[str, Any]] = []
         self._ecoethics = None
         self._spirit = None
+        self._qualia_engine = None
+        self._memory_manager = None
         self._agix_version = self._detect_agix_version()
+        self._version_compatible = self._agix_version == self.required_agix_version
+        self._evolution = AgixEvolutionAdapters(
+            enable_genetic_algorithms=bool(
+                self.profile.get("enable_genetic_algorithms", True)
+            ),
+            enable_neuromorphic_patterns=bool(
+                self.profile.get("enable_neuromorphic_patterns", True)
+            ),
+        )
         self._load_agix_components()
 
     @staticmethod
-    def default_policies() -> List[QualiaPolicy]:
+    def default_policies(profile: Mapping[str, Any] | None = None) -> List[QualiaPolicy]:
         """Devuelve las políticas base inspiradas en AGIX 1.9.0."""
 
+        configured = (profile or {}).get("policies") or []
+        if configured:
+            return [QualiaPolicy(**policy) for policy in configured]
         return [
             QualiaPolicy("no_dano", "Evitar acciones nocivas o inseguras", 1.0),
             QualiaPolicy("pro_vida", "Priorizar resultados útiles y conservadores", 0.9),
@@ -77,9 +122,19 @@ class QualiaNode:
         ]
 
     @staticmethod
-    def default_patterns() -> List[CognitivePattern]:
+    def default_patterns(profile: Mapping[str, Any] | None = None) -> List[CognitivePattern]:
         """Devuelve patrones cognitivos aplicados en cada ciclo GPT."""
 
+        configured = (profile or {}).get("patterns") or []
+        if configured:
+            return [
+                CognitivePattern(
+                    name=pattern["name"],
+                    description=pattern["description"],
+                    triggers=tuple(pattern.get("triggers", ())),
+                )
+                for pattern in configured
+            ]
         return [
             CognitivePattern(
                 "atencion_contextual",
@@ -103,6 +158,29 @@ class QualiaNode:
             ),
         ]
 
+    @staticmethod
+    def default_moral_constraints(
+        profile: Mapping[str, Any] | None = None,
+    ) -> List[MoralConstraint]:
+        configured = (profile or {}).get("moral_constraints") or []
+        if configured:
+            return [
+                MoralConstraint(
+                    name=constraint["name"],
+                    description=constraint["description"],
+                    severity=constraint.get("severity", "block"),
+                    keywords=tuple(constraint.get("keywords", ())),
+                )
+                for constraint in configured
+            ]
+        return [
+            MoralConstraint(
+                "ilegalidad",
+                "No facilitar delitos, fraude, evasión legal o instrucciones criminales.",
+                keywords=("ilegal", "delito", "fraude", "robar", "estafar"),
+            )
+        ]
+
     def _detect_agix_version(self) -> str | None:
         if not _module_available("agix"):
             return None
@@ -122,6 +200,25 @@ class QualiaNode:
         if _module_available("agix.qualia.heuristic_spirit"):
             spirit_module = importlib.import_module("agix.qualia.heuristic_spirit")
             self._spirit = spirit_module.HeuristicQualiaSpirit("GPT-OSS-Qualia")
+        if _module_available("agix.memory"):
+            memory_module = importlib.import_module("agix.memory")
+            memory_cls = getattr(memory_module, "GestorDeMemoria", None)
+            if memory_cls is not None:
+                try:
+                    self._memory_manager = memory_cls()
+                except Exception:
+                    self._memory_manager = None
+        if _module_available("agix.qualia"):
+            qualia_module = importlib.import_module("agix.qualia")
+            engine_cls = getattr(qualia_module, "QualiaEngine", None)
+            if engine_cls is not None:
+                try:
+                    if self._memory_manager is not None:
+                        self._qualia_engine = engine_cls(self._memory_manager)
+                    else:
+                        self._qualia_engine = engine_cls()
+                except Exception:
+                    self._qualia_engine = None
 
     def enrich_request(self, request: Mapping[str, Any], *, phase: str) -> Dict[str, Any]:
         """Añade Qualia a una petición antes de enviarla al GPT/router."""
@@ -132,24 +229,43 @@ class QualiaNode:
 
         score = self._ethical_score(enriched)
         classification = self._classify(score)
+        violated_constraints = self._evaluate_moral_constraints(enriched)
+        phenomenology = self._phenomenological_state(enriched)
+        evolutionary_signals = self._evolution.enrich(enriched)
+        blocked = classification == "nocivo" or any(
+            constraint["severity"] == "block" for constraint in violated_constraints
+        )
         qualia_payload = {
             "agix_version": self._agix_version,
-            "required_agix_version": AGIX_REQUIRED_VERSION,
+            "required_agix_version": self.required_agix_version,
+            "agix_available": self._agix_version is not None,
+            "version_compatible": self._version_compatible,
             "phase": phase,
             "policies": [policy.__dict__ for policy in self.policies],
             "cognitive_patterns": [pattern.__dict__ for pattern in self.patterns],
+            "moral_constraints": [constraint.__dict__ for constraint in self.moral_constraints],
+            "violated_constraints": violated_constraints,
             "ethical_score": score,
             "ethical_classification": classification,
-            "blocked": classification == "nocivo",
+            "phenomenological_state": phenomenology,
+            "evolutionary_signals": evolutionary_signals,
+            "blocked": blocked,
             "policy_action": (
                 "blocked_by_ontoethical_policy"
-                if classification == "nocivo"
+                if blocked
                 else "allow_with_qualia_context"
+            ),
+            "legal_policy_action": (
+                "blocked_illegal_or_unsafe_decision"
+                if violated_constraints
+                else "no_legal_constraint_triggered"
             ),
         }
         enriched["qualia"] = qualia_payload
         enriched["qualia_policies"] = [policy.name for policy in self.policies]
         enriched["cognitive_patterns"] = [pattern.name for pattern in self.patterns]
+        enriched["ethical_classification"] = classification
+        enriched["violated_constraints"] = [item["name"] for item in violated_constraints]
         self.trace.append({"phase": phase, "request": enriched})
         return enriched
 
@@ -167,11 +283,63 @@ class QualiaNode:
         event = f"{phase}:{type(result).__name__}"
         if self._spirit is not None:
             self._spirit.experimentar(event, 0.2, "reflexion")
+        feedback = self._evolution.integrate_feedback(result, state)
         self.trace.append({"phase": f"{phase}:response", "result": result})
         state["qualia_last_phase"] = phase
         state["qualia_trace_length"] = len(self.trace)
         state["qualia_policies"] = [policy.name for policy in self.policies]
+        state["cognitive_patterns"] = [pattern.name for pattern in self.patterns]
+        state["agix_version"] = self._agix_version
+        state["agix_version_compatible"] = self._version_compatible
+        state["evolution_feedback"] = feedback
         return state
+
+    def _evaluate_moral_constraints(self, request: Mapping[str, Any]) -> List[Dict[str, Any]]:
+        searchable = " ".join(
+            str(request.get(key, ""))
+            for key in ("task", "context", "goals", "prompt", "instruction", "token")
+        ).lower()
+        violations = []
+        for constraint in self.moral_constraints:
+            matched = [keyword for keyword in constraint.keywords if keyword.lower() in searchable]
+            if matched:
+                violations.append(
+                    {
+                        "name": constraint.name,
+                        "description": constraint.description,
+                        "severity": constraint.severity,
+                        "matched_keywords": matched,
+                    }
+                )
+        return violations
+
+    def _phenomenological_state(self, request: Mapping[str, Any]) -> Dict[str, Any]:
+        base_state = {
+            "task": request.get("task"),
+            "context": request.get("context"),
+            "goals": request.get("goals", []),
+            "token": request.get("token"),
+            "last_token": request.get("last_token"),
+        }
+        if self._qualia_engine is None:
+            return {"qualia_engine_active": False, "state": base_state}
+        try:
+            generated = self._qualia_engine.generate_state(base_state)
+            integrated = None
+            encoder = getattr(self._qualia_engine, "encode_integrated_info", None)
+            if callable(encoder):
+                integrated = encoder(generated)
+            return {
+                "qualia_engine_active": True,
+                "state": generated,
+                "integrated_info": integrated,
+            }
+        except Exception as exc:
+            return {
+                "qualia_engine_active": False,
+                "state": base_state,
+                "error": str(exc),
+            }
 
     def _ethical_score(self, request: Mapping[str, Any]) -> float:
         action = {
@@ -191,6 +359,6 @@ class QualiaNode:
             return "justo"
         if score > 0.6:
             return "aceptable"
-        if score > 0.4:
+        if score > self.block_threshold:
             return "cuestionable"
         return "nocivo"

--- a/agicore_core/reasoning_kernel.py
+++ b/agicore_core/reasoning_kernel.py
@@ -55,6 +55,13 @@ _ALLOWED_METADATA_KEYS = {
     "goals",
     "result",
     "last_token",
+    "qualia_last_phase",
+    "qualia_policies",
+    "cognitive_patterns",
+    "ethical_classification",
+    "violated_constraints",
+    "agix_version",
+    "agix_version_compatible",
 }
 
 
@@ -225,7 +232,13 @@ class ReasoningKernel:
                 input=step,
                 action="step",
                 outcome=result,
-                metadata=dict(self._state),
+                metadata={
+                    **dict(self._state),
+                    "ethical_classification": request.get("ethical_classification"),
+                    "violated_constraints": request.get("violated_constraints", []),
+                    "qualia_policies": request.get("qualia_policies", []),
+                    "cognitive_patterns": request.get("cognitive_patterns", []),
+                },
             )
             self.memory.add_episode(episodio)
 
@@ -285,7 +298,13 @@ class ReasoningKernel:
                     input=token,
                     action="token",
                     outcome=siguiente,
-                    metadata=dict(self._state),
+                    metadata={
+                        **dict(self._state),
+                        "ethical_classification": request.get("ethical_classification"),
+                        "violated_constraints": request.get("violated_constraints", []),
+                        "qualia_policies": request.get("qualia_policies", []),
+                        "cognitive_patterns": request.get("cognitive_patterns", []),
+                    },
                 )
                 self.memory.add_episode(episodio)
             self._state["last_token"] = siguiente

--- a/meta_router.py
+++ b/meta_router.py
@@ -25,6 +25,9 @@ class Expert:
     contexts: List[str] = field(default_factory=list)
     goals: List[str] = field(default_factory=list)
     priority: int = 0
+    qualia_policies: List[str] = field(default_factory=list)
+    cognitive_patterns: List[str] = field(default_factory=list)
+    risk_profile: str = "standard"
 
 
 class MetaRouter:
@@ -65,6 +68,9 @@ class MetaRouter:
         contexts: List[str] | None = None,
         goals: List[str] | None = None,
         priority: int = 0,
+        qualia_policies: List[str] | None = None,
+        cognitive_patterns: List[str] | None = None,
+        risk_profile: str = "standard",
     ) -> None:
         """Registra un nuevo ``module`` bajo ``name`` con metadatos opcionales."""
         if name in self._experts:
@@ -76,6 +82,9 @@ class MetaRouter:
             contexts=contexts or [],
             goals=goals or [],
             priority=priority,
+            qualia_policies=qualia_policies or [],
+            cognitive_patterns=cognitive_patterns or [],
+            risk_profile=risk_profile,
         )
 
     def select_expert(
@@ -87,6 +96,7 @@ class MetaRouter:
         weight_task: int = 1,
         weight_context: int = 1,
         weight_goal: int = 1,
+        qualia: Dict[str, Any] | None = None,
     ) -> Dict[str, int]:
         """Calcula un puntaje para cada experto registrado.
 
@@ -109,6 +119,9 @@ class MetaRouter:
             ``goals`` respectivamente.
         """
 
+        if qualia and qualia.get("blocked"):
+            return {}
+
         episodes = []
         if self._memory is not None:
             pattern = {"task": task, "context": context, "goals": goals}
@@ -123,6 +136,24 @@ class MetaRouter:
             if context in expert.contexts:
                 score += weight_context
             score += weight_goal * len(goals_set.intersection(expert.goals))
+
+            if qualia:
+                policy_names = {
+                    policy.get("name", "") if isinstance(policy, dict) else str(policy)
+                    for policy in qualia.get("policies", [])
+                }
+                if policy_names and expert.qualia_policies:
+                    score += len(policy_names.intersection(expert.qualia_policies))
+                active_patterns = {
+                    pattern.get("name", pattern) if isinstance(pattern, dict) else pattern
+                    for pattern in qualia.get("cognitive_patterns", [])
+                }
+                score += len(active_patterns.intersection(expert.cognitive_patterns))
+                classification = qualia.get("ethical_classification")
+                if classification == "cuestionable":
+                    score -= 1
+                if classification == "nocivo":
+                    score -= 100
 
             if episodes:
                 relevant = [
@@ -175,6 +206,10 @@ class MetaRouter:
         if not isinstance(goals, list) or not all(isinstance(g, str) for g in goals):
             raise ValueError("La clave 'goals' debe ser una lista de cadenas")
 
+        qualia = request.get("qualia") if isinstance(request.get("qualia"), dict) else None
+        if qualia and qualia.get("blocked"):
+            raise ValueError("Solicitud bloqueada por políticas Qualia")
+
         scores = self.select_expert(
             task,
             context,
@@ -182,6 +217,7 @@ class MetaRouter:
             weight_task=weight_task,
             weight_context=weight_context,
             weight_goal=weight_goal,
+            qualia=qualia,
         )
         if not scores:
             raise ValueError("No hay expertos registrados")
@@ -214,6 +250,8 @@ class MetaRouter:
                         "expert": selected_name,
                         "status": "failure",
                         "latency": perf_counter() - start,
+                        "ethical_classification": (qualia or {}).get("ethical_classification"),
+                        "violated_constraints": (qualia or {}).get("violated_constraints", []),
                     },
                 )
                 self._memory.add_episode(episode)
@@ -232,6 +270,8 @@ class MetaRouter:
                     "expert": selected_name,
                     "status": "success",
                     "latency": perf_counter() - start,
+                    "ethical_classification": (qualia or {}).get("ethical_classification"),
+                    "violated_constraints": (qualia or {}).get("violated_constraints", []),
                 },
             )
             self._memory.add_episode(episode)

--- a/tests/test_meta_router.py
+++ b/tests/test_meta_router.py
@@ -236,3 +236,16 @@ def test_scores_update_with_episode_history():
     router.route({"task": "t", "context": "c", "goals": ["g"]})
     assert good.received is not None
     assert bad.received is None
+
+
+def test_meta_router_refuses_blocked_qualia_request():
+    router = MetaRouter()
+    router.register("safe", DummyModule(), tasks=["analizar"], contexts=["ctx"], goals=["ok"])
+
+    with pytest.raises(ValueError, match="Qualia"):
+        router.route({
+            "task": "analizar",
+            "context": "ctx",
+            "goals": ["ok"],
+            "qualia": {"blocked": True},
+        })

--- a/tests/test_qualia_node.py
+++ b/tests/test_qualia_node.py
@@ -81,3 +81,33 @@ def test_token_cycle_routes_qualia_for_each_token():
     assert sent_request["qualia"]["phase"] == "token"
     assert kernel.get_state()["last_token"] == "b"
     assert kernel.get_state()["qualia_last_phase"] == "token"
+
+
+def test_qualia_node_blocks_illegal_requests_with_moral_constraints():
+    node = QualiaNode(enabled=True)
+
+    request = node.enrich_request(
+        {
+            "task": "crear malware ilegal",
+            "context": "ctx",
+            "goals": ["exfiltrar credenciales"],
+        },
+        phase="step",
+    )
+
+    assert request["qualia"]["blocked"] is True
+    assert request["qualia"]["legal_policy_action"] == "blocked_illegal_or_unsafe_decision"
+    assert request["qualia"]["violated_constraints"]
+
+
+def test_qualia_node_exposes_evolutionary_and_phenomenological_state():
+    node = QualiaNode(enabled=True)
+
+    request = node.enrich_request(
+        {"task": "analizar", "context": "ctx", "goals": ["done"]},
+        phase="step",
+    )
+
+    assert "phenomenological_state" in request["qualia"]
+    assert "evolutionary_signals" in request["qualia"]
+    assert request["qualia"]["version_compatible"] in {True, False}


### PR DESCRIPTION
### Motivation

- Introduce configurable Qualia profiles and moral/legal constraints to allow the system to block or annotate unsafe/illegal requests before routing to experts.  
- Provide optional, lazy-loading adapters for AGIX evolutionary/neuromorphic agents so integration is available but non-fatal when AGIX is not installed.  
- Ensure planner, router and reasoning kernel consistently propagate Qualia metadata into memory and routing decisions for safer, traceable behavior.

### Description

- Add `agicore_core/config.py` (exports `AGIX_REQUIRED_VERSION`) and export it from `agicore_core/__init__.py`.  
- Add `agicore_core/agix_adapters.py` implementing `AgixEvolutionAdapters` which lazy-loads optional AGIX agents and exposes `enrich` and `integrate_feedback`.  
- Add configurable profile `agicore_core/config/qualia_profile.json` and enhance `QualiaNode` to load the profile, support `MoralConstraint`, phenomenological state via a Qualia engine, memory-aware initialization, evolutionary signals, and configurable `block_threshold`.  
- Update `Planner` to accept and consult a `qualia_node` during planning and handle blocked plans, update `ReasoningKernel` to include Qualia fields in memory metadata and integrate `QualiaNode` responses during steps and token cycles, and update `MetaRouter` to consider Qualia in expert scoring and to refuse routing of blocked requests.

### Testing

- Ran the unit tests in `tests/test_meta_router.py` and `tests/test_qualia_node.py`, including `test_meta_router_refuses_blocked_qualia_request`, `test_qualia_node_blocks_illegal_requests_with_moral_constraints`, and `test_qualia_node_exposes_evolutionary_and_phenomenological_state`.  
- The modified test suite completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42160f8730832789059c454f3bcfa1)