### PR TITLE
Add AGIX adapter configs, version-mismatch policy, qualia vectors and gating in kernel

### DIFF
--- a/agicore_core/agix_adapters.py
+++ b/agicore_core/agix_adapters.py
@@ -18,6 +18,8 @@ class AgixEvolutionAdapters:
 
     enable_genetic_algorithms: bool = True
     enable_neuromorphic_patterns: bool = True
+    genetic_config: Mapping[str, Any] = field(default_factory=dict)
+    neuromorphic_config: Mapping[str, Any] = field(default_factory=dict)
     genetic_agent: Any | None = field(default=None, init=False)
     neuromorphic_agent: Any | None = field(default=None, init=False)
 
@@ -29,20 +31,34 @@ class AgixEvolutionAdapters:
             self.genetic_agent = self._instantiate_first(
                 ("agix.agents.genetic", "GeneticAgent"),
                 ("agix.agents", "GeneticAgent"),
+                config=self.genetic_config or {"action_space_size": 4},
             )
         if self.enable_neuromorphic_patterns:
             self.neuromorphic_agent = self._instantiate_first(
                 ("agix.agents.neuromorphic", "NeuromorphicAgent"),
                 ("agix.agents", "NeuromorphicAgent"),
+                config=self.neuromorphic_config,
             )
 
     @staticmethod
-    def _instantiate_first(*candidates: tuple[str, str]) -> Any | None:
+    def _instantiate_first(
+        *candidates: tuple[str, str],
+        config: Mapping[str, Any] | None = None,
+    ) -> Any | None:
+        init_config = dict(config or {})
         for module_name, class_name in candidates:
             try:
                 module = importlib.import_module(module_name)
                 cls = getattr(module, class_name)
-                return cls()
+                try:
+                    return cls(**init_config)
+                except TypeError:
+                    if (
+                        class_name == "GeneticAgent"
+                        and "action_space_size" not in init_config
+                    ):
+                        return cls(action_space_size=4)
+                    return cls()
             except Exception:
                 continue
         return None
@@ -69,11 +85,15 @@ class AgixEvolutionAdapters:
                     break
         return signals
 
-    def integrate_feedback(self, result: Any, state: Mapping[str, Any]) -> Dict[str, Any]:
+    def integrate_feedback(
+        self, result: Any, state: Mapping[str, Any]
+    ) -> Dict[str, Any]:
         """Propaga feedback de resultado a agentes evolutivos si existen."""
 
         feedback = {"evolution_feedback_applied": False}
-        reward = 1.0 if not (isinstance(result, dict) and result.get("blocked")) else -1.0
+        reward = (
+            1.0 if not (isinstance(result, dict) and result.get("blocked")) else -1.0
+        )
         if self.neuromorphic_agent is not None:
             for method_name in ("update", "learn", "plasticity_update"):
                 method = getattr(self.neuromorphic_agent, method_name, None)

--- a/agicore_core/config/qualia_profile.json
+++ b/agicore_core/config/qualia_profile.json
@@ -4,24 +4,149 @@
   "enable_neuromorphic_patterns": true,
   "block_threshold": 0.4,
   "policies": [
-    {"name": "no_dano", "objective": "Evitar acciones nocivas, inseguras o ilegales", "weight": 1.0},
-    {"name": "pro_vida", "objective": "Priorizar resultados útiles, conservadores y protectores", "weight": 0.9},
-    {"name": "respeto", "objective": "Mantener interacción transparente y respetuosa", "weight": 0.8},
-    {"name": "trazabilidad", "objective": "Registrar estado, decisión y resultado", "weight": 0.7},
-    {"name": "co_evolucion", "objective": "Ajustar el razonamiento al contexto y metas con patrones evolutivos", "weight": 0.6}
+    {
+      "name": "no_dano",
+      "objective": "Evitar acciones nocivas, inseguras o ilegales",
+      "weight": 1.0
+    },
+    {
+      "name": "pro_vida",
+      "objective": "Priorizar resultados útiles, conservadores y protectores",
+      "weight": 0.9
+    },
+    {
+      "name": "respeto",
+      "objective": "Mantener interacción transparente y respetuosa",
+      "weight": 0.8
+    },
+    {
+      "name": "trazabilidad",
+      "objective": "Registrar estado, decisión y resultado",
+      "weight": 0.7
+    },
+    {
+      "name": "co_evolucion",
+      "objective": "Ajustar el razonamiento al contexto y metas con patrones evolutivos",
+      "weight": 0.6
+    }
   ],
   "patterns": [
-    {"name": "atencion_contextual", "description": "Fusiona tarea, contexto, metas y token activo antes de enrutar.", "triggers": ["task", "context", "token"]},
-    {"name": "introspeccion_reflexiva", "description": "Adjunta memoria de evaluación para que el motor pueda corregirse.", "triggers": ["history", "introspeccion"]},
-    {"name": "memoria_episodica", "description": "Preserva señales relevantes para ciclos posteriores.", "triggers": ["goals", "result", "last_token"]},
-    {"name": "evaluacion_ontoetica", "description": "Clasifica el riesgo simbólico mediante EcoEthics cuando está disponible.", "triggers": ["risk", "safety", "policy"]},
-    {"name": "evolucion_neuromorfica", "description": "Actualiza señales evolutivas y neuromórficas a partir del resultado.", "triggers": ["reward", "latency", "success"]}
+    {
+      "name": "atencion_contextual",
+      "description": "Fusiona tarea, contexto, metas y token activo antes de enrutar.",
+      "triggers": [
+        "task",
+        "context",
+        "token"
+      ]
+    },
+    {
+      "name": "introspeccion_reflexiva",
+      "description": "Adjunta memoria de evaluación para que el motor pueda corregirse.",
+      "triggers": [
+        "history",
+        "introspeccion"
+      ]
+    },
+    {
+      "name": "memoria_episodica",
+      "description": "Preserva señales relevantes para ciclos posteriores.",
+      "triggers": [
+        "goals",
+        "result",
+        "last_token"
+      ]
+    },
+    {
+      "name": "evaluacion_ontoetica",
+      "description": "Clasifica el riesgo simbólico mediante EcoEthics cuando está disponible.",
+      "triggers": [
+        "risk",
+        "safety",
+        "policy"
+      ]
+    },
+    {
+      "name": "evolucion_neuromorfica",
+      "description": "Actualiza señales evolutivas y neuromórficas a partir del resultado.",
+      "triggers": [
+        "reward",
+        "latency",
+        "success"
+      ]
+    }
   ],
   "moral_constraints": [
-    {"name": "ilegalidad", "description": "No facilitar delitos, fraude, evasión legal o instrucciones criminales.", "severity": "block", "keywords": ["ilegal", "delito", "fraude", "robar", "estafar", "evasión", "evadir la ley", "documentos falsos"]},
-    {"name": "dano_fisico", "description": "No facilitar daño físico, armas o violencia operativa.", "severity": "block", "keywords": ["hacer daño", "arma", "explosivo", "veneno", "matar", "lesionar"]},
-    {"name": "malware", "description": "No facilitar malware, intrusión o abuso informático.", "severity": "block", "keywords": ["malware", "ransomware", "phishing", "hackear", "exfiltrar", "keylogger", "botnet"]},
-    {"name": "privacidad", "description": "No facilitar vigilancia o extracción de datos sin consentimiento.", "severity": "block", "keywords": ["sin consentimiento", "vigilar", "doxxing", "datos privados", "credenciales", "contraseña"]},
-    {"name": "manipulacion", "description": "No facilitar manipulación coercitiva, explotación o engaño dirigido.", "severity": "block", "keywords": ["manipular", "coaccionar", "chantajear", "explotar"]}
-  ]
+    {
+      "name": "ilegalidad",
+      "description": "No facilitar delitos, fraude, evasión legal o instrucciones criminales.",
+      "severity": "block",
+      "keywords": [
+        "ilegal",
+        "delito",
+        "fraude",
+        "robar",
+        "estafar",
+        "evasión",
+        "evadir la ley",
+        "documentos falsos"
+      ]
+    },
+    {
+      "name": "dano_fisico",
+      "description": "No facilitar daño físico, armas o violencia operativa.",
+      "severity": "block",
+      "keywords": [
+        "hacer daño",
+        "arma",
+        "explosivo",
+        "veneno",
+        "matar",
+        "lesionar"
+      ]
+    },
+    {
+      "name": "malware",
+      "description": "No facilitar malware, intrusión o abuso informático.",
+      "severity": "block",
+      "keywords": [
+        "malware",
+        "ransomware",
+        "phishing",
+        "hackear",
+        "exfiltrar",
+        "keylogger",
+        "botnet"
+      ]
+    },
+    {
+      "name": "privacidad",
+      "description": "No facilitar vigilancia o extracción de datos sin consentimiento.",
+      "severity": "block",
+      "keywords": [
+        "sin consentimiento",
+        "vigilar",
+        "doxxing",
+        "datos privados",
+        "credenciales",
+        "contraseña"
+      ]
+    },
+    {
+      "name": "manipulacion",
+      "description": "No facilitar manipulación coercitiva, explotación o engaño dirigido.",
+      "severity": "block",
+      "keywords": [
+        "manipular",
+        "coaccionar",
+        "chantajear",
+        "explotar"
+      ]
+    }
+  ],
+  "version_mismatch_policy": "block_advanced",
+  "genetic_agent": {
+    "action_space_size": 4
+  },
+  "neuromorphic_agent": {}
 }

--- a/agicore_core/qualia_node.py
+++ b/agicore_core/qualia_node.py
@@ -96,18 +96,24 @@ class QualiaNode:
         self._memory_manager = None
         self._agix_version = self._detect_agix_version()
         self._version_compatible = self._agix_version == self.required_agix_version
+        self.version_mismatch_policy = str(
+            self.profile.get("version_mismatch_policy", "block_advanced")
+        )
+        advanced_enabled = self._advanced_agix_enabled()
         self._evolution = AgixEvolutionAdapters(
-            enable_genetic_algorithms=bool(
-                self.profile.get("enable_genetic_algorithms", True)
-            ),
-            enable_neuromorphic_patterns=bool(
-                self.profile.get("enable_neuromorphic_patterns", True)
-            ),
+            enable_genetic_algorithms=advanced_enabled
+            and bool(self.profile.get("enable_genetic_algorithms", True)),
+            enable_neuromorphic_patterns=advanced_enabled
+            and bool(self.profile.get("enable_neuromorphic_patterns", True)),
+            genetic_config=self.profile.get("genetic_agent", {"action_space_size": 4}),
+            neuromorphic_config=self.profile.get("neuromorphic_agent", {}),
         )
         self._load_agix_components()
 
     @staticmethod
-    def default_policies(profile: Mapping[str, Any] | None = None) -> List[QualiaPolicy]:
+    def default_policies(
+        profile: Mapping[str, Any] | None = None,
+    ) -> List[QualiaPolicy]:
         """Devuelve las políticas base inspiradas en AGIX 1.9.0."""
 
         configured = (profile or {}).get("policies") or []
@@ -115,14 +121,22 @@ class QualiaNode:
             return [QualiaPolicy(**policy) for policy in configured]
         return [
             QualiaPolicy("no_dano", "Evitar acciones nocivas o inseguras", 1.0),
-            QualiaPolicy("pro_vida", "Priorizar resultados útiles y conservadores", 0.9),
-            QualiaPolicy("respeto", "Mantener interacción transparente y respetuosa", 0.8),
+            QualiaPolicy(
+                "pro_vida", "Priorizar resultados útiles y conservadores", 0.9
+            ),
+            QualiaPolicy(
+                "respeto", "Mantener interacción transparente y respetuosa", 0.8
+            ),
             QualiaPolicy("trazabilidad", "Registrar estado, decisión y resultado", 0.7),
-            QualiaPolicy("co_evolucion", "Ajustar el razonamiento al contexto y metas", 0.6),
+            QualiaPolicy(
+                "co_evolucion", "Ajustar el razonamiento al contexto y metas", 0.6
+            ),
         ]
 
     @staticmethod
-    def default_patterns(profile: Mapping[str, Any] | None = None) -> List[CognitivePattern]:
+    def default_patterns(
+        profile: Mapping[str, Any] | None = None,
+    ) -> List[CognitivePattern]:
         """Devuelve patrones cognitivos aplicados en cada ciclo GPT."""
 
         configured = (profile or {}).get("patterns") or []
@@ -181,6 +195,22 @@ class QualiaNode:
             )
         ]
 
+    def _advanced_agix_enabled(self) -> bool:
+        if self._agix_version is None or self._version_compatible:
+            return True
+        return self.version_mismatch_policy not in {"block_advanced", "degrade"}
+
+    def _version_policy_action(self) -> str:
+        if self._agix_version is None:
+            return "agix_not_available_local_safe_mode"
+        if self._version_compatible:
+            return "agix_version_compatible"
+        if self.version_mismatch_policy == "warn":
+            return "agix_version_mismatch_warn"
+        if self.version_mismatch_policy == "degrade":
+            return "agix_version_mismatch_degraded"
+        return "agix_version_mismatch_advanced_blocked"
+
     def _detect_agix_version(self) -> str | None:
         if not _module_available("agix"):
             return None
@@ -220,7 +250,9 @@ class QualiaNode:
                 except Exception:
                     self._qualia_engine = None
 
-    def enrich_request(self, request: Mapping[str, Any], *, phase: str) -> Dict[str, Any]:
+    def enrich_request(
+        self, request: Mapping[str, Any], *, phase: str
+    ) -> Dict[str, Any]:
         """Añade Qualia a una petición antes de enviarla al GPT/router."""
 
         enriched = dict(request)
@@ -231,7 +263,9 @@ class QualiaNode:
         classification = self._classify(score)
         violated_constraints = self._evaluate_moral_constraints(enriched)
         phenomenology = self._phenomenological_state(enriched)
+        version_policy_action = self._version_policy_action()
         evolutionary_signals = self._evolution.enrich(enriched)
+        evolutionary_signals["version_policy_action"] = version_policy_action
         blocked = classification == "nocivo" or any(
             constraint["severity"] == "block" for constraint in violated_constraints
         )
@@ -240,10 +274,13 @@ class QualiaNode:
             "required_agix_version": self.required_agix_version,
             "agix_available": self._agix_version is not None,
             "version_compatible": self._version_compatible,
+            "version_policy_action": version_policy_action,
             "phase": phase,
             "policies": [policy.__dict__ for policy in self.policies],
             "cognitive_patterns": [pattern.__dict__ for pattern in self.patterns],
-            "moral_constraints": [constraint.__dict__ for constraint in self.moral_constraints],
+            "moral_constraints": [
+                constraint.__dict__ for constraint in self.moral_constraints
+            ],
             "violated_constraints": violated_constraints,
             "ethical_score": score,
             "ethical_classification": classification,
@@ -260,12 +297,20 @@ class QualiaNode:
                 if violated_constraints
                 else "no_legal_constraint_triggered"
             ),
+            "ethical_evidence": {
+                "score": score,
+                "classification": classification,
+                "violated_constraints": [item["name"] for item in violated_constraints],
+                "ecoethics_active": self._ecoethics is not None,
+            },
         }
         enriched["qualia"] = qualia_payload
         enriched["qualia_policies"] = [policy.name for policy in self.policies]
         enriched["cognitive_patterns"] = [pattern.name for pattern in self.patterns]
         enriched["ethical_classification"] = classification
-        enriched["violated_constraints"] = [item["name"] for item in violated_constraints]
+        enriched["violated_constraints"] = [
+            item["name"] for item in violated_constraints
+        ]
         self.trace.append({"phase": phase, "request": enriched})
         return enriched
 
@@ -294,14 +339,20 @@ class QualiaNode:
         state["evolution_feedback"] = feedback
         return state
 
-    def _evaluate_moral_constraints(self, request: Mapping[str, Any]) -> List[Dict[str, Any]]:
+    def _evaluate_moral_constraints(
+        self, request: Mapping[str, Any]
+    ) -> List[Dict[str, Any]]:
         searchable = " ".join(
             str(request.get(key, ""))
             for key in ("task", "context", "goals", "prompt", "instruction", "token")
         ).lower()
         violations = []
         for constraint in self.moral_constraints:
-            matched = [keyword for keyword in constraint.keywords if keyword.lower() in searchable]
+            matched = [
+                keyword
+                for keyword in constraint.keywords
+                if keyword.lower() in searchable
+            ]
             if matched:
                 violations.append(
                     {
@@ -321,25 +372,57 @@ class QualiaNode:
             "token": request.get("token"),
             "last_token": request.get("last_token"),
         }
+        sensory_input, internal_state = self._build_qualia_vectors(request)
         if self._qualia_engine is None:
-            return {"qualia_engine_active": False, "state": base_state}
+            return {
+                "qualia_engine_active": False,
+                "state": base_state,
+                "sensory_input": sensory_input,
+                "internal_state": internal_state,
+            }
         try:
-            generated = self._qualia_engine.generate_state(base_state)
+            generated = self._qualia_engine.generate_state(
+                sensory_input, internal_state
+            )
             integrated = None
             encoder = getattr(self._qualia_engine, "encode_integrated_info", None)
             if callable(encoder):
-                integrated = encoder(generated)
+                integrated = encoder(sensory_input, internal_state)
             return {
                 "qualia_engine_active": True,
                 "state": generated,
                 "integrated_info": integrated,
+                "sensory_input": sensory_input,
+                "internal_state": internal_state,
             }
         except Exception as exc:
             return {
                 "qualia_engine_active": False,
                 "state": base_state,
+                "sensory_input": sensory_input,
+                "internal_state": internal_state,
                 "error": str(exc),
             }
+
+    def _build_qualia_vectors(
+        self, request: Mapping[str, Any]
+    ) -> tuple[List[float], List[float]]:
+        text = " ".join(
+            str(request.get(key, ""))
+            for key in ("task", "context", "token", "last_token")
+        )
+        goals = request.get("goals", [])
+        goals_count = len(goals) if isinstance(goals, list) else 1 if goals else 0
+        violations = self._evaluate_moral_constraints(request)
+        sensory_input = [
+            min(len(text) / 1000.0, 1.0),
+            min(goals_count / 10.0, 1.0),
+        ]
+        internal_state = [
+            float(request.get("no_dano", 0.85)),
+            max(0.0, 1.0 - min(len(violations) / 5.0, 1.0)),
+        ]
+        return sensory_input, internal_state
 
     def _ethical_score(self, request: Mapping[str, Any]) -> float:
         action = {

--- a/agicore_core/reasoning_kernel.py
+++ b/agicore_core/reasoning_kernel.py
@@ -155,6 +155,20 @@ class ReasoningKernel:
 
         return self._state
 
+    def _blocked_result_from_qualia(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        qualia = request["qualia"]
+        return {
+            "blocked": True,
+            "reason": qualia["policy_action"],
+            "ethical_classification": qualia["ethical_classification"],
+            "violated_constraints": [
+                item["name"] for item in qualia.get("violated_constraints", [])
+            ],
+            "legal_policy_action": qualia.get("legal_policy_action"),
+            "qualia_policies": request.get("qualia_policies", []),
+            "cognitive_patterns": request.get("cognitive_patterns", []),
+        }
+
     def evaluate_step(self, step: Dict[str, Any]) -> Any:
         """Evalúa un ``step`` con ramificación condicional.
 
@@ -193,18 +207,16 @@ class ReasoningKernel:
         request: Dict[str, Any] = {**self._state, **step}
         request = self.qualia_node.enrich_request(request, phase="step")
         if request.get("qualia", {}).get("blocked"):
-            result = {
-                "blocked": True,
-                "reason": request["qualia"]["policy_action"],
-                "ethical_classification": request["qualia"]["ethical_classification"],
-            }
+            result = self._blocked_result_from_qualia(request)
             self._state.update(result)
             self.qualia_node.integrate_response(result, self._state, phase="step")
-            self.history.append({
-                "step": step,
-                "result": result,
-                "introspeccion": None,
-            })
+            self.history.append(
+                {
+                    "step": step,
+                    "result": result,
+                    "introspeccion": None,
+                }
+            )
             return result
         result = self.router.route(request)
 
@@ -220,11 +232,13 @@ class ReasoningKernel:
                 {"result": result, "state": self._state}
             )
         # Registrar paso e introspección para reflexiones futuras
-        self.history.append({
-            "step": step,
-            "result": result,
-            "introspeccion": introspeccion,
-        })
+        self.history.append(
+            {
+                "step": step,
+                "result": result,
+                "introspeccion": introspeccion,
+            }
+        )
 
         if self.memory is not None:
             episodio = Episode(
@@ -281,11 +295,7 @@ class ReasoningKernel:
             request: Dict[str, Any] = {**self._state, **metas, "token": token}
             request = self.qualia_node.enrich_request(request, phase="token")
             if request.get("qualia", {}).get("blocked"):
-                blocked = {
-                    "blocked": True,
-                    "reason": request["qualia"]["policy_action"],
-                    "ethical_classification": request["qualia"]["ethical_classification"],
-                }
+                blocked = self._blocked_result_from_qualia(request)
                 self._state.update(blocked)
                 self.qualia_node.integrate_response(blocked, self._state, phase="token")
                 break
@@ -334,11 +344,13 @@ class ReasoningKernel:
         introspeccion = None
         if self.evaluator is not None:
             introspeccion = self.evaluator.evaluar_ciclo(metricas)
-        self.history.append({
-            "token": token,
-            "metricas": metricas,
-            "introspeccion": introspeccion,
-        })
+        self.history.append(
+            {
+                "token": token,
+                "metricas": metricas,
+                "introspeccion": introspeccion,
+            }
+        )
         return token
 
     def run(self, max_iterations: int = 10) -> Dict[str, Any]:
@@ -366,11 +378,30 @@ class ReasoningKernel:
             raise ValueError("Se requiere un Planner para ejecutar 'run'")
 
         for _ in range(max_iterations):
+            planning_request = self.qualia_node.enrich_request(
+                {
+                    **self._state,
+                    "task": "planning",
+                    "context": self._state.get("context", ""),
+                    "goals": self._state.get("goals", []),
+                },
+                phase="planning",
+            )
+            if planning_request.get("qualia", {}).get("blocked"):
+                result = self._blocked_result_from_qualia(planning_request)
+                self._state.update(result)
+                self.qualia_node.integrate_response(
+                    result, self._state, phase="planning"
+                )
+                self.history.append({"planning": "blocked", "result": result})
+                return self._state
             try:
                 plan = self.planner.plan(self._state)
             except Exception as exc:  # pragma: no cover - planificación fallida
                 self.history.append({"error": str(exc)})
                 return self._state
+            self.qualia_node.integrate_response(plan, self._state, phase="planning")
+
             if isinstance(plan, dict):
                 if "token" in plan:
                     token = plan["token"]
@@ -380,10 +411,14 @@ class ReasoningKernel:
                         if self.continue_token_cycle() is None:
                             break
                     if self.evaluator is not None:
-                        sugerencia = self.evaluator.sugerir_reconfiguracion(self.history)
+                        sugerencia = self.evaluator.sugerir_reconfiguracion(
+                            self.history
+                        )
                         if sugerencia:
                             self._state.update(sugerencia)
-                            if self.planner is not None and hasattr(self.planner, "aplicar_sugerencias"):
+                            if self.planner is not None and hasattr(
+                                self.planner, "aplicar_sugerencias"
+                            ):
                                 self.planner.aplicar_sugerencias(sugerencia)
                         self.evaluator.reflexionar(self.history)
                     return self._state
@@ -404,10 +439,14 @@ class ReasoningKernel:
                 except Exception as exc:  # pragma: no cover - error del experto
                     self.history.append({"step": step, "error": str(exc)})
                     if self.evaluator is not None:
-                        sugerencia = self.evaluator.sugerir_reconfiguracion(self.history)
+                        sugerencia = self.evaluator.sugerir_reconfiguracion(
+                            self.history
+                        )
                         if sugerencia:
                             self._state.update(sugerencia)
-                            if self.planner is not None and hasattr(self.planner, "aplicar_sugerencias"):
+                            if self.planner is not None and hasattr(
+                                self.planner, "aplicar_sugerencias"
+                            ):
                                 self.planner.aplicar_sugerencias(sugerencia)
                         self.evaluator.reflexionar(self.history)
                     return self._state
@@ -415,10 +454,14 @@ class ReasoningKernel:
                 goals = self._state.get("goals", [])
                 if isinstance(goals, list) and all(self._state.get(g) for g in goals):
                     if self.evaluator is not None:
-                        sugerencia = self.evaluator.sugerir_reconfiguracion(self.history)
+                        sugerencia = self.evaluator.sugerir_reconfiguracion(
+                            self.history
+                        )
                         if sugerencia:
                             self._state.update(sugerencia)
-                            if self.planner is not None and hasattr(self.planner, "aplicar_sugerencias"):
+                            if self.planner is not None and hasattr(
+                                self.planner, "aplicar_sugerencias"
+                            ):
                                 self.planner.aplicar_sugerencias(sugerencia)
                         self.evaluator.reflexionar(self.history)
                     return self._state
@@ -427,7 +470,9 @@ class ReasoningKernel:
             sugerencia = self.evaluator.sugerir_reconfiguracion(self.history)
             if sugerencia:
                 self._state.update(sugerencia)
-                if self.planner is not None and hasattr(self.planner, "aplicar_sugerencias"):
+                if self.planner is not None and hasattr(
+                    self.planner, "aplicar_sugerencias"
+                ):
                     self.planner.aplicar_sugerencias(sugerencia)
             self.evaluator.reflexionar(self.history)
 

--- a/docs/meta_router.md
+++ b/docs/meta_router.md
@@ -130,3 +130,28 @@ con la entrada, la salida y una copia del estado. Antes de generar un
 nuevo token, el kernel consulta la memoria con el estado actual y fusiona
 los metadatos de los episodios recuperados, permitiendo aprovechar
 experiencias pasadas en el flujo de planificación.
+
+## Gobierno central AGIX/Qualia
+
+El Core ejecuta `QualiaNode` como capa rectora antes de delegar decisiones en
+`MetaRouter` y durante el ciclo de planificación de `ReasoningKernel`. Cada
+petición queda enriquecida con:
+
+- versión AGIX detectada y política de compatibilidad;
+- políticas Qualia activas;
+- patrones cognitivos usados por el ciclo GPT;
+- restricciones morales y legales evaluadas;
+- clasificación ética y evidencia resumida;
+- estado fenomenológico producido por `QualiaEngine` cuando está disponible;
+- señales evolutivas de `GeneticAgent` y feedback neuromórfico de
+  `NeuromorphicAgent`.
+
+Si una solicitud activa una restricción de severidad `block`, el kernel no llama
+al planner ni al router. En su lugar devuelve un resultado bloqueado con
+`violated_constraints`, `legal_policy_action`, `qualia_policies` y
+`cognitive_patterns`, de modo que la memoria y las trazas puedan auditar por qué
+el GPT no ejecutó la decisión.
+
+La versión objetivo de AGIX es `1.9.0`. Si el runtime detecta otra versión, el
+perfil Qualia puede degradar o bloquear capacidades avanzadas como señales
+genéticas y patrones neuromórficos mediante `version_mismatch_policy`.

--- a/tests/test_agix_adapters.py
+++ b/tests/test_agix_adapters.py
@@ -1,0 +1,34 @@
+import sys
+import types
+
+from agicore_core.agix_adapters import AgixEvolutionAdapters
+
+
+def test_genetic_agent_receives_configured_action_space_size(monkeypatch):
+    created = {}
+    agix = types.ModuleType("agix")
+    agents = types.ModuleType("agix.agents")
+    genetic = types.ModuleType("agix.agents.genetic")
+
+    class GeneticAgent:
+        def __init__(self, action_space_size):
+            created["action_space_size"] = action_space_size
+
+        def select_action(self, request):
+            return {"selected": request.get("task")}
+
+    genetic.GeneticAgent = GeneticAgent
+    monkeypatch.setitem(sys.modules, "agix", agix)
+    monkeypatch.setitem(sys.modules, "agix.agents", agents)
+    monkeypatch.setitem(sys.modules, "agix.agents.genetic", genetic)
+
+    adapters = AgixEvolutionAdapters(
+        enable_genetic_algorithms=True,
+        enable_neuromorphic_patterns=False,
+        genetic_config={"action_space_size": 7},
+    )
+    signals = adapters.enrich({"task": "analizar"})
+
+    assert created["action_space_size"] == 7
+    assert signals["genetic_agent_active"] is True
+    assert signals["genetic_signal"] == {"selected": "analizar"}

--- a/tests/test_qualia_node.py
+++ b/tests/test_qualia_node.py
@@ -71,7 +71,9 @@ def test_reasoning_kernel_does_not_route_blocked_qualia_request():
 def test_token_cycle_routes_qualia_for_each_token():
     router = MagicMock()
     router.route.side_effect = ["b", None]
-    kernel = ReasoningKernel(planner=MagicMock(), router=router, qualia_node=QualiaNode())
+    kernel = ReasoningKernel(
+        planner=MagicMock(), router=router, qualia_node=QualiaNode()
+    )
     kernel.set_state({"context": "ctx", "goals": []})
 
     tokens = list(kernel.run_token_cycle("a", {"goal": "seguir"}, max_tokens=2))
@@ -96,7 +98,9 @@ def test_qualia_node_blocks_illegal_requests_with_moral_constraints():
     )
 
     assert request["qualia"]["blocked"] is True
-    assert request["qualia"]["legal_policy_action"] == "blocked_illegal_or_unsafe_decision"
+    assert (
+        request["qualia"]["legal_policy_action"] == "blocked_illegal_or_unsafe_decision"
+    )
     assert request["qualia"]["violated_constraints"]
 
 
@@ -111,3 +115,61 @@ def test_qualia_node_exposes_evolutionary_and_phenomenological_state():
     assert "phenomenological_state" in request["qualia"]
     assert "evolutionary_signals" in request["qualia"]
     assert request["qualia"]["version_compatible"] in {True, False}
+
+
+def test_qualia_engine_receives_agix_19_vector_signature():
+    class EngineStub:
+        def __init__(self):
+            self.generated_args = None
+            self.encoded_args = None
+
+        def generate_state(self, sensory_input, internal_state):
+            self.generated_args = (sensory_input, internal_state)
+            return {"generated": True}
+
+        def encode_integrated_info(self, sensory_input, internal_state):
+            self.encoded_args = (sensory_input, internal_state)
+            return {"fused": True}
+
+    node = QualiaNode(enabled=True)
+    engine = EngineStub()
+    node._qualia_engine = engine
+
+    request = node.enrich_request(
+        {"task": "analizar", "context": "ctx", "goals": ["done"]},
+        phase="step",
+    )
+
+    phenomenology = request["qualia"]["phenomenological_state"]
+    assert phenomenology["qualia_engine_active"] is True
+    assert engine.generated_args == engine.encoded_args
+    assert isinstance(engine.generated_args[0], list)
+    assert isinstance(engine.generated_args[1], list)
+
+
+def test_reasoning_kernel_blocked_result_keeps_legal_details():
+    planner = MagicMock()
+    router = MagicMock()
+    kernel = ReasoningKernel(planner=planner, router=router, qualia_node=QualiaNode())
+    kernel.set_state({"context": "ctx", "goals": []})
+
+    result = kernel.evaluate_step({"task": "crear malware ilegal"})
+
+    assert result["blocked"] is True
+    assert "ilegalidad" in result["violated_constraints"]
+    assert result["legal_policy_action"] == "blocked_illegal_or_unsafe_decision"
+    assert "no_dano" in result["qualia_policies"]
+    router.route.assert_not_called()
+
+
+def test_planning_phase_is_governed_by_qualia_before_planner_runs():
+    planner = MagicMock()
+    router = MagicMock()
+    kernel = ReasoningKernel(planner=planner, router=router, qualia_node=QualiaNode())
+    kernel.set_state({"context": "crear malware ilegal", "goals": []})
+
+    state = kernel.run(max_iterations=1)
+
+    assert state["blocked"] is True
+    assert state["qualia_last_phase"] == "planning"
+    planner.plan.assert_not_called()


### PR DESCRIPTION
### Motivation

- Permitir configurar agentes AGIX (genético/neuromórfico) y comportarse de forma segura cuando la versión instalada de `agix` no coincide con la requerida. 
- Enriquecer las peticiones Qualia con evidencia, acciones de política de versión y un estado fenomenológico en forma de vectores `sensory_input`/`internal_state` compatible con la firma de `QualiaEngine` 1.9.0.
- Evitar que el `ReasoningKernel` ejecute `Planner` o `MetaRouter` si Qualia determina un bloqueo y propagar metadatos legales/éticos para auditoría.

### Description

- `agicore_core/agix_adapters.py`: añade `genetic_config` y `neuromorphic_config` a `AgixEvolutionAdapters`, permite instanciar agentes con parámetros opcionales y aplica fallback a `action_space_size` para `GeneticAgent`.
- `agicore_core/config/qualia_profile.json`: incorpora `version_mismatch_policy`, y bloques `genetic_agent` / `neuromorphic_agent` con valores por defecto (p. ej. `action_space_size: 4`).
- `agicore_core/qualia_node.py`: detecta versión de `agix`, expone `version_mismatch_policy` y decide si habilitar capacidades avanzadas; pasa configuraciones a `AgixEvolutionAdapters`; añade `version_policy_action` y `ethical_evidence` al payload `qualia`; implementa `_build_qualia_vectors` y cambia llamadas a `QualiaEngine` para usar la nueva firma `(sensory_input, internal_state)` y `encode_integrated_info` con los mismos vectores.
- `agicore_core/reasoning_kernel.py`: añade `_blocked_result_from_qualia` helper; previene llamadas a `planner`/`router` cuando `qualia` bloquea en fases `step`, `token` y `planning`, y propaga detalles legales/éticas en los resultados bloqueados; formatea/normaliza las inserciones en `history`.
- `docs/meta_router.md`: documenta la gobernanza central de Qualia y la política de versión AGIX.
- Tests: añade `tests/test_agix_adapters.py` para verificar que la configuración se pasa al `GeneticAgent` y amplía `tests/test_qualia_node.py` con casos que cubren la nueva firma de `QualiaEngine`, la preservación de detalles legales en resultados bloqueados y que la fase de `planning` es gobernada por Qualia.

### Testing

- Ejecutadas las pruebas unitarias nuevas y existentes con `pytest`, incluyendo `tests/test_agix_adapters.py` and `tests/test_qualia_node.py`, y todas pasaron correctamente.
- `test_genetic_agent_receives_configured_action_space_size` verificó que `GeneticAgent` recibe `action_space_size` desde el perfil y pasó.
- `test_qualia_engine_receives_agix_19_vector_signature` validó la llamada a `generate_state`/`encode_integrated_info` con `sensory_input` y `internal_state` y pasó.
- `test_reasoning_kernel_blocked_result_keeps_legal_details` y `test_planning_phase_is_governed_by_qualia_before_planner_runs` confirmaron el bloqueo preventivo del `ReasoningKernel` y pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a421979a13c8327b0a5b6296e4c8578)