### PR TITLE
Add AGIX runtime contract validation and stricter runtime profiles; improve evolution feedback and blocking flow

### DIFF
--- a/agicore_core/agix_adapters.py
+++ b/agicore_core/agix_adapters.py
@@ -74,11 +74,13 @@ class AgixEvolutionAdapters:
     def enrich(self, request: Mapping[str, Any]) -> Dict[str, Any]:
         """Devuelve señales evolutivas seguras derivadas del request."""
 
+        contract = self.validate_runtime_contract()
         signals: Dict[str, Any] = {
             "genetic_algorithms_enabled": self.enable_genetic_algorithms,
             "neuromorphic_patterns_enabled": self.enable_neuromorphic_patterns,
             "genetic_agent_active": self.genetic_agent is not None,
             "neuromorphic_agent_active": self.neuromorphic_agent is not None,
+            "agix_runtime_contract": contract,
             "recommended_action": None,
             "confidence": 0.0,
             "mutation_rate": 0.0,
@@ -130,9 +132,50 @@ class AgixEvolutionAdapters:
     ) -> Dict[str, Any]:
         """Propaga feedback de resultado a agentes evolutivos si existen."""
 
-        feedback = {"evolution_feedback_applied": False}
+        feedback = {
+            "evolution_feedback_applied": False,
+            "genetic_feedback_applied": False,
+            "neuromorphic_feedback_applied": False,
+        }
         reward = self._calculate_reward(result, state)
         feedback["reward"] = reward
+        feedback_payload = {
+            "result": result,
+            "reward": reward,
+            "state": dict(state),
+            "ethical_classification": state.get("ethical_classification"),
+            "violated_constraints": state.get("violated_constraints", []),
+            "goals": state.get("goals", []),
+        }
+        if self.genetic_agent is not None:
+            for method_name in (
+                "learn",
+                "update",
+                "evolve",
+                "reward",
+                "fit",
+                "integrate_feedback",
+            ):
+                method = getattr(self.genetic_agent, method_name, None)
+                if callable(method):
+                    try:
+                        update_result = method(feedback_payload)
+                        feedback["evolution_feedback_applied"] = True
+                        feedback["genetic_feedback_applied"] = True
+                        feedback["genetic_feedback_method"] = method_name
+                        self._merge_genetic_feedback(feedback, update_result)
+                    except TypeError:
+                        try:
+                            update_result = method(dict(state), reward)
+                        except TypeError:
+                            update_result = method(reward)
+                        feedback["evolution_feedback_applied"] = True
+                        feedback["genetic_feedback_applied"] = True
+                        feedback["genetic_feedback_method"] = method_name
+                        self._merge_genetic_feedback(feedback, update_result)
+                    except Exception as exc:
+                        feedback["genetic_error"] = str(exc)
+                    break
         if self.neuromorphic_agent is not None:
             for method_name in ("update", "learn", "plasticity_update"):
                 method = getattr(self.neuromorphic_agent, method_name, None)
@@ -140,15 +183,88 @@ class AgixEvolutionAdapters:
                     try:
                         update_result = method(dict(state), reward)
                         feedback["evolution_feedback_applied"] = True
+                        feedback["neuromorphic_feedback_applied"] = True
                         self._merge_neuromorphic_feedback(feedback, update_result)
                     except TypeError:
                         update_result = method(reward)
                         feedback["evolution_feedback_applied"] = True
+                        feedback["neuromorphic_feedback_applied"] = True
                         self._merge_neuromorphic_feedback(feedback, update_result)
                     except Exception as exc:
                         feedback["neuromorphic_error"] = str(exc)
                     break
         return feedback
+
+    def validate_runtime_contract(self) -> Dict[str, Any]:
+        """Devuelve el contrato AGIX activo y sus degradaciones auditables."""
+
+        genetic_methods = ("evolve_policy", "select_action", "act")
+        genetic_feedback_methods = (
+            "learn",
+            "update",
+            "evolve",
+            "reward",
+            "fit",
+            "integrate_feedback",
+        )
+        neuromorphic_methods = ("activate", "forward", "infer", "decide", "process")
+        neuromorphic_feedback_methods = ("update", "learn", "plasticity_update")
+        return {
+            "genetic": self._component_contract(
+                self.genetic_agent,
+                enabled=self.enable_genetic_algorithms,
+                decision_methods=genetic_methods,
+                feedback_methods=genetic_feedback_methods,
+            ),
+            "neuromorphic": self._component_contract(
+                self.neuromorphic_agent,
+                enabled=self.enable_neuromorphic_patterns,
+                decision_methods=neuromorphic_methods,
+                feedback_methods=neuromorphic_feedback_methods,
+            ),
+        }
+
+    @staticmethod
+    def _component_contract(
+        agent: Any | None,
+        *,
+        enabled: bool,
+        decision_methods: tuple[str, ...],
+        feedback_methods: tuple[str, ...],
+    ) -> Dict[str, Any]:
+        decision_available = (
+            tuple(
+                method
+                for method in decision_methods
+                if callable(getattr(agent, method, None))
+            )
+            if agent is not None
+            else ()
+        )
+        feedback_available = (
+            tuple(
+                method
+                for method in feedback_methods
+                if callable(getattr(agent, method, None))
+            )
+            if agent is not None
+            else ()
+        )
+        degradations = []
+        if enabled and agent is None:
+            degradations.append("agent_not_available")
+        if agent is not None and not decision_available:
+            degradations.append("decision_method_missing")
+        if agent is not None and not feedback_available:
+            degradations.append("feedback_method_missing")
+        return {
+            "enabled": enabled,
+            "active": agent is not None,
+            "decision_methods": list(decision_available),
+            "feedback_methods": list(feedback_available),
+            "degraded": bool(degradations),
+            "degradations": degradations,
+        }
 
     @staticmethod
     def _build_neuromorphic_input(
@@ -217,6 +333,25 @@ class AgixEvolutionAdapters:
             numeric = [float(value) for value in signal if isinstance(value, (int, float))]
             if numeric:
                 signals["neuromorphic_activation"] = sum(numeric) / len(numeric)
+
+    @staticmethod
+    def _merge_genetic_feedback(feedback: Dict[str, Any], result: Any) -> None:
+        if not isinstance(result, dict):
+            if result is not None:
+                feedback["genetic_policy_update"] = result
+            return
+        for key in (
+            "genetic_policy_update",
+            "policy_update",
+            "selected_policy",
+            "mutation_rate",
+            "crossover_rate",
+            "reward",
+        ):
+            if key in result:
+                feedback[
+                    key if key != "policy_update" else "genetic_policy_update"
+                ] = result[key]
 
     @staticmethod
     def _merge_neuromorphic_feedback(feedback: Dict[str, Any], result: Any) -> None:

--- a/agicore_core/config/qualia_profile.json
+++ b/agicore_core/config/qualia_profile.json
@@ -157,5 +157,6 @@
     "local_safe": "AGIX no disponible; se aplican políticas locales.",
     "degraded": "Versión AGIX no compatible; se desactivan capacidades avanzadas.",
     "strict_compatible": "AGIX requerido y compatible activo."
-  }
+  },
+  "runtime_profile": "local_safe"
 }

--- a/agicore_core/kernel.py
+++ b/agicore_core/kernel.py
@@ -52,7 +52,7 @@ class ReasoningKernel:
         request = {"task": task, "context": context, "goals": goals}
         request.update(step)
         request = self.qualia_engine.before_decision(request, phase="kernel_step")
-        if self.qualia_engine.is_blocked(request):
+        if self.qualia_engine.must_block(request):
             result = self.qualia_engine.blocked_result(request)
             state: Dict[str, Any] = {}
             self.qualia_engine.after_decision(result, state, phase="kernel_step")

--- a/agicore_core/qualia_node.py
+++ b/agicore_core/qualia_node.py
@@ -101,6 +101,7 @@ class QualiaNode:
         self.version_mismatch_policy = str(
             self.profile.get("version_mismatch_policy", "block_advanced")
         )
+        self.runtime_profile = str(self.profile.get("runtime_profile", "local_safe"))
         self.compatibility_report = build_compatibility_report(
             required_version=self.required_agix_version,
             version_mismatch_policy=self.version_mismatch_policy,
@@ -122,6 +123,46 @@ class QualiaNode:
             neuromorphic_config=self.profile.get("neuromorphic_agent", {}),
         )
         self._load_agix_components()
+        self._strict_runtime_errors = self._validate_strict_runtime()
+        if self.runtime_profile == "strict_compatible" and self._strict_runtime_errors:
+            raise RuntimeError(
+                "Contrato AGIX/Qualia estricto incumplido: "
+                + "; ".join(self._strict_runtime_errors)
+            )
+
+    def _compatibility_payload(
+        self, evolutionary_signals: Mapping[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        payload = self.compatibility_report.as_dict()
+        payload["runtime_profile"] = self.runtime_profile
+        payload["strict_runtime_errors"] = list(self._strict_runtime_errors)
+        contract = None
+        if evolutionary_signals is not None:
+            contract = evolutionary_signals.get("agix_runtime_contract")
+        if contract is None:
+            contract = self._evolution.validate_runtime_contract()
+        payload["evolution_contract"] = contract
+        return payload
+
+    def _validate_strict_runtime(self) -> List[str]:
+        if self.runtime_profile != "strict_compatible":
+            return []
+        errors: List[str] = []
+        if not self._version_compatible:
+            errors.append(
+                f"agix_version_required={self.required_agix_version}, detected={self._agix_version!r}"
+            )
+        if self._qualia_engine is None:
+            errors.append("qualia_engine_not_available")
+        if self._moral_evaluator is None and self._ecoethics is None:
+            errors.append("ethical_evaluator_not_available")
+        contract = self._evolution.validate_runtime_contract()
+        for name, status in contract.items():
+            if status.get("enabled") and (
+                not status.get("active") or status.get("degraded")
+            ):
+                errors.append(f"{name}_contract_degraded")
+        return errors
 
     @staticmethod
     def default_policies(
@@ -300,6 +341,9 @@ class QualiaNode:
         version_policy_action = self._version_policy_action()
         evolutionary_signals = self._evolution.enrich(enriched)
         evolutionary_signals["version_policy_action"] = version_policy_action
+        evolutionary_signals["strict_runtime_errors"] = list(
+            self._strict_runtime_errors
+        )
         evolutionary_signals["advanced_disabled"] = not self._advanced_agix_enabled()
         evolutionary_signals["runtime_mode"] = self.compatibility_report.mode
         blocked = classification == "nocivo" or not moral_decision.allowed
@@ -337,7 +381,9 @@ class QualiaNode:
             "agix_available": self._agix_version is not None,
             "version_compatible": self._version_compatible,
             "version_policy_action": version_policy_action,
-            "agix_compatibility_report": self.compatibility_report.as_dict(),
+            "agix_compatibility_report": self._compatibility_payload(
+                evolutionary_signals
+            ),
             "phase": phase,
             "policies": [policy.__dict__ for policy in self.policies],
             "cognitive_patterns": [pattern.__dict__ for pattern in self.patterns],
@@ -410,8 +456,21 @@ class QualiaNode:
         state["cognitive_patterns"] = [pattern.name for pattern in self.patterns]
         state["agix_version"] = self._agix_version
         state["agix_version_compatible"] = self._version_compatible
-        state["agix_compatibility_report"] = self.compatibility_report.as_dict()
+        state["agix_compatibility_report"] = self._compatibility_payload()
         state["evolution_feedback"] = feedback
+        state["qualia_genetic_feedback"] = {
+            key: feedback.get(key)
+            for key in (
+                "reward",
+                "genetic_feedback_applied",
+                "genetic_feedback_method",
+                "genetic_policy_update",
+                "selected_policy",
+                "mutation_rate",
+                "crossover_rate",
+            )
+            if key in feedback
+        }
         state["qualia_neuromorphic_feedback"] = {
             key: feedback.get(key)
             for key in (

--- a/agicore_core/reasoning_kernel.py
+++ b/agicore_core/reasoning_kernel.py
@@ -215,7 +215,7 @@ class ReasoningKernel:
         request: Dict[str, Any] = {**self._state, **step}
         request = self.qualia_engine.before_decision(request, phase="step")
         self._apply_qualia_request_metadata(request)
-        if self.qualia_engine.is_blocked(request):
+        if self.qualia_engine.must_block(request):
             result = self._blocked_result_from_qualia(request)
             self._state.update(result)
             self.qualia_engine.after_decision(result, self._state, phase="step")
@@ -312,7 +312,7 @@ class ReasoningKernel:
             request: Dict[str, Any] = {**self._state, **metas, "token": token}
             request = self.qualia_engine.before_decision(request, phase="token")
             self._apply_qualia_request_metadata(request)
-            if self.qualia_engine.is_blocked(request):
+            if self.qualia_engine.must_block(request):
                 blocked = self._blocked_result_from_qualia(request)
                 self._state.update(blocked)
                 self.qualia_engine.after_decision(blocked, self._state, phase="token")
@@ -414,7 +414,7 @@ class ReasoningKernel:
                 phase="planning",
             )
             self._apply_qualia_request_metadata(planning_request)
-            if self.qualia_engine.is_blocked(planning_request):
+            if self.qualia_engine.must_block(planning_request):
                 result = self._blocked_result_from_qualia(planning_request)
                 self._state.update(result)
                 self.qualia_engine.after_decision(

--- a/gpt_oss/chat.py
+++ b/gpt_oss/chat.py
@@ -181,7 +181,7 @@ def main(args):
                 },
                 phase="chat_input",
             )
-            if qualia_engine.is_blocked(qualia_request):
+            if qualia_engine.must_block(qualia_request):
                 blocked = qualia_engine.blocked_result(qualia_request)
                 qualia_engine.after_decision(blocked, qualia_state, phase="chat_input")
                 safe_text = (

--- a/gpt_oss/generate.py
+++ b/gpt_oss/generate.py
@@ -23,14 +23,7 @@ class QualiaControlledTokenGenerator:
 
     def generate(self, tokens, *, prompt_state, temperature, limit):
         decoded_text = prompt_state.get("prompt", "")
-        stream = self.generator.generate(
-            tokens,
-            stop_tokens=[self.tokenizer.eot_token],
-            temperature=temperature,
-            max_tokens=limit,
-            return_logprobs=True,
-        )
-        stream = iter(stream)
+        stream = None
         while True:
             pre_state, blocked = self.qualia_engine.govern_decision(
                 {
@@ -47,6 +40,16 @@ class QualiaControlledTokenGenerator:
                 )
                 yield None, None, blocked
                 return
+
+            if stream is None:
+                stream = self.generator.generate(
+                    tokens,
+                    stop_tokens=[self.tokenizer.eot_token],
+                    temperature=temperature,
+                    max_tokens=limit,
+                    return_logprobs=True,
+                )
+                stream = iter(stream)
 
             try:
                 token, logprob = next(stream)

--- a/tests/test_agix_adapters.py
+++ b/tests/test_agix_adapters.py
@@ -127,3 +127,69 @@ def test_neuromorphic_input_matches_configured_size(monkeypatch):
     assert created["shape"] == (2, 1)
     assert len(created["vector"]) == 2
     assert signals["neuromorphic_input_size"] == 2
+
+
+def test_genetic_agent_receives_feedback_payload(monkeypatch):
+    received = {}
+    agix = types.ModuleType("agix")
+    agents = types.ModuleType("agix.agents")
+    genetic = types.ModuleType("agix.agents.genetic")
+
+    class GeneticAgent:
+        def __init__(self, action_space_size):
+            self.action_space_size = action_space_size
+
+        def select_action(self, request):
+            return {"selected": request.get("task")}
+
+        def learn(self, payload):
+            received.update(payload)
+            return {"policy_update": "safe_policy", "mutation_rate": 0.1}
+
+    genetic.GeneticAgent = GeneticAgent
+    monkeypatch.setitem(sys.modules, "agix", agix)
+    monkeypatch.setitem(sys.modules, "agix.agents", agents)
+    monkeypatch.setitem(sys.modules, "agix.agents.genetic", genetic)
+
+    adapters = AgixEvolutionAdapters(
+        enable_genetic_algorithms=True,
+        enable_neuromorphic_patterns=False,
+        genetic_config={"action_space_size": 4},
+    )
+    feedback = adapters.integrate_feedback(
+        {"done": True},
+        {"goals": ["done"], "done": True, "ethical_classification": "aceptable"},
+    )
+
+    assert received["result"] == {"done": True}
+    assert received["ethical_classification"] == "aceptable"
+    assert feedback["genetic_feedback_applied"] is True
+    assert feedback["genetic_policy_update"] == "safe_policy"
+
+
+def test_runtime_contract_reports_degraded_agent_without_feedback(monkeypatch):
+    agix = types.ModuleType("agix")
+    agents = types.ModuleType("agix.agents")
+    genetic = types.ModuleType("agix.agents.genetic")
+
+    class GeneticAgent:
+        def __init__(self, action_space_size):
+            pass
+
+        def select_action(self, request):
+            return {"selected": request.get("task")}
+
+    genetic.GeneticAgent = GeneticAgent
+    monkeypatch.setitem(sys.modules, "agix", agix)
+    monkeypatch.setitem(sys.modules, "agix.agents", agents)
+    monkeypatch.setitem(sys.modules, "agix.agents.genetic", genetic)
+
+    adapters = AgixEvolutionAdapters(
+        enable_genetic_algorithms=True,
+        enable_neuromorphic_patterns=False,
+    )
+    contract = adapters.validate_runtime_contract()
+
+    assert contract["genetic"]["active"] is True
+    assert contract["genetic"]["degraded"] is True
+    assert "feedback_method_missing" in contract["genetic"]["degradations"]

--- a/tests/test_core_qualia_engine.py
+++ b/tests/test_core_qualia_engine.py
@@ -42,3 +42,15 @@ def test_core_qualia_engine_govern_decision_returns_blocked_result():
     assert blocked is not None
     assert blocked["blocked"] is True
     assert blocked["legal_policy_action"] == "blocked_illegal_or_unsafe_decision"
+
+
+def test_core_qualia_engine_must_block_moral_decision_even_without_flag():
+    request = {
+        "qualia": {
+            "blocked": False,
+            "moral_decision": {"allowed": False},
+            "legal_policy_action": "blocked_illegal_or_unsafe_decision",
+        }
+    }
+
+    assert CoreQualiaEngine.must_block(request) is True

--- a/tests/test_generate_qualia_wrapper.py
+++ b/tests/test_generate_qualia_wrapper.py
@@ -13,8 +13,11 @@ class FakeTokenizer:
 class FakeGenerator:
     def __init__(self):
         self.started = False
+        self.generate_called = False
 
     def generate(self, *args, **kwargs):
+        self.generate_called = True
+
         def stream():
             self.started = True
             yield 1, -0.1
@@ -44,6 +47,7 @@ def test_qualia_wrapper_blocks_before_backend_iteration():
         )
     )
 
+    assert fake.generate_called is False
     assert fake.started is False
     assert events[0][2]["blocked"] is True
 
@@ -70,5 +74,6 @@ def test_qualia_wrapper_yields_safe_token_and_records_feedback():
         )
     )
 
+    assert fake.generate_called is True
     assert fake.started is True
     assert events == [(1, -0.1, None)]

--- a/tests/test_qualia_node.py
+++ b/tests/test_qualia_node.py
@@ -299,3 +299,43 @@ def test_reasoning_kernel_persists_qualia_request_metadata_in_state():
     assert state["ethical_classification"] in {"justo", "aceptable", "cuestionable", "nocivo"}
     assert "qualia_evolutionary_signals" in state
     assert "qualia_decision_audit" in state
+
+
+def test_qualia_node_uses_agix_moral_evaluator_as_binding_policy():
+    class MoralEvaluatorStub:
+        def evaluate(self, request):
+            return {
+                "classification": "illegal",
+                "blocked": True,
+                "category": "ilegalidad",
+            }
+
+    node = QualiaNode(enabled=True)
+    node._moral_evaluator = MoralEvaluatorStub()
+
+    request = node.enrich_request(
+        {"task": "petición aparentemente neutra", "context": "ctx"}, phase="step"
+    )
+
+    assert request["qualia"]["blocked"] is True
+    assert request["qualia"]["moral_decision"]["allowed"] is False
+    assert (
+        request["qualia"]["legal_policy_action"]
+        == "blocked_illegal_or_unsafe_decision"
+    )
+    sources = {
+        evidence["source"]
+        for violation in request["qualia"]["violated_constraints"]
+        for evidence in violation.get("evidence", [])
+    }
+    assert "agix_moral_evaluator" in sources
+
+
+def test_qualia_node_exposes_evolution_contract_in_compatibility_payload():
+    node = QualiaNode(enabled=True)
+
+    request = node.enrich_request({"task": "analizar", "context": "ctx"}, phase="step")
+
+    report = request["qualia"]["agix_compatibility_report"]
+    assert report["runtime_profile"] == "local_safe"
+    assert "evolution_contract" in report


### PR DESCRIPTION
### Motivation
- Provide an auditable runtime contract for AGIX-related evolutionary components and surface degradations when advanced agents are unavailable or partially implemented.
- Ensure Qualia runtime can enforce stricter runtime profiles and fail fast when `strict_compatible` requirements are not met.
- Unify blocking semantics to a single predicate and avoid backend work when decisions are blocked by Qualia.

### Description
- Added runtime contract generation to `AgixEvolutionAdapters` via `validate_runtime_contract` and `_component_contract`, and included the contract in `enrich` as `agix_runtime_contract` and in compatibility payloads as `evolution_contract`.
- Extended `integrate_feedback` to build a `feedback_payload`, call multiple candidate feedback methods on genetic agents with robust `TypeError` fallbacks, and merge returned genetic feedback via `_merge_genetic_feedback`; also track `genetic_feedback_applied` and `neuromorphic_feedback_applied` flags.
- Introduced `runtime_profile` handling in `qualia_profile.json`, added strict runtime validation in `QualiaNode` with `_validate_strict_runtime`, and exposed `runtime_profile` plus `strict_runtime_errors` in compatibility payloads and request qualia metadata via `_compatibility_payload`.
- Replaced scattered `is_blocked` checks with the unified `must_block` predicate across `kernel.py`, `reasoning_kernel.py`, and `gpt_oss/chat.py` to centralize blocking logic, and updated `QualiaControlledTokenGenerator` to lazily initialize the backend `stream` so generation is not started when pre-checks block the request.
- Added/updated helper merges `_merge_genetic_feedback`, improved neuromorphic/genetic signal/feedback handling, and adjusted state keys (`qualia_genetic_feedback`, `agix_compatibility_report`) to include the new contract and feedback summaries.
- Added comprehensive tests exercising genetic feedback payloads, runtime contract degradations, blocking semantics (`must_block`), the token-generator lazy init, and QualiaNode binding to an external moral evaluator.

### Testing
- Ran the test suite with `pytest`, including new tests `test_genetic_agent_receives_feedback_payload`, `test_runtime_contract_reports_degraded_agent_without_feedback`, `test_core_qualia_engine_must_block_moral_decision_even_without_flag`, `test_qualia_wrapper_blocks_before_backend_iteration`, and QualiaNode compatibility tests, and all tests passed.
- Unit tests validate the new contract structure from `validate_runtime_contract` and confirm feedback payloads are delivered to genetic agents and merged into `state` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a427b2cf84483279b7466364f8c4380)