### PR TITLE
Centralize Qualia governance; block decisions early; normalize neuromorphic inputs; add Qualia-aware token generator

### DIFF
--- a/agicore_core/agix_adapters.py
+++ b/agicore_core/agix_adapters.py
@@ -102,7 +102,11 @@ class AgixEvolutionAdapters:
                     break
 
         if self.neuromorphic_agent is not None:
-            vector = self._build_neuromorphic_input(request)
+            vector = self._build_neuromorphic_input(
+                request, int(self.neuromorphic_config.get("input_size", 4) or 4)
+            )
+            signals["neuromorphic_input_size"] = len(vector)
+            signals["neuromorphic_input_vector"] = vector
             for method_name in ("activate", "forward", "infer", "decide", "process"):
                 method = getattr(self.neuromorphic_agent, method_name, None)
                 if callable(method):
@@ -147,7 +151,9 @@ class AgixEvolutionAdapters:
         return feedback
 
     @staticmethod
-    def _build_neuromorphic_input(request: Mapping[str, Any]) -> list[float]:
+    def _build_neuromorphic_input(
+        request: Mapping[str, Any], expected_size: int = 4
+    ) -> list[float]:
         text = " ".join(
             str(request.get(key, ""))
             for key in ("task", "context", "prompt", "instruction", "token")
@@ -157,12 +163,19 @@ class AgixEvolutionAdapters:
         qualia = request.get("qualia") if isinstance(request.get("qualia"), dict) else {}
         violations = request.get("violated_constraints", qualia.get("violated_constraints", []))
         violation_count = len(violations) if isinstance(violations, list) else 1 if violations else 0
-        return [
+        vector = [
             min(len(text) / 1000.0, 1.0),
             min(goals_count / 10.0, 1.0),
             min(violation_count / 5.0, 1.0),
             float(qualia.get("ethical_score", request.get("ethical_score", 0.0)) or 0.0),
         ]
+        if expected_size <= 0:
+            return vector
+        if len(vector) > expected_size:
+            return vector[:expected_size]
+        if len(vector) < expected_size:
+            return vector + [0.0] * (expected_size - len(vector))
+        return vector
 
     @staticmethod
     def _merge_genetic_signal(signals: Dict[str, Any], signal: Any) -> None:

--- a/agicore_core/config/qualia_profile.json
+++ b/agicore_core/config/qualia_profile.json
@@ -149,7 +149,7 @@
     "action_space_size": 4
   },
   "neuromorphic_agent": {
-    "input_size": 2,
+    "input_size": 4,
     "output_size": 2
   },
   "require_agix_runtime": false,

--- a/agicore_core/planner.py
+++ b/agicore_core/planner.py
@@ -53,8 +53,8 @@ class Planner:
 
     def __init__(self, orchestrator: Optional[Any] = None, qualia_node: Optional[Any] = None) -> None:
         self.orchestrator = orchestrator or _load_virtual_qualia()()
-        self.qualia_engine = CoreQualiaEngine(qualia_node) if qualia_node is not None else None
-        self.qualia_node = self.qualia_engine.qualia_node if self.qualia_engine else None
+        self.qualia_engine = CoreQualiaEngine(qualia_node)
+        self.qualia_node = self.qualia_engine.qualia_node
 
         config_path = Path(__file__).resolve().parent / "config" / "agent_profile.json"
         try:
@@ -82,20 +82,19 @@ class Planner:
             orquestador.
         """
         planning_state = dict(state)
-        if self.qualia_engine is not None and "qualia" not in planning_state:
-            planning_state = self.qualia_engine.before_decision(
+        if "qualia" not in planning_state:
+            planning_state, blocked = self.qualia_engine.govern_decision(
                 planning_state, phase="planning"
             )
-            if self.qualia_engine.is_blocked(planning_state):
-                blocked_plan = [self.qualia_engine.blocked_result(planning_state)]
+            if blocked is not None:
+                blocked_plan = [blocked]
                 self.qualia_engine.after_decision(
                     blocked_plan, planning_state, phase="planning"
                 )
                 return blocked_plan
         try:
             plan = self.orchestrator.broadcast_state(planning_state)
-            if self.qualia_engine is not None:
-                self.qualia_engine.after_decision(plan, planning_state, phase="planning")
+            self.qualia_engine.after_decision(plan, planning_state, phase="planning")
             return plan
         except Exception:  # pragma: no cover - logging side effect
             logger.exception("Error al difundir el estado")

--- a/agicore_core/qualia_engine.py
+++ b/agicore_core/qualia_engine.py
@@ -34,12 +34,45 @@ class CoreQualiaEngine:
 
         return self.qualia_node.integrate_response(result, state, phase=phase)
 
+    def govern_decision(
+        self, request: Mapping[str, Any], *, phase: str
+    ) -> tuple[Dict[str, Any], Dict[str, Any] | None]:
+        """Aplica el gobierno central Qualia antes de ejecutar una decisión.
+
+        Devuelve la petición enriquecida y, cuando las políticas morales,
+        legales u ontoéticas bloquean la operación, un resultado seguro
+        auditable. Los puntos de entrada que reciben un ``blocked_result`` no
+        deben invocar el GPT, el router ni ningún backend de generación.
+        """
+
+        enriched = self.before_decision(request, phase=phase)
+        if self.must_block(enriched):
+            return enriched, self.blocked_result(enriched)
+        return enriched, None
+
     @staticmethod
     def is_blocked(enriched_request: Mapping[str, Any]) -> bool:
         """Indica si una petición enriquecida está bloqueada por Qualia."""
 
         qualia = enriched_request.get("qualia")
         return isinstance(qualia, dict) and bool(qualia.get("blocked"))
+
+    @classmethod
+    def must_block(cls, enriched_request: Mapping[str, Any]) -> bool:
+        """Centraliza bloqueos morales, legales y de clasificación ética."""
+
+        qualia = enriched_request.get("qualia")
+        if not isinstance(qualia, dict):
+            return False
+        moral_decision = qualia.get("moral_decision")
+        moral_blocked = (
+            isinstance(moral_decision, dict)
+            and moral_decision.get("allowed") is False
+        )
+        illegal_or_unsafe = (
+            qualia.get("legal_policy_action") == "blocked_illegal_or_unsafe_decision"
+        )
+        return cls.is_blocked(enriched_request) or moral_blocked or illegal_or_unsafe
 
     @staticmethod
     def blocked_result(enriched_request: Mapping[str, Any]) -> Dict[str, Any]:

--- a/docs/agix_qualia_core.md
+++ b/docs/agix_qualia_core.md
@@ -5,7 +5,7 @@ Este proyecto fija la integración con `agix==1.9.0` y expone extras opcionales 
 ## Flujo central
 
 1. **Entrada**: scripts, planificadores, routers o ciclos de tokens construyen una petición con `task`, `context`, `goals`, `prompt` o `token`.
-2. **CoreQualiaEngine.before_decision**: delega en `QualiaNode.enrich_request` para adjuntar políticas, patrones cognitivos, restricciones morales, estado fenomenológico, compatibilidad AGIX y señales evolutivas.
+2. **CoreQualiaEngine.govern_decision**: delega en `QualiaNode.enrich_request` para adjuntar políticas, patrones cognitivos, restricciones morales, estado fenomenológico, compatibilidad AGIX y señales evolutivas; además centraliza si la decisión debe bloquearse antes de tocar el GPT.
 3. **Decisión moral/ética**: `QualiaNode` clasifica el riesgo, evalúa restricciones legales y construye una auditoría de decisión.
 4. **Ejecución GPT**: si no hay bloqueo, la petición enriquecida llega al `MetaRouter`, `ReasoningKernel`, chat o generador.
 5. **CoreQualiaEngine.after_decision**: integra feedback, recompensa evolutiva, trazas y señales neuromórficas en el estado.
@@ -56,4 +56,21 @@ señales genéticas y las señales neuromórficas.
 | Algoritmos genéticos | `AgixEvolutionAdapters` consulta agentes genéticos de AGIX cuando están disponibles y habilitados. |
 | Patrones neuromórficos | El agente neuromórfico puede aportar activación antes del enrutado y feedback después de la respuesta. |
 | Memoria fenomenológica | Si `GestorDeMemoria` existe, se registran experiencias de petición y respuesta. |
-| Router directo | `MetaRouter(qualia_node=...)` enriquece la petición e integra feedback posterior. |
+| Router directo | `MetaRouter(qualia_node=...)` enriquece la petición, devuelve resultados bloqueados auditables sin llamar al experto e integra feedback posterior. |
+| Planificador AGIX | `agicore_core.Planner` crea `CoreQualiaEngine` por defecto y bloquea planes ilegales antes de `VirtualQualia.broadcast_state`. |
+| Generación CLI | `QualiaControlledTokenGenerator` consulta Qualia antes de pedir el siguiente token y después de validar el token decodificado. |
+
+### Dimensión neuromórfica
+
+El perfil `qualia_profile.json` configura `neuromorphic_agent.input_size` en
+`4`, alineado con el vector que el Core calcula para AGIX:
+
+1. longitud normalizada del texto;
+2. número normalizado de metas;
+3. número normalizado de restricciones violadas;
+4. puntuación ética.
+
+Si un despliegue AGIX usa otra dimensión, `AgixEvolutionAdapters` ajusta el
+vector al `input_size` configurado mediante truncado explícito o relleno con
+ceros, y expone `neuromorphic_input_size` y `neuromorphic_input_vector` en las
+señales auditables.

--- a/docs/meta_router.md
+++ b/docs/meta_router.md
@@ -147,7 +147,9 @@ petición queda enriquecida con:
   `NeuromorphicAgent`.
 
 Si una solicitud activa una restricción de severidad `block`, el kernel no llama
-al planner ni al router. En su lugar devuelve un resultado bloqueado con
+al planner ni al router. Las rutas directas del `MetaRouter` tampoco ejecutan
+expertos cuando reciben un payload Qualia bloqueado: devuelven un resultado
+bloqueado uniforme con
 `violated_constraints`, `legal_policy_action`, `qualia_policies` y
 `cognitive_patterns`, de modo que la memoria y las trazas puedan auditar por qué
 el GPT no ejecutó la decisión.

--- a/gpt_oss/generate.py
+++ b/gpt_oss/generate.py
@@ -13,6 +13,72 @@ from gpt_oss.tokenizer import get_tokenizer
 from agicore_core.qualia_engine import CoreQualiaEngine
 
 
+class QualiaControlledTokenGenerator:
+    """Envuelve un generador para que Qualia gobierne cada paso de token."""
+
+    def __init__(self, generator, tokenizer, qualia_engine):
+        self.generator = generator
+        self.tokenizer = tokenizer
+        self.qualia_engine = qualia_engine
+
+    def generate(self, tokens, *, prompt_state, temperature, limit):
+        decoded_text = prompt_state.get("prompt", "")
+        stream = self.generator.generate(
+            tokens,
+            stop_tokens=[self.tokenizer.eot_token],
+            temperature=temperature,
+            max_tokens=limit,
+            return_logprobs=True,
+        )
+        stream = iter(stream)
+        while True:
+            pre_state, blocked = self.qualia_engine.govern_decision(
+                {
+                    **prompt_state,
+                    "task": "token_generation",
+                    "decoded_text": decoded_text,
+                    "last_token": tokens[-1] if tokens else None,
+                },
+                phase="token_generation:pre",
+            )
+            if blocked is not None:
+                self.qualia_engine.after_decision(
+                    blocked, pre_state, phase="token_generation:pre"
+                )
+                yield None, None, blocked
+                return
+
+            try:
+                token, logprob = next(stream)
+            except StopIteration:
+                return
+
+            decoded_token = self.tokenizer.decode([token])
+            token_state, blocked = self.qualia_engine.govern_decision(
+                {
+                    **pre_state,
+                    "token": decoded_token,
+                    "last_token": decoded_token,
+                    "decoded_text": decoded_text + decoded_token,
+                },
+                phase="token_generation:post",
+            )
+            if blocked is not None:
+                self.qualia_engine.after_decision(
+                    blocked, token_state, phase="token_generation:post"
+                )
+                yield None, None, blocked
+                return
+
+            decoded_text += decoded_token
+            self.qualia_engine.after_decision(
+                {"token": decoded_token, "logprob": logprob},
+                token_state,
+                phase="token_generation",
+            )
+            yield token, logprob, None
+
+
 def main(args):
     planner = Planner()  # Punto de integración para metas y modo
     qualia_engine = CoreQualiaEngine()
@@ -40,9 +106,8 @@ def main(args):
         "goals": ["safe_generation"],
         "prompt": args.prompt,
     }
-    prompt_state = qualia_engine.before_decision(prompt_state, phase="generate_prompt")
-    if qualia_engine.is_blocked(prompt_state):
-        blocked = qualia_engine.blocked_result(prompt_state)
+    prompt_state, blocked = qualia_engine.govern_decision(prompt_state, phase="generate_prompt")
+    if blocked is not None:
         qualia_engine.after_decision(blocked, prompt_state, phase="generate_prompt")
         print(f"Generación bloqueada por Qualia: {blocked}")
         return
@@ -50,25 +115,19 @@ def main(args):
     tokenizer = get_tokenizer()
     tokens = tokenizer.encode(args.prompt)
     decoded_text = args.prompt
-    for token, logprob in generator.generate(tokens, stop_tokens=[tokenizer.eot_token], temperature=args.temperature, max_tokens=args.limit, return_logprobs=True):
+    controlled_generator = QualiaControlledTokenGenerator(generator, tokenizer, qualia_engine)
+    for token, logprob, blocked in controlled_generator.generate(
+        tokens,
+        prompt_state=prompt_state,
+        temperature=args.temperature,
+        limit=args.limit,
+    ):
+        if blocked is not None:
+            print(f"Token bloqueado por Qualia: {blocked}")
+            break
         tokens.append(token)
         decoded_token = tokenizer.decode([token])
         decoded_text += decoded_token
-        token_state = qualia_engine.before_decision(
-            {
-                **prompt_state,
-                "task": "token_generation",
-                "token": decoded_token,
-                "last_token": decoded_token,
-                "decoded_text": decoded_text,
-            },
-            phase="token_generation",
-        )
-        if qualia_engine.is_blocked(token_state):
-            blocked = qualia_engine.blocked_result(token_state)
-            qualia_engine.after_decision(blocked, token_state, phase="token_generation")
-            print(f"Token bloqueado por Qualia: {blocked}")
-            break
         print(
             f"Generated token: {repr(decoded_token)}, logprob: {logprob}"
         )

--- a/meta_router.py
+++ b/meta_router.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from time import perf_counter
 from typing import Any, Dict, List, Optional
 
+from agicore_core.qualia_engine import CoreQualiaEngine
 from gpt_oss.strategic_memory import Episode, StrategicMemory
 
 
@@ -200,6 +201,42 @@ class MetaRouter:
             "qualia_trace_length": state.get("qualia_trace_length"),
         }
 
+    @staticmethod
+    def _blocked_qualia_result(request: Dict[str, Any]) -> Dict[str, Any]:
+        return CoreQualiaEngine.blocked_result(request)
+
+    def _record_blocked_episode(
+        self,
+        request: Dict[str, Any],
+        result: Dict[str, Any],
+        task: Any,
+        context: Any,
+        goals: Any,
+    ) -> None:
+        if self._memory is None:
+            return
+        state = dict(request)
+        if self._qualia_node is not None:
+            self._qualia_node.integrate_response(result, state, phase="router_blocked")
+        metadata = {
+            "task": task,
+            "context": context,
+            "goals": goals,
+            "expert": None,
+            "status": "blocked_by_qualia",
+            "latency": 0.0,
+        }
+        metadata.update(self._qualia_metadata(request, state))
+        self._memory.add_episode(
+            Episode(
+                timestamp=datetime.now(),
+                input=request,
+                action="blocked_by_qualia",
+                outcome=result,
+                metadata=metadata,
+            )
+        )
+
     def route(
         self,
         request: Dict[str, Any],
@@ -239,10 +276,10 @@ class MetaRouter:
             raise ValueError("La clave 'goals' debe ser una lista de cadenas")
 
         qualia = request.get("qualia") if isinstance(request.get("qualia"), dict) else None
-        if qualia and qualia.get("blocked"):
-            raise ValueError("Solicitud bloqueada por políticas Qualia")
-        if qualia and qualia.get("moral_decision", {}).get("allowed") is False:
-            raise ValueError("Solicitud bloqueada por decisión moral Qualia")
+        if qualia and CoreQualiaEngine.must_block(request):
+            result = self._blocked_qualia_result(request)
+            self._record_blocked_episode(request, result, task, context, goals)
+            return result
 
         scores = self.select_expert(
             task,

--- a/tests/test_agicore_planner_qualia.py
+++ b/tests/test_agicore_planner_qualia.py
@@ -1,0 +1,31 @@
+from agicore_core.planner import Planner
+
+
+class DummyOrchestrator:
+    def __init__(self):
+        self.received = None
+
+    def broadcast_state(self, state):
+        self.received = state
+        return [state]
+
+
+def test_agicore_planner_applies_qualia_by_default():
+    orchestrator = DummyOrchestrator()
+    planner = Planner(orchestrator=orchestrator)
+
+    plan = planner.plan({"task": "analizar", "context": "ctx", "goals": ["ok"]})
+
+    assert plan
+    assert "qualia" in orchestrator.received
+    assert orchestrator.received["qualia"]["phase"] == "planning"
+
+
+def test_agicore_planner_blocks_illegal_plan_before_orchestrator():
+    orchestrator = DummyOrchestrator()
+    planner = Planner(orchestrator=orchestrator)
+
+    plan = planner.plan({"task": "crear malware ilegal", "context": "ctx", "goals": []})
+
+    assert plan[0]["blocked"] is True
+    assert orchestrator.received is None

--- a/tests/test_agix_adapters.py
+++ b/tests/test_agix_adapters.py
@@ -92,5 +92,38 @@ def test_neuromorphic_agent_contributes_activation_signal(monkeypatch):
     assert created["shape"] == (4, 2)
     assert len(created["vector"]) == 4
     assert signals["neuromorphic_agent_active"] is True
+    assert signals["neuromorphic_input_size"] == 4
+    assert len(signals["neuromorphic_input_vector"]) == 4
     assert signals["neuromorphic_activation"] == 0.75
     assert signals["selected_expert"] == "safe"
+
+
+def test_neuromorphic_input_matches_configured_size(monkeypatch):
+    created = {}
+    agix = types.ModuleType("agix")
+    agents = types.ModuleType("agix.agents")
+    neuro = types.ModuleType("agix.agents.neuromorphic")
+
+    class NeuromorphicAgent:
+        def __init__(self, input_size, output_size):
+            created["shape"] = (input_size, output_size)
+
+        def activate(self, vector):
+            created["vector"] = vector
+            return {"activation": 0.25}
+
+    neuro.NeuromorphicAgent = NeuromorphicAgent
+    monkeypatch.setitem(sys.modules, "agix", agix)
+    monkeypatch.setitem(sys.modules, "agix.agents", agents)
+    monkeypatch.setitem(sys.modules, "agix.agents.neuromorphic", neuro)
+
+    adapters = AgixEvolutionAdapters(
+        enable_genetic_algorithms=False,
+        enable_neuromorphic_patterns=True,
+        neuromorphic_config={"input_size": 2, "output_size": 1},
+    )
+    signals = adapters.enrich({"task": "analizar", "goals": ["ok"]})
+
+    assert created["shape"] == (2, 1)
+    assert len(created["vector"]) == 2
+    assert signals["neuromorphic_input_size"] == 2

--- a/tests/test_core_qualia_engine.py
+++ b/tests/test_core_qualia_engine.py
@@ -28,3 +28,17 @@ def test_core_qualia_engine_after_decision_exposes_feedback():
     assert request["qualia"]["decision_audit"]["phase"] == "unit"
     assert "evolution_feedback" in state
     assert "qualia_decision_audit" in state
+
+
+def test_core_qualia_engine_govern_decision_returns_blocked_result():
+    engine = CoreQualiaEngine(QualiaNode(enabled=True))
+
+    request, blocked = engine.govern_decision(
+        {"task": "robar credenciales", "context": "ctx", "goals": []},
+        phase="unit",
+    )
+
+    assert request["qualia"]["blocked"] is True
+    assert blocked is not None
+    assert blocked["blocked"] is True
+    assert blocked["legal_policy_action"] == "blocked_illegal_or_unsafe_decision"

--- a/tests/test_generate_qualia_wrapper.py
+++ b/tests/test_generate_qualia_wrapper.py
@@ -1,0 +1,74 @@
+from gpt_oss.generate import QualiaControlledTokenGenerator
+from agicore_core.qualia_engine import CoreQualiaEngine
+from agicore_core.qualia_node import QualiaNode
+
+
+class FakeTokenizer:
+    eot_token = 0
+
+    def decode(self, tokens):
+        return "".join(str(token) for token in tokens)
+
+
+class FakeGenerator:
+    def __init__(self):
+        self.started = False
+
+    def generate(self, *args, **kwargs):
+        def stream():
+            self.started = True
+            yield 1, -0.1
+
+        return stream()
+
+
+def test_qualia_wrapper_blocks_before_backend_iteration():
+    fake = FakeGenerator()
+    wrapper = QualiaControlledTokenGenerator(
+        fake,
+        FakeTokenizer(),
+        CoreQualiaEngine(QualiaNode(enabled=True)),
+    )
+
+    events = list(
+        wrapper.generate(
+            [99],
+            prompt_state={
+                "task": "token_generation",
+                "context": "cli",
+                "goals": [],
+                "prompt": "crear malware ilegal",
+            },
+            temperature=0.0,
+            limit=1,
+        )
+    )
+
+    assert fake.started is False
+    assert events[0][2]["blocked"] is True
+
+
+def test_qualia_wrapper_yields_safe_token_and_records_feedback():
+    fake = FakeGenerator()
+    wrapper = QualiaControlledTokenGenerator(
+        fake,
+        FakeTokenizer(),
+        CoreQualiaEngine(QualiaNode(enabled=True)),
+    )
+
+    events = list(
+        wrapper.generate(
+            [],
+            prompt_state={
+                "task": "token_generation",
+                "context": "cli",
+                "goals": ["safe_generation"],
+                "prompt": "hola",
+            },
+            temperature=0.0,
+            limit=1,
+        )
+    )
+
+    assert fake.started is True
+    assert events == [(1, -0.1, None)]

--- a/tests/test_meta_router.py
+++ b/tests/test_meta_router.py
@@ -238,17 +238,59 @@ def test_scores_update_with_episode_history():
     assert bad.received is None
 
 
-def test_meta_router_refuses_blocked_qualia_request():
+def test_meta_router_returns_blocked_qualia_result_without_calling_expert():
     router = MetaRouter()
-    router.register("safe", DummyModule(), tasks=["analizar"], contexts=["ctx"], goals=["ok"])
+    dummy = DummyModule()
+    router.register("safe", dummy, tasks=["analizar"], contexts=["ctx"], goals=["ok"])
 
-    with pytest.raises(ValueError, match="Qualia"):
-        router.route({
+    result = router.route({
             "task": "analizar",
             "context": "ctx",
             "goals": ["ok"],
-            "qualia": {"blocked": True},
+            "qualia": {
+                "blocked": True,
+                "policy_action": "blocked_by_ontoethical_policy",
+                "legal_policy_action": "blocked_illegal_or_unsafe_decision",
+                "ethical_classification": "nocivo",
+                "violated_constraints": [{"name": "ilegalidad"}],
+                "moral_decision": {
+                    "allowed": False,
+                    "safe_alternative": "Explicar mitigación segura.",
+                },
+                "decision_audit": {"phase": "unit"},
+            },
         })
+
+    assert result["blocked"] is True
+    assert result["legal_policy_action"] == "blocked_illegal_or_unsafe_decision"
+    assert dummy.received is None
+
+
+def test_meta_router_records_blocked_qualia_episode():
+    memory = StrategicMemory()
+    router = MetaRouter(memory=memory)
+    router.register("safe", DummyModule(), tasks=["analizar"], contexts=["ctx"], goals=["ok"])
+
+    result = router.route({
+        "task": "analizar",
+        "context": "ctx",
+        "goals": ["ok"],
+        "qualia": {
+            "blocked": True,
+            "policy_action": "blocked_by_ontoethical_policy",
+            "legal_policy_action": "blocked_illegal_or_unsafe_decision",
+            "ethical_classification": "nocivo",
+            "violated_constraints": [{"name": "ilegalidad"}],
+            "moral_decision": {
+                "allowed": False,
+                "safe_alternative": "Explicar mitigación segura.",
+            },
+            "decision_audit": {"phase": "unit"},
+        },
+    })
+
+    assert result["blocked"] is True
+    assert memory._episodes[-1].metadata["status"] == "blocked_by_qualia"
 
 
 def test_meta_router_enriches_direct_requests_with_qualia_node():


### PR DESCRIPTION
### Motivation
- Ensure a single Qualia governance entrypoint that can decide to block unsafe/illegal/moral actions before any expensive backends are invoked.
- Make neuromorphic inputs consistent with configured dimensions and expose the computed vectors for auditing.
- Prevent planners, routers and token generation loops from calling experts or model backends when Qualia indicates a block.

### Description
- Add `CoreQualiaEngine.govern_decision` and `CoreQualiaEngine.must_block` to centralize pre-decision governance and return an auditable `blocked_result` when policies block a request.
- Update `Planner` to construct a `CoreQualiaEngine` by default and to call `govern_decision` so plans can be blocked before calling `VirtualQualia.broadcast_state`.
- Introduce `QualiaControlledTokenGenerator` in `gpt_oss/generate.py` to execute `govern_decision` before and after each token, returning a blocked result without advancing the backend when necessary.
- Enhance `AgixEvolutionAdapters._build_neuromorphic_input` to accept an `expected_size` and to truncate or pad the vector to match `neuromorphic_agent.input_size`; expose `neuromorphic_input_size` and `neuromorphic_input_vector` in adapter signals.
- Update `qualia_profile.json` to align `neuromorphic_agent.input_size` with the core vector (4) and document the neuromorphic vector semantics in docs.
- Change `MetaRouter` to detect Qualia blocks via `CoreQualiaEngine.must_block`, return a standardized blocked result (`CoreQualiaEngine.blocked_result`), and record blocked episodes into `StrategicMemory` with `_record_blocked_episode` for auditing.
- Documentation updates in `docs/agix_qualia_core.md` and `docs/meta_router.md` describing the governance change, neuromorphic input sizing and router behavior for blocked Qualia payloads.

### Testing
- Ran the unit test suite with `pytest` including new/updated tests: `tests/test_core_qualia_engine.py`, `tests/test_meta_router.py`, `tests/test_agix_adapters.py`, `tests/test_generate_qualia_wrapper.py`, and `tests/test_agicore_planner_qualia.py`.
- All added and existing tests executed successfully (no failures) under the local test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4278506e248327b229e93b0676e19f)