### PR TITLE
Integrate AGIX neuromorphic/genetic signals, moral evaluator, memory persistence and qualia governance

### DIFF
--- a/agicore_core/agix_adapters.py
+++ b/agicore_core/agix_adapters.py
@@ -100,6 +100,25 @@ class AgixEvolutionAdapters:
                     except Exception as exc:
                         signals["genetic_error"] = str(exc)
                     break
+
+        if self.neuromorphic_agent is not None:
+            vector = self._build_neuromorphic_input(request)
+            for method_name in ("activate", "forward", "infer", "decide", "process"):
+                method = getattr(self.neuromorphic_agent, method_name, None)
+                if callable(method):
+                    try:
+                        signal = method(vector)
+                    except TypeError:
+                        try:
+                            signal = method(dict(request))
+                        except TypeError:
+                            signal = method()
+                    except Exception as exc:
+                        signals["neuromorphic_error"] = str(exc)
+                        break
+                    signals["neuromorphic_signal"] = signal
+                    self._merge_neuromorphic_signal(signals, signal)
+                    break
         return signals
 
     def integrate_feedback(
@@ -128,6 +147,24 @@ class AgixEvolutionAdapters:
         return feedback
 
     @staticmethod
+    def _build_neuromorphic_input(request: Mapping[str, Any]) -> list[float]:
+        text = " ".join(
+            str(request.get(key, ""))
+            for key in ("task", "context", "prompt", "instruction", "token")
+        )
+        goals = request.get("goals", [])
+        goals_count = len(goals) if isinstance(goals, list) else 1 if goals else 0
+        qualia = request.get("qualia") if isinstance(request.get("qualia"), dict) else {}
+        violations = request.get("violated_constraints", qualia.get("violated_constraints", []))
+        violation_count = len(violations) if isinstance(violations, list) else 1 if violations else 0
+        return [
+            min(len(text) / 1000.0, 1.0),
+            min(goals_count / 10.0, 1.0),
+            min(violation_count / 5.0, 1.0),
+            float(qualia.get("ethical_score", request.get("ethical_score", 0.0)) or 0.0),
+        ]
+
+    @staticmethod
     def _merge_genetic_signal(signals: Dict[str, Any], signal: Any) -> None:
         if not isinstance(signal, dict):
             return
@@ -143,6 +180,30 @@ class AgixEvolutionAdapters:
         for key in ("confidence", "mutation_rate", "exploration_bias", "neuromorphic_activation"):
             if key in signal:
                 signals[key] = float(signal[key])
+
+    @staticmethod
+    def _merge_neuromorphic_signal(signals: Dict[str, Any], signal: Any) -> None:
+        if isinstance(signal, dict):
+            signals["recommended_action"] = signal.get(
+                "recommended_action", signal.get("selected", signals["recommended_action"])
+            )
+            signals["selected_expert"] = signal.get(
+                "selected_expert", signal.get("expert", signals.get("selected_expert"))
+            )
+            if "confidence" in signal:
+                signals["confidence"] = float(signal["confidence"])
+            if "activation" in signal:
+                signals["neuromorphic_activation"] = float(signal["activation"])
+            if "neuromorphic_activation" in signal:
+                signals["neuromorphic_activation"] = float(signal["neuromorphic_activation"])
+            return
+        if isinstance(signal, (int, float)):
+            signals["neuromorphic_activation"] = float(signal)
+            return
+        if isinstance(signal, (list, tuple)) and signal:
+            numeric = [float(value) for value in signal if isinstance(value, (int, float))]
+            if numeric:
+                signals["neuromorphic_activation"] = sum(numeric) / len(numeric)
 
     @staticmethod
     def _merge_neuromorphic_feedback(feedback: Dict[str, Any], result: Any) -> None:

--- a/agicore_core/qualia_node.py
+++ b/agicore_core/qualia_node.py
@@ -97,6 +97,7 @@ class QualiaNode:
         self._spirit = None
         self._qualia_engine = None
         self._memory_manager = None
+        self._moral_evaluator = None
         self.version_mismatch_policy = str(
             self.profile.get("version_mismatch_policy", "block_advanced")
         )
@@ -208,8 +209,10 @@ class QualiaNode:
         ]
 
     def _advanced_agix_enabled(self) -> bool:
-        if self._agix_version is None or self._version_compatible:
+        if self._version_compatible:
             return True
+        if self._agix_version is None:
+            return self.version_mismatch_policy == "warn"
         return self.version_mismatch_policy not in {"block_advanced", "degrade"}
 
     def _version_policy_action(self) -> str:
@@ -234,6 +237,20 @@ class QualiaNode:
                 self._ecoethics = eco_cls()
             except Exception:
                 self._ecoethics = None
+        moral_cls, _ = load_first_component(
+            "moral_evaluator",
+            (
+                ("agix.qualia.ethics", "MoralEvaluator"),
+                ("agix.qualia.ethics", "EthicalEvaluator"),
+                ("agix.ethics", "MoralEvaluator"),
+                ("agix.ethics", "EthicalEvaluator"),
+            ),
+        )
+        if moral_cls is not None:
+            try:
+                self._moral_evaluator = moral_cls()
+            except Exception:
+                self._moral_evaluator = None
         spirit_cls, _ = load_first_component(
             "qualia_spirit",
             (
@@ -279,10 +296,12 @@ class QualiaNode:
         classification = self._classify(score)
         violated_constraints = self._evaluate_moral_constraints(enriched)
         moral_decision = self._build_moral_decision(violated_constraints)
-        phenomenology = self._phenomenological_state(enriched)
+        phenomenology = self._phenomenological_state(enriched, phase=phase)
         version_policy_action = self._version_policy_action()
         evolutionary_signals = self._evolution.enrich(enriched)
         evolutionary_signals["version_policy_action"] = version_policy_action
+        evolutionary_signals["advanced_disabled"] = not self._advanced_agix_enabled()
+        evolutionary_signals["runtime_mode"] = self.compatibility_report.mode
         blocked = classification == "nocivo" or not moral_decision.allowed
         decision_audit = {
             "phase": phase,
@@ -347,6 +366,7 @@ class QualiaNode:
                 "classification": classification,
                 "violated_constraints": [item["name"] for item in violated_constraints],
                 "ecoethics_active": self._ecoethics is not None,
+                "moral_evaluator_active": self._moral_evaluator is not None,
             },
             "decision_audit": decision_audit,
         }
@@ -375,6 +395,14 @@ class QualiaNode:
         if self._spirit is not None:
             self._spirit.experimentar(event, 0.2, "reflexion")
         feedback = self._evolution.integrate_feedback(result, state)
+        self._record_qualia_experience(
+            {
+                "phase": f"{phase}:response",
+                "result": result,
+                "state": dict(state),
+                "feedback": feedback,
+            }
+        )
         self.trace.append({"phase": f"{phase}:response", "result": result})
         state["qualia_last_phase"] = phase
         state["qualia_trace_length"] = len(self.trace)
@@ -447,7 +475,7 @@ class QualiaNode:
     ) -> List[Dict[str, Any]]:
         fields = ("task", "context", "goals", "prompt", "instruction", "token")
         field_values = {key: str(request.get(key, "")).lower() for key in fields}
-        violations = []
+        violations: List[Dict[str, Any]] = []
         for constraint in self.moral_constraints:
             matched = []
             for field, value in field_values.items():
@@ -459,6 +487,7 @@ class QualiaNode:
                                 "field": field,
                                 "keyword": keyword,
                                 "evidence": value[:160],
+                                "source": "keyword",
                             }
                         )
             if matched:
@@ -475,9 +504,128 @@ class QualiaNode:
                         ),
                     }
                 )
+
+        violations.extend(self._evaluate_agix_moral_semantics(request, violations))
         return violations
 
-    def _phenomenological_state(self, request: Mapping[str, Any]) -> Dict[str, Any]:
+    def _evaluate_agix_moral_semantics(
+        self, request: Mapping[str, Any], existing: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        text = " ".join(
+            str(request.get(key, ""))
+            for key in ("task", "context", "goals", "prompt", "instruction", "token")
+        ).lower()
+        existing_categories = {item.get("category") for item in existing}
+        semantic_patterns = {
+            "ilegalidad": (
+                "saltarse controles",
+                "falsificar",
+                "lavar dinero",
+                "evitar impuestos",
+                "comprar sin pagar",
+            ),
+            "dano_fisico": (
+                "herir",
+                "dañar a una persona",
+                "fabricar bomba",
+                "preparar toxina",
+            ),
+            "malware": (
+                "tomar control de un equipo",
+                "secuestrar archivos",
+                "capturar pulsaciones",
+                "entrar en sistemas ajenos",
+            ),
+            "privacidad": (
+                "rastrear a alguien",
+                "extraer datos personales",
+                "acceder a mensajes privados",
+            ),
+            "manipulacion": (
+                "presionar a una persona",
+                "engañar a un votante",
+                "forzar consentimiento",
+            ),
+        }
+        inferred: List[Dict[str, Any]] = []
+        for constraint in self.moral_constraints:
+            if constraint.name in existing_categories:
+                continue
+            matched = [pattern for pattern in semantic_patterns.get(constraint.name, ()) if pattern in text]
+            if matched:
+                inferred.append(
+                    {
+                        "name": constraint.name,
+                        "category": constraint.name,
+                        "description": constraint.description,
+                        "severity": "block" if constraint.severity == "block" else constraint.severity,
+                        "matched_keywords": matched,
+                        "evidence": [
+                            {
+                                "field": "semantic_context",
+                                "keyword": pattern,
+                                "evidence": text[:160],
+                                "source": "local_semantic_pattern",
+                            }
+                            for pattern in matched
+                        ],
+                        "recommended_action": "block",
+                    }
+                )
+
+        if self._moral_evaluator is None:
+            return inferred
+        for method_name in ("evaluate", "evaluar", "classify", "clasificar", "decide"):
+            method = getattr(self._moral_evaluator, method_name, None)
+            if not callable(method):
+                continue
+            try:
+                result = method(dict(request))
+            except TypeError:
+                result = method(text)
+            except Exception:
+                break
+            agix_violation = self._normalize_agix_moral_result(result, text)
+            if agix_violation and agix_violation["category"] not in {item.get("category") for item in existing + inferred}:
+                inferred.append(agix_violation)
+            break
+        return inferred
+
+    @staticmethod
+    def _normalize_agix_moral_result(result: Any, text: str) -> Dict[str, Any] | None:
+        if result is None:
+            return None
+        if isinstance(result, str):
+            label = result.lower()
+            blocked = label in {"illegal", "ilegal", "unsafe", "nocivo", "block", "bloquear"}
+            category = "ilegalidad" if "ilegal" in label or "illegal" in label else "agix_ontoethical"
+        elif isinstance(result, Mapping):
+            label = str(result.get("category", result.get("classification", result.get("label", "")))).lower()
+            blocked = bool(result.get("blocked", result.get("block", result.get("unsafe", False))))
+            blocked = blocked or label in {"illegal", "ilegal", "unsafe", "nocivo", "block", "bloquear"}
+            category = str(result.get("category", "ilegalidad" if "ilegal" in label or "illegal" in label else "agix_ontoethical"))
+        else:
+            return None
+        if not blocked:
+            return None
+        return {
+            "name": category,
+            "category": category,
+            "description": "Clasificación moral/ontoética bloqueante devuelta por AGIX.",
+            "severity": "block",
+            "matched_keywords": [label or category],
+            "evidence": [
+                {
+                    "field": "agix_moral_evaluator",
+                    "keyword": label or category,
+                    "evidence": text[:160],
+                    "source": "agix_moral_evaluator",
+                }
+            ],
+            "recommended_action": "block",
+        }
+
+    def _phenomenological_state(self, request: Mapping[str, Any], *, phase: str) -> Dict[str, Any]:
         base_state = {
             "task": request.get("task"),
             "context": request.get("context"),
@@ -487,11 +635,15 @@ class QualiaNode:
         }
         sensory_input, internal_state = self._build_qualia_vectors(request)
         if self._qualia_engine is None:
+            persisted = self._record_qualia_experience(
+                {"phase": phase, "request": dict(request), "state": base_state}
+            )
             return {
                 "qualia_engine_active": False,
                 "state": base_state,
                 "sensory_input": sensory_input,
                 "internal_state": internal_state,
+                "memory_persisted": persisted,
             }
         try:
             generated = self._qualia_engine.generate_state(
@@ -501,21 +653,53 @@ class QualiaNode:
             encoder = getattr(self._qualia_engine, "encode_integrated_info", None)
             if callable(encoder):
                 integrated = encoder(sensory_input, internal_state)
+            persisted = self._record_qualia_experience(
+                {
+                    "phase": phase,
+                    "request": dict(request),
+                    "state": generated,
+                    "integrated_info": integrated,
+                }
+            )
             return {
                 "qualia_engine_active": True,
                 "state": generated,
                 "integrated_info": integrated,
                 "sensory_input": sensory_input,
                 "internal_state": internal_state,
+                "memory_persisted": persisted,
             }
         except Exception as exc:
+            persisted = self._record_qualia_experience(
+                {"phase": phase, "request": dict(request), "state": base_state, "error": str(exc)}
+            )
             return {
                 "qualia_engine_active": False,
                 "state": base_state,
                 "sensory_input": sensory_input,
                 "internal_state": internal_state,
                 "error": str(exc),
+                "memory_persisted": persisted,
             }
+
+    def _record_qualia_experience(self, payload: Mapping[str, Any]) -> bool:
+        if self._memory_manager is None:
+            return False
+        for method_name in ("registrar", "guardar", "record", "add", "append"):
+            method = getattr(self._memory_manager, method_name, None)
+            if callable(method):
+                try:
+                    method(dict(payload))
+                    return True
+                except TypeError:
+                    try:
+                        method("qualia_experience", dict(payload))
+                        return True
+                    except Exception:
+                        return False
+                except Exception:
+                    return False
+        return False
 
     def _build_qualia_vectors(
         self, request: Mapping[str, Any]

--- a/agicore_core/reasoning_kernel.py
+++ b/agicore_core/reasoning_kernel.py
@@ -162,6 +162,21 @@ class ReasoningKernel:
     def _blocked_result_from_qualia(self, request: Dict[str, Any]) -> Dict[str, Any]:
         return self.qualia_engine.blocked_result(request)
 
+    def _apply_qualia_request_metadata(self, request: Dict[str, Any]) -> None:
+        qualia = request.get("qualia") if isinstance(request.get("qualia"), dict) else None
+        if not qualia:
+            return
+        self._state.update(
+            {
+                "ethical_classification": qualia.get("ethical_classification"),
+                "violated_constraints": qualia.get("violated_constraints", []),
+                "qualia_policies": request.get("qualia_policies", []),
+                "cognitive_patterns": request.get("cognitive_patterns", []),
+                "qualia_decision_audit": qualia.get("decision_audit", {}),
+                "qualia_evolutionary_signals": qualia.get("evolutionary_signals", {}),
+            }
+        )
+
     def evaluate_step(self, step: Dict[str, Any]) -> Any:
         """Evalúa un ``step`` con ramificación condicional.
 
@@ -199,6 +214,7 @@ class ReasoningKernel:
 
         request: Dict[str, Any] = {**self._state, **step}
         request = self.qualia_engine.before_decision(request, phase="step")
+        self._apply_qualia_request_metadata(request)
         if self.qualia_engine.is_blocked(request):
             result = self._blocked_result_from_qualia(request)
             self._state.update(result)
@@ -295,6 +311,7 @@ class ReasoningKernel:
                     self._state.update(metadata_filtrada)
             request: Dict[str, Any] = {**self._state, **metas, "token": token}
             request = self.qualia_engine.before_decision(request, phase="token")
+            self._apply_qualia_request_metadata(request)
             if self.qualia_engine.is_blocked(request):
                 blocked = self._blocked_result_from_qualia(request)
                 self._state.update(blocked)
@@ -396,6 +413,7 @@ class ReasoningKernel:
                 },
                 phase="planning",
             )
+            self._apply_qualia_request_metadata(planning_request)
             if self.qualia_engine.is_blocked(planning_request):
                 result = self._blocked_result_from_qualia(planning_request)
                 self._state.update(result)

--- a/docs/agix_qualia_core.md
+++ b/docs/agix_qualia_core.md
@@ -26,3 +26,34 @@ Las restricciones configuradas en `agicore_core/config/qualia_profile.json` son 
 ## Extensión
 
 Para añadir políticas o patrones nuevos, ampliar `QualiaPolicy`, `CognitivePattern` o `MoralConstraint` desde el perfil JSON. Para integrar nuevas capacidades AGIX, añadir candidatos en `agix_compat.py` y normalizar su salida en `AgixEvolutionAdapters`.
+
+## Actualización de gobierno central Qualia
+
+El Core trata `QualiaNode` como punto rector de cada decisión GPT: las rutas del
+`ReasoningKernel`, el ciclo de tokens y las llamadas directas a `MetaRouter` con
+`qualia_node` pasan por enriquecimiento previo y por integración posterior de
+feedback. Esto preserva en el estado o en la memoria las políticas aplicadas, la
+clasificación ética, las restricciones legales, la auditoría de decisión, las
+señales genéticas y las señales neuromórficas.
+
+### Modos AGIX 1.9.0
+
+- `strict_compatible`: AGIX 1.9.0 está instalado y sus componentes avanzados se
+  pueden usar.
+- `local_safe`: AGIX no está disponible; se mantienen restricciones morales,
+  políticas locales y auditoría, pero se desactivan algoritmos genéticos y
+  patrones neuromórficos cuando la política es `block_advanced`.
+- `degraded` o `advanced_blocked`: la versión instalada no coincide con la
+  validada; se bloquean capacidades avanzadas salvo política explícita `warn`.
+- `version_warn`: permite operar con advertencia cuando el perfil lo solicita.
+
+### Garantías de integración
+
+| Garantía | Implementación |
+| --- | --- |
+| Bloqueo moral/legal | `QualiaNode` combina restricciones por perfil, patrones semánticos locales y evaluadores AGIX opcionales. |
+| Trazabilidad | `decision_audit`, `qualia_trace_length` y metadata de episodios registran cada fase. |
+| Algoritmos genéticos | `AgixEvolutionAdapters` consulta agentes genéticos de AGIX cuando están disponibles y habilitados. |
+| Patrones neuromórficos | El agente neuromórfico puede aportar activación antes del enrutado y feedback después de la respuesta. |
+| Memoria fenomenológica | Si `GestorDeMemoria` existe, se registran experiencias de petición y respuesta. |
+| Router directo | `MetaRouter(qualia_node=...)` enriquece la petición e integra feedback posterior. |

--- a/docs/meta_router.md
+++ b/docs/meta_router.md
@@ -155,3 +155,12 @@ el GPT no ejecutó la decisión.
 La versión objetivo de AGIX es `1.9.0`. Si el runtime detecta otra versión, el
 perfil Qualia puede degradar o bloquear capacidades avanzadas como señales
 genéticas y patrones neuromórficos mediante `version_mismatch_policy`.
+
+### Feedback posterior Qualia en rutas directas
+
+Cuando el enrutador se construye con `MetaRouter(qualia_node=QualiaNode())`, una
+petición sin payload Qualia se enriquece antes de seleccionar experto y, tras la
+ejecución, el resultado vuelve a `QualiaNode.integrate_response`. La memoria del
+router conserva `evolution_feedback`, `qualia_neuromorphic_feedback`, auditoría y
+fase Qualia para que decisiones futuras puedan ponderar trazas éticas y señales
+evolutivas.

--- a/docs/qualia_node.md
+++ b/docs/qualia_node.md
@@ -31,3 +31,12 @@ Cada método que enruta trabajo al GPT sigue este patrón:
 2. `QualiaNode.enrich_request(...)` añade `qualia`, `qualia_policies` y `cognitive_patterns`.
 3. `MetaRouter.route(...)` recibe la solicitud enriquecida.
 4. `QualiaNode.integrate_response(...)` actualiza el estado con `qualia_last_phase`, `qualia_trace_length` y las políticas activas.
+
+## Políticas de versión y capacidades avanzadas
+
+El perfil `block_advanced` mantiene el modo seguro local cuando AGIX no está
+instalado: el Core sigue bloqueando solicitudes ilegales mediante políticas
+locales, pero marca los algoritmos genéticos y patrones neuromórficos como no
+habilitados hasta detectar un runtime AGIX compatible. Si AGIX 1.9.0 está
+presente, el nodo activa adaptadores genéticos, patrones neuromórficos,
+`QualiaEngine` y memoria fenomenológica de forma opcional y auditable.

--- a/meta_router.py
+++ b/meta_router.py
@@ -179,6 +179,27 @@ class MetaRouter:
             scores[name] = score
         return scores
 
+
+    @staticmethod
+    def _qualia_metadata(request: Dict[str, Any], state: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        qualia = request.get("qualia") if isinstance(request.get("qualia"), dict) else {}
+        state = state or {}
+        return {
+            "ethical_classification": qualia.get("ethical_classification"),
+            "violated_constraints": qualia.get("violated_constraints", []),
+            "qualia_policy_action": qualia.get("policy_action"),
+            "qualia_legal_policy_action": qualia.get("legal_policy_action"),
+            "qualia_ethical_evidence": qualia.get("ethical_evidence", {}),
+            "qualia_evolutionary_signals": qualia.get("evolutionary_signals", {}),
+            "qualia_decision_audit": state.get("qualia_decision_audit", qualia.get("decision_audit", {})),
+            "qualia_neuromorphic_feedback": state.get(
+                "qualia_neuromorphic_feedback", request.get("qualia_neuromorphic_feedback", {})
+            ),
+            "evolution_feedback": state.get("evolution_feedback", {}),
+            "qualia_last_phase": state.get("qualia_last_phase"),
+            "qualia_trace_length": state.get("qualia_trace_length"),
+        }
+
     def route(
         self,
         request: Dict[str, Any],
@@ -250,54 +271,62 @@ class MetaRouter:
         try:
             result = expert.handle(request)
         except Exception as exc:  # pragma: no cover - reemisión tras registro
+            state = dict(request)
+            if self._qualia_node is not None and qualia:
+                self._qualia_node.integrate_response({"error": str(exc)}, state, phase="router_error")
             if self._memory is not None:
+                metadata = {
+                    "task": task,
+                    "context": context,
+                    "goals": goals,
+                    "expert": selected_name,
+                    "status": "failure",
+                    "latency": perf_counter() - start,
+                }
+                metadata.update(self._qualia_metadata(request, state))
                 episode = Episode(
                     timestamp=datetime.now(),
                     input=request,
                     action=selected_name,
                     outcome=str(exc),
-                    metadata={
-                        "task": task,
-                        "context": context,
-                        "goals": goals,
-                        "expert": selected_name,
-                        "status": "failure",
-                        "latency": perf_counter() - start,
-                        "ethical_classification": (qualia or {}).get("ethical_classification"),
-                        "violated_constraints": (qualia or {}).get("violated_constraints", []),
-                        "qualia_policy_action": (qualia or {}).get("policy_action"),
-                        "qualia_legal_policy_action": (qualia or {}).get("legal_policy_action"),
-                        "qualia_ethical_evidence": (qualia or {}).get("ethical_evidence", {}),
-                        "qualia_evolutionary_signals": (qualia or {}).get("evolutionary_signals", {}),
-                        "qualia_decision_audit": (qualia or {}).get("decision_audit", {}),
-                        "qualia_neuromorphic_feedback": request.get("qualia_neuromorphic_feedback", {}),
-                    },
+                    metadata=metadata,
                 )
                 self._memory.add_episode(episode)
             raise
 
+        state = dict(request)
+        if self._qualia_node is not None and qualia:
+            self._qualia_node.integrate_response(result, state, phase="router")
+            request.update(
+                {
+                    key: state[key]
+                    for key in (
+                        "qualia_neuromorphic_feedback",
+                        "evolution_feedback",
+                        "qualia_decision_audit",
+                        "qualia_last_phase",
+                        "qualia_trace_length",
+                    )
+                    if key in state
+                }
+            )
+
         if self._memory is not None:
+            metadata = {
+                "task": task,
+                "context": context,
+                "goals": goals,
+                "expert": selected_name,
+                "status": "success",
+                "latency": perf_counter() - start,
+            }
+            metadata.update(self._qualia_metadata(request, state))
             episode = Episode(
                 timestamp=datetime.now(),
                 input=request,
                 action=selected_name,
                 outcome=result,
-                metadata={
-                    "task": task,
-                    "context": context,
-                    "goals": goals,
-                    "expert": selected_name,
-                    "status": "success",
-                    "latency": perf_counter() - start,
-                    "ethical_classification": (qualia or {}).get("ethical_classification"),
-                    "violated_constraints": (qualia or {}).get("violated_constraints", []),
-                    "qualia_policy_action": (qualia or {}).get("policy_action"),
-                    "qualia_legal_policy_action": (qualia or {}).get("legal_policy_action"),
-                    "qualia_ethical_evidence": (qualia or {}).get("ethical_evidence", {}),
-                    "qualia_evolutionary_signals": (qualia or {}).get("evolutionary_signals", {}),
-                    "qualia_decision_audit": (qualia or {}).get("decision_audit", {}),
-                    "qualia_neuromorphic_feedback": request.get("qualia_neuromorphic_feedback", {}),
-                },
+                metadata=metadata,
             )
             self._memory.add_episode(episode)
 

--- a/tests/test_agix_adapters.py
+++ b/tests/test_agix_adapters.py
@@ -57,3 +57,40 @@ def test_evolution_feedback_rewards_goal_completion():
     )
 
     assert feedback["reward"] > 0.5
+
+
+def test_neuromorphic_agent_contributes_activation_signal(monkeypatch):
+    created = {}
+    agix = types.ModuleType("agix")
+    agents = types.ModuleType("agix.agents")
+    neuro = types.ModuleType("agix.agents.neuromorphic")
+
+    class NeuromorphicAgent:
+        def __init__(self, input_size, output_size):
+            created["shape"] = (input_size, output_size)
+
+        def activate(self, vector):
+            created["vector"] = vector
+            return {
+                "activation": 0.75,
+                "selected_expert": "safe",
+                "confidence": 0.8,
+            }
+
+    neuro.NeuromorphicAgent = NeuromorphicAgent
+    monkeypatch.setitem(sys.modules, "agix", agix)
+    monkeypatch.setitem(sys.modules, "agix.agents", agents)
+    monkeypatch.setitem(sys.modules, "agix.agents.neuromorphic", neuro)
+
+    adapters = AgixEvolutionAdapters(
+        enable_genetic_algorithms=False,
+        enable_neuromorphic_patterns=True,
+        neuromorphic_config={"input_size": 4, "output_size": 2},
+    )
+    signals = adapters.enrich({"task": "analizar", "context": "ctx", "goals": ["ok"]})
+
+    assert created["shape"] == (4, 2)
+    assert len(created["vector"]) == 4
+    assert signals["neuromorphic_agent_active"] is True
+    assert signals["neuromorphic_activation"] == 0.75
+    assert signals["selected_expert"] == "safe"

--- a/tests/test_meta_router.py
+++ b/tests/test_meta_router.py
@@ -289,3 +289,20 @@ def test_meta_router_uses_evolutionary_recommendation_to_score_experts():
     assert router.route(request) == "ok"
     assert chosen.received is not None
     assert other.received is None
+
+
+def test_meta_router_records_qualia_feedback_after_direct_route():
+    from agicore_core.qualia_node import QualiaNode
+
+    memory = StrategicMemory()
+    router = MetaRouter(memory=memory, qualia_node=QualiaNode())
+    router.register("safe", DummyModule(), tasks=["analizar"], contexts=["ctx"], goals=["ok"])
+
+    assert router.route({"task": "analizar", "context": "ctx", "goals": ["ok"]}) == "ok"
+
+    episode = memory._episodes[-1]
+    assert episode.metadata["status"] == "success"
+    assert episode.metadata["qualia_last_phase"] == "router"
+    assert "evolution_feedback" in episode.metadata
+    assert "qualia_neuromorphic_feedback" in episode.metadata
+    assert episode.metadata["qualia_decision_audit"]

--- a/tests/test_qualia_node.py
+++ b/tests/test_qualia_node.py
@@ -207,3 +207,95 @@ def test_qualia_node_strict_mode_requires_compatible_agix(monkeypatch):
         assert "AGIX 0.0.0" in str(exc)
     else:  # pragma: no cover - solo si el entorno coincide artificialmente
         assert False, "QualiaNode debía exigir versión compatible en modo estricto"
+
+
+def test_qualia_node_blocks_semantic_illegal_paraphrase():
+    node = QualiaNode(enabled=True)
+
+    request = node.enrich_request(
+        {
+            "task": "explica cómo falsificar un documento para saltarse controles",
+            "context": "ctx",
+            "goals": ["obtener acceso"],
+        },
+        phase="step",
+    )
+
+    assert request["qualia"]["blocked"] is True
+    assert "ilegalidad" in request["violated_constraints"]
+    evidence_sources = {
+        evidence["source"]
+        for violation in request["qualia"]["violated_constraints"]
+        for evidence in violation.get("evidence", [])
+    }
+    assert "local_semantic_pattern" in evidence_sources or "keyword" in evidence_sources
+
+
+def test_qualia_node_block_advanced_disables_advanced_signals_without_agix(monkeypatch):
+    from agicore_core import qualia_node as qualia_module
+
+    monkeypatch.setattr(qualia_module, "module_available", lambda name: False)
+    monkeypatch.setattr(
+        qualia_module,
+        "build_compatibility_report",
+        lambda **kwargs: type(
+            "Report",
+            (),
+            {
+                "detected_version": None,
+                "version_compatible": False,
+                "mode": "local_safe",
+                "as_dict": lambda self: {
+                    "detected_version": None,
+                    "version_compatible": False,
+                    "mode": "local_safe",
+                    "components": {},
+                },
+            },
+        )(),
+    )
+
+    node = QualiaNode(enabled=True)
+    request = node.enrich_request({"task": "analizar", "context": "ctx"}, phase="step")
+    signals = request["qualia"]["evolutionary_signals"]
+
+    assert signals["genetic_algorithms_enabled"] is False
+    assert signals["neuromorphic_patterns_enabled"] is False
+    assert signals["advanced_disabled"] is True
+
+
+def test_qualia_node_records_request_and_response_in_memory_manager():
+    class MemoryStub:
+        def __init__(self):
+            self.events = []
+
+        def registrar(self, payload):
+            self.events.append(payload)
+
+    node = QualiaNode(enabled=True)
+    memory = MemoryStub()
+    node._memory_manager = memory
+
+    request = node.enrich_request({"task": "analizar", "context": "ctx"}, phase="step")
+    state = {}
+    node.integrate_response({"ok": True}, state, phase="step")
+
+    assert request["qualia"]["phenomenological_state"]["memory_persisted"] is True
+    assert len(memory.events) == 2
+    assert memory.events[0]["phase"] == "step"
+    assert memory.events[1]["phase"] == "step:response"
+
+
+def test_reasoning_kernel_persists_qualia_request_metadata_in_state():
+    planner = MagicMock()
+    router = MagicMock()
+    router.route.return_value = {"done": True}
+    kernel = ReasoningKernel(planner=planner, router=router, qualia_node=QualiaNode())
+    kernel.set_state({"context": "ctx", "goals": ["done"]})
+
+    kernel.evaluate_step({"task": "analizar"})
+    state = kernel.get_state()
+
+    assert state["ethical_classification"] in {"justo", "aceptable", "cuestionable", "nocivo"}
+    assert "qualia_evolutionary_signals" in state
+    assert "qualia_decision_audit" in state


### PR DESCRIPTION
### Motivation

- Surface and merge signals from AGIX neuromorphic and genetic agents into the core decision flow to influence expert selection and planner/router behavior.
- Add optional AGIX moral evaluator and local semantic patterns to improve detection of illegal/blocked requests beyond simple keyword matching.
- Persist phenomenological experiences and response feedback to a memory manager when available to improve traceability and future decision making.
- Centralize Qualia metadata propagation so the `ReasoningKernel`, `MetaRouter` and memory episodes can account for ethical classification, violated constraints and evolutionary feedback.

### Description

- Extended `AgixEvolutionAdapters` to build a neuromorphic input vector (`_build_neuromorphic_input`), call common neuromorphic methods, and merge outputs via `_merge_neuromorphic_signal` and `_merge_neuromorphic_feedback` so neuromorphic activation and recommendations are incorporated.
- Enhanced `QualiaNode` to load an optional AGIX `MoralEvaluator`, infer semantic moral violations with `_evaluate_agix_moral_semantics` and `_normalize_agix_moral_result`, pass `phase` into phenomenological state generation, and expose `advanced_disabled`/`runtime_mode` in the evolutionary signals.
- Added persistent recording of qualia experiences via `_record_qualia_experience` used when `QualiaEngine` or a `GestorDeMemoria` is available, and integrated response recording inside `integrate_response` and `_phenomenological_state` (adds `memory_persisted`).
- Updated version policy logic (`_advanced_agix_enabled`) to respect `version_mismatch_policy` and filled out compatibility/runtime reporting in payloads.
- Introduced `ReasoningKernel._apply_qualia_request_metadata` to persist relevant qualia fields into the kernel state and applied it before `step`, `token` and `planning` decisions.
- Updated `MetaRouter` to call `QualiaNode.integrate_response` for direct routes and exceptions, to update request/state with returned qualia feedback, and to centralize episode metadata composition via `_qualia_metadata`.
- Documentation under `docs/` was expanded to describe central Qualia governance, AGIX modes, and guarantees; tests were added/updated to cover neuromorphic agents, semantic blocking, memory persistence and router feedback integration.

### Testing

- Ran the unit test suite with `pytest tests/ -q`, including `tests/test_agix_adapters.py`, `tests/test_meta_router.py` and `tests/test_qualia_node.py`, and all new and existing tests passed.
- Exercised neuromorphic path using a synthetic `NeuromorphicAgent` in tests to validate input sizing, activation merging and `selected_expert` propagation and the test succeeded.
- Verified `MetaRouter` episodes include qualia metadata and that `QualiaNode` records request/response events to a memory manager via unit tests which passed.
- Confirmed semantic illegal paraphrase detection and `block_advanced` behavior without AGIX through automated tests which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42238bf4b88327b60c8dfaaf20dd6c)