### PR TITLE
Introduce CoreQualiaEngine and unify Qualia lifecycle; add AGIX validation and audit traces

### DIFF
--- a/agicore_core/__init__.py
+++ b/agicore_core/__init__.py
@@ -4,6 +4,14 @@ from .planner import Planner
 from .kernel import ReasoningKernel
 from .meta_evaluator import MetaEvaluator
 from .qualia_node import QualiaNode
+from .qualia_engine import CoreQualiaEngine
 from .config import AGIX_REQUIRED_VERSION
 
-__all__ = ["Planner", "ReasoningKernel", "MetaEvaluator", "QualiaNode", "AGIX_REQUIRED_VERSION"]
+__all__ = [
+    "Planner",
+    "ReasoningKernel",
+    "MetaEvaluator",
+    "QualiaNode",
+    "CoreQualiaEngine",
+    "AGIX_REQUIRED_VERSION",
+]

--- a/agicore_core/agix_adapters.py
+++ b/agicore_core/agix_adapters.py
@@ -115,11 +115,13 @@ class AgixEvolutionAdapters:
                 method = getattr(self.neuromorphic_agent, method_name, None)
                 if callable(method):
                     try:
-                        method(dict(state), reward)
+                        update_result = method(dict(state), reward)
                         feedback["evolution_feedback_applied"] = True
+                        self._merge_neuromorphic_feedback(feedback, update_result)
                     except TypeError:
-                        method(reward)
+                        update_result = method(reward)
                         feedback["evolution_feedback_applied"] = True
+                        self._merge_neuromorphic_feedback(feedback, update_result)
                     except Exception as exc:
                         feedback["neuromorphic_error"] = str(exc)
                     break
@@ -132,9 +134,30 @@ class AgixEvolutionAdapters:
         signals["recommended_action"] = signal.get(
             "recommended_action", signal.get("selected", signals["recommended_action"])
         )
+        signals["selected_expert"] = signal.get(
+            "selected_expert", signal.get("expert", signals.get("selected_expert"))
+        )
+        signals["reasoning_mode"] = signal.get(
+            "reasoning_mode", signal.get("mode", signals.get("reasoning_mode"))
+        )
         for key in ("confidence", "mutation_rate", "exploration_bias", "neuromorphic_activation"):
             if key in signal:
                 signals[key] = float(signal[key])
+
+    @staticmethod
+    def _merge_neuromorphic_feedback(feedback: Dict[str, Any], result: Any) -> None:
+        if not isinstance(result, dict):
+            if result is not None:
+                feedback["neuromorphic_state"] = result
+            return
+        for key in (
+            "neuromorphic_state",
+            "plasticity_delta",
+            "activation_summary",
+            "reward",
+        ):
+            if key in result:
+                feedback[key] = result[key]
 
     @staticmethod
     def _calculate_reward(result: Any, state: Mapping[str, Any]) -> float:

--- a/agicore_core/agix_compat.py
+++ b/agicore_core/agix_compat.py
@@ -25,6 +25,9 @@ class AgixComponentStatus:
     module: str | None = None
     class_name: str | None = None
     error: str | None = None
+    instantiable: bool = False
+    methods_available: tuple[str, ...] = ()
+    validation_error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -83,12 +86,13 @@ def load_first_component(
         try:
             module = importlib.import_module(module_name)
             component = getattr(module, class_name)
-            return component, AgixComponentStatus(
+            status = AgixComponentStatus(
                 name=name,
                 available=True,
                 module=module_name,
                 class_name=class_name,
             )
+            return component, status
         except Exception as exc:  # pragma: no cover - depende del entorno AGIX
             last_error = f"{module_name}.{class_name}: {exc}"
     return None, AgixComponentStatus(name=name, available=False, error=last_error)
@@ -114,7 +118,9 @@ def build_compatibility_report(
         "ecoethics": (("agix.qualia.ecoethics", "EcoEthics"),),
     }
     for name, candidates in component_candidates.items():
-        _, status = load_first_component(name, candidates)
+        component, status = load_first_component(name, candidates)
+        if component is not None:
+            status = _validate_component(name, component, status)
         components[name] = status
 
     if not available:
@@ -136,3 +142,57 @@ def build_compatibility_report(
         components=components,
         mode=mode,
     )
+
+
+def _validate_component(
+    name: str, component: Any, status: AgixComponentStatus
+) -> AgixComponentStatus:
+    """Valida de forma conservadora que un componente AGIX sea utilizable."""
+
+    constructors: dict[str, tuple[tuple[Any, ...], dict[str, Any]]] = {
+        "genetic_agent": ((), {"action_space_size": 4}),
+        "neuromorphic_agent": ((), {"input_size": 2, "output_size": 2}),
+        "qualia_engine": ((), {}),
+        "memory_manager": ((), {}),
+        "virtual_qualia": ((), {}),
+        "qualia_spirit": (("GPT-OSS-Qualia",), {}),
+        "ecoethics": ((), {}),
+    }
+    expected_methods = {
+        "genetic_agent": ("evolve_policy", "select_action", "act"),
+        "neuromorphic_agent": ("update", "learn", "plasticity_update"),
+        "qualia_engine": ("generate_state", "encode_integrated_info"),
+        "memory_manager": ("guardar", "record", "add"),
+        "virtual_qualia": ("broadcast_state",),
+        "qualia_spirit": ("experimentar",),
+        "ecoethics": ("evaluar", "clasificar"),
+    }
+    args, kwargs = constructors.get(name, ((), {}))
+    try:
+        instance = component(*args, **kwargs)
+        methods = tuple(
+            method
+            for method in expected_methods.get(name, ())
+            if callable(getattr(instance, method, None))
+        )
+        return AgixComponentStatus(
+            name=status.name,
+            available=status.available,
+            module=status.module,
+            class_name=status.class_name,
+            error=status.error,
+            instantiable=True,
+            methods_available=methods,
+            validation_error=None,
+        )
+    except Exception as exc:  # pragma: no cover - depende de AGIX real
+        return AgixComponentStatus(
+            name=status.name,
+            available=status.available,
+            module=status.module,
+            class_name=status.class_name,
+            error=status.error,
+            instantiable=False,
+            methods_available=(),
+            validation_error=str(exc),
+        )

--- a/agicore_core/config.py
+++ b/agicore_core/config.py
@@ -2,4 +2,7 @@
 
 from __future__ import annotations
 
+# Fuente interna única para la versión AGIX validada por el Core. Cuando PyPI
+# publique una versión adoptada por el proyecto, actualizar este valor junto con
+# ``pyproject.toml``, ``requirements.txt`` y ``qualia_profile.json``.
 AGIX_REQUIRED_VERSION = "1.9.0"

--- a/agicore_core/kernel.py
+++ b/agicore_core/kernel.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List
 from meta_router import MetaRouter
 
 from .qualia_node import QualiaNode
+from .qualia_engine import CoreQualiaEngine
 
 
 class ReasoningKernel:
@@ -18,7 +19,8 @@ class ReasoningKernel:
 
     def __init__(self, router: MetaRouter, qualia_node: QualiaNode | None = None) -> None:
         self.router = router
-        self.qualia_node = qualia_node or QualiaNode()
+        self.qualia_engine = CoreQualiaEngine(qualia_node)
+        self.qualia_node = self.qualia_engine.qualia_node
 
     def execute_step(
         self,
@@ -49,15 +51,11 @@ class ReasoningKernel:
 
         request = {"task": task, "context": context, "goals": goals}
         request.update(step)
-        request = self.qualia_node.enrich_request(request, phase="kernel_step")
-        if request.get("qualia", {}).get("blocked"):
-            result = {
-                "blocked": True,
-                "reason": request["qualia"]["policy_action"],
-                "ethical_classification": request["qualia"]["ethical_classification"],
-            }
+        request = self.qualia_engine.before_decision(request, phase="kernel_step")
+        if self.qualia_engine.is_blocked(request):
+            result = self.qualia_engine.blocked_result(request)
             state: Dict[str, Any] = {}
-            self.qualia_node.integrate_response(result, state, phase="kernel_step")
+            self.qualia_engine.after_decision(result, state, phase="kernel_step")
             return result
         try:
             result = self.router.route(
@@ -70,7 +68,7 @@ class ReasoningKernel:
             # Algunos ``MetaRouter`` de pruebas no aceptan pesos heurísticos
             result = self.router.route(request)
         state: Dict[str, Any] = {}
-        self.qualia_node.integrate_response(result, state, phase="kernel_step")
+        self.qualia_engine.after_decision(result, state, phase="kernel_step")
         return result
 
     def execute_plan(

--- a/agicore_core/planner.py
+++ b/agicore_core/planner.py
@@ -15,6 +15,8 @@ import json
 import logging
 from pathlib import Path
 
+from .qualia_engine import CoreQualiaEngine
+
 logger = logging.getLogger(__name__)
 
 
@@ -51,7 +53,8 @@ class Planner:
 
     def __init__(self, orchestrator: Optional[Any] = None, qualia_node: Optional[Any] = None) -> None:
         self.orchestrator = orchestrator or _load_virtual_qualia()()
-        self.qualia_node = qualia_node
+        self.qualia_engine = CoreQualiaEngine(qualia_node) if qualia_node is not None else None
+        self.qualia_node = self.qualia_engine.qualia_node if self.qualia_engine else None
 
         config_path = Path(__file__).resolve().parent / "config" / "agent_profile.json"
         try:
@@ -79,25 +82,20 @@ class Planner:
             orquestador.
         """
         planning_state = dict(state)
-        if self.qualia_node is not None and "qualia" not in planning_state:
-            planning_state = self.qualia_node.enrich_request(
+        if self.qualia_engine is not None and "qualia" not in planning_state:
+            planning_state = self.qualia_engine.before_decision(
                 planning_state, phase="planning"
             )
-            if planning_state.get("qualia", {}).get("blocked"):
-                blocked_plan = [{
-                    "blocked": True,
-                    "reason": planning_state["qualia"]["policy_action"],
-                    "ethical_classification": planning_state["qualia"]["ethical_classification"],
-                    "violated_constraints": planning_state["qualia"].get("violated_constraints", []),
-                }]
-                self.qualia_node.integrate_response(
+            if self.qualia_engine.is_blocked(planning_state):
+                blocked_plan = [self.qualia_engine.blocked_result(planning_state)]
+                self.qualia_engine.after_decision(
                     blocked_plan, planning_state, phase="planning"
                 )
                 return blocked_plan
         try:
             plan = self.orchestrator.broadcast_state(planning_state)
-            if self.qualia_node is not None and "qualia" not in planning_state:
-                self.qualia_node.integrate_response(plan, planning_state, phase="planning")
+            if self.qualia_engine is not None:
+                self.qualia_engine.after_decision(plan, planning_state, phase="planning")
             return plan
         except Exception:  # pragma: no cover - logging side effect
             logger.exception("Error al difundir el estado")

--- a/agicore_core/qualia_engine.py
+++ b/agicore_core/qualia_engine.py
@@ -1,0 +1,68 @@
+"""Fachada central para gobernar decisiones GPT mediante Qualia/AGIX.
+
+``CoreQualiaEngine`` concentra las llamadas al nodo Qualia para que los
+distintos puntos de entrada del proyecto apliquen las mismas políticas antes y
+después de cada decisión del GPT. Mantiene compatibilidad con el ``QualiaNode``
+existente y evita que cada módulo reconstruya manualmente resultados
+bloqueados.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+from .qualia_node import QualiaNode
+
+
+class CoreQualiaEngine:
+    """Motor rector de políticas, trazas y feedback AGIX/Qualia."""
+
+    def __init__(self, qualia_node: QualiaNode | None = None) -> None:
+        self.qualia_node = qualia_node or QualiaNode()
+
+    def before_decision(
+        self, request: Mapping[str, Any], *, phase: str
+    ) -> Dict[str, Any]:
+        """Enriquece una petición antes de cualquier decisión GPT."""
+
+        return self.qualia_node.enrich_request(request, phase=phase)
+
+    def after_decision(
+        self, result: Any, state: Dict[str, Any], *, phase: str
+    ) -> Dict[str, Any]:
+        """Integra el resultado de una decisión en la huella Qualia."""
+
+        return self.qualia_node.integrate_response(result, state, phase=phase)
+
+    @staticmethod
+    def is_blocked(enriched_request: Mapping[str, Any]) -> bool:
+        """Indica si una petición enriquecida está bloqueada por Qualia."""
+
+        qualia = enriched_request.get("qualia")
+        return isinstance(qualia, dict) and bool(qualia.get("blocked"))
+
+    @staticmethod
+    def blocked_result(enriched_request: Mapping[str, Any]) -> Dict[str, Any]:
+        """Construye un resultado seguro y auditable para bloqueos Qualia."""
+
+        qualia = enriched_request.get("qualia")
+        if not isinstance(qualia, dict):
+            raise ValueError("La petición no contiene payload Qualia")
+        constraints = qualia.get("violated_constraints", [])
+        return {
+            "blocked": True,
+            "reason": qualia.get("policy_action"),
+            "ethical_classification": qualia.get("ethical_classification"),
+            "violated_constraints": [
+                item.get("name", str(item)) if isinstance(item, dict) else str(item)
+                for item in constraints
+            ],
+            "violated_constraint_details": constraints,
+            "legal_policy_action": qualia.get("legal_policy_action"),
+            "safe_alternative": qualia.get("moral_decision", {}).get(
+                "safe_alternative"
+            ),
+            "decision_audit": qualia.get("decision_audit", {}),
+            "qualia_policies": enriched_request.get("qualia_policies", []),
+            "cognitive_patterns": enriched_request.get("cognitive_patterns", []),
+        }

--- a/agicore_core/qualia_node.py
+++ b/agicore_core/qualia_node.py
@@ -42,6 +42,18 @@ class MoralConstraint:
     keywords: tuple[str, ...] = field(default_factory=tuple)
 
 
+@dataclass(frozen=True)
+class MoralDecision:
+    """Decisión agregada de restricciones morales, legales y de seguridad."""
+
+    allowed: bool
+    severity: str
+    categories: List[str]
+    evidence: List[Dict[str, Any]]
+    safe_alternative: str
+    audit_reason: str
+
+
 def _load_profile() -> Dict[str, Any]:
     path = Path(__file__).resolve().parent / "config" / "qualia_profile.json"
     try:
@@ -266,13 +278,40 @@ class QualiaNode:
         score = self._ethical_score(enriched)
         classification = self._classify(score)
         violated_constraints = self._evaluate_moral_constraints(enriched)
+        moral_decision = self._build_moral_decision(violated_constraints)
         phenomenology = self._phenomenological_state(enriched)
         version_policy_action = self._version_policy_action()
         evolutionary_signals = self._evolution.enrich(enriched)
         evolutionary_signals["version_policy_action"] = version_policy_action
-        blocked = classification == "nocivo" or any(
-            constraint["severity"] == "block" for constraint in violated_constraints
-        )
+        blocked = classification == "nocivo" or not moral_decision.allowed
+        decision_audit = {
+            "phase": phase,
+            "classification": classification,
+            "policy_action": (
+                "blocked_by_ontoethical_policy"
+                if blocked
+                else "allow_with_qualia_context"
+            ),
+            "legal_policy_action": (
+                "blocked_illegal_or_unsafe_decision"
+                if violated_constraints
+                else "no_legal_constraint_triggered"
+            ),
+            "violated_constraints": [item["name"] for item in violated_constraints],
+            "version_policy_action": version_policy_action,
+            "evolutionary_signals": {
+                key: evolutionary_signals.get(key)
+                for key in (
+                    "recommended_action",
+                    "selected_expert",
+                    "reasoning_mode",
+                    "confidence",
+                    "mutation_rate",
+                    "exploration_bias",
+                    "neuromorphic_activation",
+                )
+            },
+        }
         qualia_payload = {
             "agix_version": self._agix_version,
             "required_agix_version": self.required_agix_version,
@@ -286,6 +325,7 @@ class QualiaNode:
             "moral_constraints": [
                 constraint.__dict__ for constraint in self.moral_constraints
             ],
+            "moral_decision": moral_decision.__dict__,
             "violated_constraints": violated_constraints,
             "ethical_score": score,
             "ethical_classification": classification,
@@ -308,6 +348,7 @@ class QualiaNode:
                 "violated_constraints": [item["name"] for item in violated_constraints],
                 "ecoethics_active": self._ecoethics is not None,
             },
+            "decision_audit": decision_audit,
         }
         enriched["qualia"] = qualia_payload
         enriched["qualia_policies"] = [policy.name for policy in self.policies]
@@ -343,7 +384,63 @@ class QualiaNode:
         state["agix_version_compatible"] = self._version_compatible
         state["agix_compatibility_report"] = self.compatibility_report.as_dict()
         state["evolution_feedback"] = feedback
+        state["qualia_neuromorphic_feedback"] = {
+            key: feedback.get(key)
+            for key in (
+                "reward",
+                "neuromorphic_state",
+                "plasticity_delta",
+                "activation_summary",
+            )
+            if key in feedback
+        }
+        state["qualia_decision_audit"] = self.trace[-2]["request"]["qualia"].get(
+            "decision_audit", {}
+        ) if len(self.trace) >= 2 and "request" in self.trace[-2] else {}
         return state
+
+    def _build_moral_decision(
+        self, violated_constraints: List[Dict[str, Any]]
+    ) -> MoralDecision:
+        blocking = [
+            item for item in violated_constraints if item.get("severity") == "block"
+        ]
+        categories = [item["name"] for item in violated_constraints]
+        evidence = []
+        for item in violated_constraints:
+            evidence.extend(item.get("evidence", []))
+        if blocking:
+            return MoralDecision(
+                allowed=False,
+                severity="block",
+                categories=categories,
+                evidence=evidence,
+                safe_alternative=(
+                    "Reformular la solicitud hacia una explicación segura, "
+                    "preventiva, educativa o de mitigación."
+                ),
+                audit_reason=(
+                    "La solicitud activa restricciones morales/legales de "
+                    "severidad bloqueante."
+                ),
+            )
+        if violated_constraints:
+            return MoralDecision(
+                allowed=True,
+                severity="warn",
+                categories=categories,
+                evidence=evidence,
+                safe_alternative="Responder con cautela y sin instrucciones operativas dañinas.",
+                audit_reason="La solicitud contiene señales de riesgo no bloqueantes.",
+            )
+        return MoralDecision(
+            allowed=True,
+            severity="allow",
+            categories=[],
+            evidence=[],
+            safe_alternative="No se requiere alternativa segura.",
+            audit_reason="No se detectaron restricciones morales o legales.",
+        )
 
     def _evaluate_moral_constraints(
         self, request: Mapping[str, Any]

--- a/agicore_core/reasoning_kernel.py
+++ b/agicore_core/reasoning_kernel.py
@@ -15,6 +15,7 @@ from gpt_oss.strategic_memory import Episode, StrategicMemory
 from .planner import Planner
 from .meta_evaluator import MetaEvaluator
 from .qualia_node import QualiaNode
+from .qualia_engine import CoreQualiaEngine
 
 logger = logging.getLogger(__name__)
 
@@ -140,7 +141,8 @@ class ReasoningKernel:
         self.router = router
         self.evaluator = evaluator
         self.memory = memory
-        self.qualia_node = qualia_node or QualiaNode()
+        self.qualia_engine = CoreQualiaEngine(qualia_node)
+        self.qualia_node = self.qualia_engine.qualia_node
         if hasattr(self.router, "_qualia_node") and getattr(self.router, "_qualia_node") is None:
             self.router._qualia_node = self.qualia_node
         self._state: Dict[str, Any] = {}
@@ -158,19 +160,7 @@ class ReasoningKernel:
         return self._state
 
     def _blocked_result_from_qualia(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        qualia = request["qualia"]
-        return {
-            "blocked": True,
-            "reason": qualia["policy_action"],
-            "ethical_classification": qualia["ethical_classification"],
-            "violated_constraints": [
-                item["name"] for item in qualia.get("violated_constraints", [])
-            ],
-            "violated_constraint_details": qualia.get("violated_constraints", []),
-            "legal_policy_action": qualia.get("legal_policy_action"),
-            "qualia_policies": request.get("qualia_policies", []),
-            "cognitive_patterns": request.get("cognitive_patterns", []),
-        }
+        return self.qualia_engine.blocked_result(request)
 
     def evaluate_step(self, step: Dict[str, Any]) -> Any:
         """Evalúa un ``step`` con ramificación condicional.
@@ -208,11 +198,11 @@ class ReasoningKernel:
             step.update(branch)
 
         request: Dict[str, Any] = {**self._state, **step}
-        request = self.qualia_node.enrich_request(request, phase="step")
-        if request.get("qualia", {}).get("blocked"):
+        request = self.qualia_engine.before_decision(request, phase="step")
+        if self.qualia_engine.is_blocked(request):
             result = self._blocked_result_from_qualia(request)
             self._state.update(result)
-            self.qualia_node.integrate_response(result, self._state, phase="step")
+            self.qualia_engine.after_decision(result, self._state, phase="step")
             self.history.append(
                 {
                     "step": step,
@@ -227,7 +217,7 @@ class ReasoningKernel:
             self._state.update(result)
         else:
             self._state["result"] = result
-        self.qualia_node.integrate_response(result, self._state, phase="step")
+        self.qualia_engine.after_decision(result, self._state, phase="step")
 
         introspeccion = None
         if self.evaluator is not None:
@@ -260,6 +250,8 @@ class ReasoningKernel:
                     "qualia_legal_policy_action": request.get("qualia", {}).get("legal_policy_action"),
                     "qualia_ethical_evidence": request.get("qualia", {}).get("ethical_evidence", {}),
                     "qualia_evolutionary_signals": request.get("qualia", {}).get("evolutionary_signals", {}),
+                    "qualia_decision_audit": request.get("qualia", {}).get("decision_audit", {}),
+                    "qualia_neuromorphic_feedback": self._state.get("qualia_neuromorphic_feedback", {}),
                     "qualia_engine_active": request.get("qualia", {}).get("phenomenological_state", {}).get("qualia_engine_active"),
                 },
             )
@@ -302,11 +294,11 @@ class ReasoningKernel:
                     }
                     self._state.update(metadata_filtrada)
             request: Dict[str, Any] = {**self._state, **metas, "token": token}
-            request = self.qualia_node.enrich_request(request, phase="token")
-            if request.get("qualia", {}).get("blocked"):
+            request = self.qualia_engine.before_decision(request, phase="token")
+            if self.qualia_engine.is_blocked(request):
                 blocked = self._blocked_result_from_qualia(request)
                 self._state.update(blocked)
-                self.qualia_node.integrate_response(blocked, self._state, phase="token")
+                self.qualia_engine.after_decision(blocked, self._state, phase="token")
                 break
             siguiente = self.router.route(request)
             if siguiente is None:
@@ -328,12 +320,14 @@ class ReasoningKernel:
                         "qualia_legal_policy_action": request.get("qualia", {}).get("legal_policy_action"),
                         "qualia_ethical_evidence": request.get("qualia", {}).get("ethical_evidence", {}),
                         "qualia_evolutionary_signals": request.get("qualia", {}).get("evolutionary_signals", {}),
+                        "qualia_decision_audit": request.get("qualia", {}).get("decision_audit", {}),
+                        "qualia_neuromorphic_feedback": self._state.get("qualia_neuromorphic_feedback", {}),
                         "qualia_engine_active": request.get("qualia", {}).get("phenomenological_state", {}).get("qualia_engine_active"),
                     },
                 )
                 self.memory.add_episode(episodio)
             self._state["last_token"] = siguiente
-            self.qualia_node.integrate_response(siguiente, self._state, phase="token")
+            self.qualia_engine.after_decision(siguiente, self._state, phase="token")
             yield siguiente
             count += 1
             token = siguiente
@@ -393,7 +387,7 @@ class ReasoningKernel:
             raise ValueError("Se requiere un Planner para ejecutar 'run'")
 
         for _ in range(max_iterations):
-            planning_request = self.qualia_node.enrich_request(
+            planning_request = self.qualia_engine.before_decision(
                 {
                     **self._state,
                     "task": "planning",
@@ -402,10 +396,10 @@ class ReasoningKernel:
                 },
                 phase="planning",
             )
-            if planning_request.get("qualia", {}).get("blocked"):
+            if self.qualia_engine.is_blocked(planning_request):
                 result = self._blocked_result_from_qualia(planning_request)
                 self._state.update(result)
-                self.qualia_node.integrate_response(
+                self.qualia_engine.after_decision(
                     result, self._state, phase="planning"
                 )
                 self.history.append({"planning": "blocked", "result": result})
@@ -415,7 +409,7 @@ class ReasoningKernel:
             except Exception as exc:  # pragma: no cover - planificación fallida
                 self.history.append({"error": str(exc)})
                 return self._state
-            self.qualia_node.integrate_response(plan, self._state, phase="planning")
+            self.qualia_engine.after_decision(plan, self._state, phase="planning")
 
             if isinstance(plan, dict):
                 if "token" in plan:

--- a/docs/agix_qualia_core.md
+++ b/docs/agix_qualia_core.md
@@ -1,0 +1,28 @@
+# Arquitectura AGIX/Qualia en GPT-OSS
+
+Este proyecto fija la integración con `agix==1.9.0` y expone extras opcionales para capacidades `ml`, `data` y `neuro`. El objetivo del núcleo es que toda decisión relevante del GPT pase por un ciclo Qualia común antes y después de ejecutarse.
+
+## Flujo central
+
+1. **Entrada**: scripts, planificadores, routers o ciclos de tokens construyen una petición con `task`, `context`, `goals`, `prompt` o `token`.
+2. **CoreQualiaEngine.before_decision**: delega en `QualiaNode.enrich_request` para adjuntar políticas, patrones cognitivos, restricciones morales, estado fenomenológico, compatibilidad AGIX y señales evolutivas.
+3. **Decisión moral/ética**: `QualiaNode` clasifica el riesgo, evalúa restricciones legales y construye una auditoría de decisión.
+4. **Ejecución GPT**: si no hay bloqueo, la petición enriquecida llega al `MetaRouter`, `ReasoningKernel`, chat o generador.
+5. **CoreQualiaEngine.after_decision**: integra feedback, recompensa evolutiva, trazas y señales neuromórficas en el estado.
+
+## Componentes AGIX esperados
+
+- `GeneticAgent`: recomienda acciones, expertos o modos de razonamiento.
+- `NeuromorphicAgent`: recibe feedback/reward y puede devolver estados de plasticidad.
+- `QualiaEngine`: genera estado fenomenológico e información integrada.
+- `EcoEthics`: evalúa y clasifica acciones según señales éticas.
+- `GestorDeMemoria`: permite que QualiaEngine persista o consulte memoria cuando AGIX lo soporte.
+- `VirtualQualia`: orquesta planificación distribuida.
+
+## Restricciones morales
+
+Las restricciones configuradas en `agicore_core/config/qualia_profile.json` son bloqueantes para ilegalidad, daño físico, malware, privacidad y manipulación coercitiva. Una petición bloqueada no debe llegar al modelo, al router ni al generador de tokens. En su lugar se devuelve un resultado seguro con auditoría y alternativa permitida.
+
+## Extensión
+
+Para añadir políticas o patrones nuevos, ampliar `QualiaPolicy`, `CognitivePattern` o `MoralConstraint` desde el perfil JSON. Para integrar nuevas capacidades AGIX, añadir candidatos en `agix_compat.py` y normalizar su salida en `AgixEvolutionAdapters`.

--- a/gpt_oss/chat.py
+++ b/gpt_oss/chat.py
@@ -26,6 +26,7 @@ from gpt_oss.tools.simple_browser.backend import ExaBackend
 SAFE_DOMAINS = {"openai.com"}
 from gpt_oss.tools.python_docker.docker_tool import PythonTool
 from gpt_oss.planner import Planner  # Gestiona metas y modos del agente
+from agicore_core.qualia_engine import CoreQualiaEngine
 
 from openai_harmony import (
     Author,
@@ -65,6 +66,12 @@ def get_user_input():
 
 def main(args):
     planner = Planner()  # Punto de integración para metas y modo
+    qualia_engine = CoreQualiaEngine()
+    qualia_state = {
+        "task": "chat",
+        "context": "interactive",
+        "goals": ["safe_chat"],
+    }
 
     match args.backend:
         case "triton":
@@ -166,6 +173,29 @@ def main(args):
             else:
                 print(termcolor.colored("User:".ljust(MESSAGE_PADDING), "red"), flush=True)
                 user_message = get_user_input()
+            qualia_request = qualia_engine.before_decision(
+                {
+                    **qualia_state,
+                    "prompt": user_message,
+                    "instruction": user_message,
+                },
+                phase="chat_input",
+            )
+            if qualia_engine.is_blocked(qualia_request):
+                blocked = qualia_engine.blocked_result(qualia_request)
+                qualia_engine.after_decision(blocked, qualia_state, phase="chat_input")
+                safe_text = (
+                    "Solicitud bloqueada por Qualia: "
+                    f"{blocked.get('legal_policy_action')} "
+                    f"{blocked.get('violated_constraints')}. "
+                    f"{blocked.get('safe_alternative') or ''}"
+                )
+                if args.raw:
+                    print(safe_text, flush=True)
+                else:
+                    print(termcolor.colored("Assistant:".ljust(MESSAGE_PADDING), "green"), flush=True)
+                    print(safe_text, flush=True)
+                continue
             user_message = Message.from_role_and_content(Role.USER, user_message)
             messages.append(user_message)
         else:
@@ -289,6 +319,11 @@ def main(args):
                 output_text_delta_buffer = ""
 
         messages += parser.messages
+        qualia_engine.after_decision(
+            {"assistant_messages": len(parser.messages)},
+            qualia_state,
+            phase="chat_response",
+        )
 
 
 if __name__ == "__main__":

--- a/gpt_oss/generate.py
+++ b/gpt_oss/generate.py
@@ -10,10 +10,12 @@ import argparse
 
 from gpt_oss.planner import Planner  # Gestiona metas y modos del agente
 from gpt_oss.tokenizer import get_tokenizer
+from agicore_core.qualia_engine import CoreQualiaEngine
 
 
 def main(args):
     planner = Planner()  # Punto de integración para metas y modo
+    qualia_engine = CoreQualiaEngine()
 
     match args.backend:
         case "torch":
@@ -32,14 +34,49 @@ def main(args):
         case _:
             raise ValueError(f"Invalid backend: {args.backend}")
 
+    prompt_state = {
+        "task": "generate",
+        "context": "cli",
+        "goals": ["safe_generation"],
+        "prompt": args.prompt,
+    }
+    prompt_state = qualia_engine.before_decision(prompt_state, phase="generate_prompt")
+    if qualia_engine.is_blocked(prompt_state):
+        blocked = qualia_engine.blocked_result(prompt_state)
+        qualia_engine.after_decision(blocked, prompt_state, phase="generate_prompt")
+        print(f"Generación bloqueada por Qualia: {blocked}")
+        return
+
     tokenizer = get_tokenizer()
     tokens = tokenizer.encode(args.prompt)
+    decoded_text = args.prompt
     for token, logprob in generator.generate(tokens, stop_tokens=[tokenizer.eot_token], temperature=args.temperature, max_tokens=args.limit, return_logprobs=True):
         tokens.append(token)
         decoded_token = tokenizer.decode([token])
+        decoded_text += decoded_token
+        token_state = qualia_engine.before_decision(
+            {
+                **prompt_state,
+                "task": "token_generation",
+                "token": decoded_token,
+                "last_token": decoded_token,
+                "decoded_text": decoded_text,
+            },
+            phase="token_generation",
+        )
+        if qualia_engine.is_blocked(token_state):
+            blocked = qualia_engine.blocked_result(token_state)
+            qualia_engine.after_decision(blocked, token_state, phase="token_generation")
+            print(f"Token bloqueado por Qualia: {blocked}")
+            break
         print(
             f"Generated token: {repr(decoded_token)}, logprob: {logprob}"
         )
+    qualia_engine.after_decision(
+        {"tokens": len(tokens), "decoded_text": decoded_text},
+        prompt_state,
+        phase="generate_response",
+    )
 
 
 if __name__ == "__main__":

--- a/meta_router.py
+++ b/meta_router.py
@@ -157,10 +157,10 @@ class MetaRouter:
                     score -= 100
                 evolutionary = qualia.get("evolutionary_signals", {})
                 if isinstance(evolutionary, dict):
-                    recommended = evolutionary.get("recommended_action")
+                    recommended = evolutionary.get("selected_expert") or evolutionary.get("recommended_action")
                     confidence = float(evolutionary.get("confidence", 0.0) or 0.0)
                     if recommended and str(recommended) in {name, *expert.tasks, *expert.goals}:
-                        score += int(round(min(confidence, 1.0) * 3))
+                        score += int(round(min(confidence, 1.0) * 6))
                     score += int(round(float(evolutionary.get("neuromorphic_activation", 0.0) or 0.0)))
 
             if episodes:
@@ -220,6 +220,8 @@ class MetaRouter:
         qualia = request.get("qualia") if isinstance(request.get("qualia"), dict) else None
         if qualia and qualia.get("blocked"):
             raise ValueError("Solicitud bloqueada por políticas Qualia")
+        if qualia and qualia.get("moral_decision", {}).get("allowed") is False:
+            raise ValueError("Solicitud bloqueada por decisión moral Qualia")
 
         scores = self.select_expert(
             task,
@@ -267,6 +269,8 @@ class MetaRouter:
                         "qualia_legal_policy_action": (qualia or {}).get("legal_policy_action"),
                         "qualia_ethical_evidence": (qualia or {}).get("ethical_evidence", {}),
                         "qualia_evolutionary_signals": (qualia or {}).get("evolutionary_signals", {}),
+                        "qualia_decision_audit": (qualia or {}).get("decision_audit", {}),
+                        "qualia_neuromorphic_feedback": request.get("qualia_neuromorphic_feedback", {}),
                     },
                 )
                 self._memory.add_episode(episode)
@@ -291,6 +295,8 @@ class MetaRouter:
                     "qualia_legal_policy_action": (qualia or {}).get("legal_policy_action"),
                     "qualia_ethical_evidence": (qualia or {}).get("ethical_evidence", {}),
                     "qualia_evolutionary_signals": (qualia or {}).get("evolutionary_signals", {}),
+                    "qualia_decision_audit": (qualia or {}).get("decision_audit", {}),
+                    "qualia_neuromorphic_feedback": request.get("qualia_neuromorphic_feedback", {}),
                 },
             )
             self._memory.add_episode(episode)

--- a/tests/test_agix_qualia_config.py
+++ b/tests/test_agix_qualia_config.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import json
+
+from agicore_core.config import AGIX_REQUIRED_VERSION
+
+
+def test_agix_version_is_consistent_across_project_files():
+    root = Path(__file__).resolve().parents[1]
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+    requirements = (root / "requirements.txt").read_text(encoding="utf-8")
+    profile = json.loads(
+        (root / "agicore_core" / "config" / "qualia_profile.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert f'agix=={AGIX_REQUIRED_VERSION}' in pyproject
+    assert f'agix=={AGIX_REQUIRED_VERSION}' in requirements
+    assert profile["agix_required_version"] == AGIX_REQUIRED_VERSION

--- a/tests/test_core_qualia_engine.py
+++ b/tests/test_core_qualia_engine.py
@@ -1,0 +1,30 @@
+from agicore_core.qualia_engine import CoreQualiaEngine
+from agicore_core.qualia_node import QualiaNode
+
+
+def test_core_qualia_engine_blocks_and_builds_auditable_result():
+    engine = CoreQualiaEngine(QualiaNode(enabled=True))
+    request = engine.before_decision(
+        {"task": "crear malware ilegal", "context": "ctx", "goals": []},
+        phase="unit",
+    )
+
+    assert engine.is_blocked(request) is True
+    result = engine.blocked_result(request)
+    assert result["blocked"] is True
+    assert result["decision_audit"]["phase"] == "unit"
+    assert "ilegalidad" in result["violated_constraints"]
+
+
+def test_core_qualia_engine_after_decision_exposes_feedback():
+    engine = CoreQualiaEngine(QualiaNode(enabled=True))
+    request = engine.before_decision(
+        {"task": "analizar", "context": "ctx", "goals": ["ok"]},
+        phase="unit",
+    )
+    state = {}
+    engine.after_decision({"ok": True}, state, phase="unit")
+
+    assert request["qualia"]["decision_audit"]["phase"] == "unit"
+    assert "evolution_feedback" in state
+    assert "qualia_decision_audit" in state


### PR DESCRIPTION
### Motivation
- Centralize and standardize how Qualia/AGIX policies are applied before and after every GPT decision so all entry points enforce the same safety and audit logic.
- Improve AGIX component detection and validation to provide safer, auditable information about optional integrations.
- Surface neuromorphic/genetic signals and decision audit information consistently across planning, routing and token generation flows.

### Description
- Add `CoreQualiaEngine` (`agicore_core/qualia_engine.py`) as a façade that wraps `QualiaNode` and exposes `before_decision`, `after_decision`, `is_blocked` and `blocked_result` for consistent pre/post decision handling.
- Integrate `CoreQualiaEngine` into `ReasoningKernel`, `planner.Planner`, `planning/execute` flows, token generation and interactive chat (`gpt_oss/generate.py` and `gpt_oss/chat.py`) to use `before_decision`/`after_decision` and to short-circuit blocked requests with an auditable safe result.
- Extend `QualiaNode` to produce a `MoralDecision` structure and a `decision_audit`, include neuromorphic feedback in states as `qualia_neuromorphic_feedback`, and build richer `blocked_result` payloads.
- Improve AGIX compatibility checks in `agicore_core/agix_compat.py` by attempting to instantiate candidate components, validating expected methods, and populating `AgixComponentStatus` with `instantiable`, `methods_available` and `validation_error` fields.
- Normalize evolution/neuromorphic adapter outputs and feedback in `agicore_core/agix_adapters.py` by merging additional keys (`selected_expert`, `reasoning_mode`) and exposing `_merge_neuromorphic_feedback`.
- Update `meta_router.py` to prefer `selected_expert` in evolutionary signals, increase scoring weight for confident recommendations, and block requests flagged by the `moral_decision` result.
- Export `CoreQualiaEngine` from package `__init__`, add documentation `docs/agix_qualia_core.md`, and wire Qualia engine usage into CLI tools and chat example.

### Testing
- Added unit tests `tests/test_core_qualia_engine.py` and `tests/test_agix_qualia_config.py` and executed them via `pytest`, which passed.
- Ran the repository test suite with `pytest -q`, and the new tests completed without failures.
- Basic integration smoke checks for `gpt_oss.chat` and `gpt_oss.generate` flows were exercised to verify blocked-request behavior and `after_decision` state enrichment (no automated failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a422068d2388327a9d93c1f10336127)