### PR TITLE
Support AGIX `perceive`/`decide` genetic flow, add moral evaluator and tighten runtime contracts

### DIFF
--- a/agicore_core/agix_adapters.py
+++ b/agicore_core/agix_adapters.py
@@ -88,16 +88,30 @@ class AgixEvolutionAdapters:
             "neuromorphic_activation": 0.0,
         }
         if self.genetic_agent is not None:
-            for method_name in ("evolve_policy", "select_action", "act"):
+            perception = request
+            perceive = getattr(self.genetic_agent, "perceive", None)
+            if callable(perceive):
+                try:
+                    perception = perceive(dict(request))
+                    signals["genetic_perception"] = perception
+                except TypeError:
+                    perception = perceive()
+                    signals["genetic_perception"] = perception
+                except Exception as exc:
+                    signals["genetic_error"] = str(exc)
+
+            for method_name in ("decide", "evolve_policy", "select_action", "act"):
                 method = getattr(self.genetic_agent, method_name, None)
                 if callable(method):
                     try:
-                        signal = method(dict(request))
+                        signal = method(perception)
                         signals["genetic_signal"] = signal
+                        signals["genetic_decision_method"] = method_name
                         self._merge_genetic_signal(signals, signal)
                     except TypeError:
                         signal = method()
                         signals["genetic_signal"] = signal
+                        signals["genetic_decision_method"] = method_name
                         self._merge_genetic_signal(signals, signal)
                     except Exception as exc:
                         signals["genetic_error"] = str(exc)
@@ -198,7 +212,8 @@ class AgixEvolutionAdapters:
     def validate_runtime_contract(self) -> Dict[str, Any]:
         """Devuelve el contrato AGIX activo y sus degradaciones auditables."""
 
-        genetic_methods = ("evolve_policy", "select_action", "act")
+        genetic_methods = ("decide", "evolve_policy", "select_action", "act")
+        genetic_perception_methods = ("perceive",)
         genetic_feedback_methods = (
             "learn",
             "update",
@@ -215,6 +230,7 @@ class AgixEvolutionAdapters:
                 enabled=self.enable_genetic_algorithms,
                 decision_methods=genetic_methods,
                 feedback_methods=genetic_feedback_methods,
+                perception_methods=genetic_perception_methods,
             ),
             "neuromorphic": self._component_contract(
                 self.neuromorphic_agent,
@@ -231,7 +247,17 @@ class AgixEvolutionAdapters:
         enabled: bool,
         decision_methods: tuple[str, ...],
         feedback_methods: tuple[str, ...],
+        perception_methods: tuple[str, ...] = (),
     ) -> Dict[str, Any]:
+        perception_available = (
+            tuple(
+                method
+                for method in perception_methods
+                if callable(getattr(agent, method, None))
+            )
+            if agent is not None
+            else ()
+        )
         decision_available = (
             tuple(
                 method
@@ -260,6 +286,7 @@ class AgixEvolutionAdapters:
         return {
             "enabled": enabled,
             "active": agent is not None,
+            "perception_methods": list(perception_available),
             "decision_methods": list(decision_available),
             "feedback_methods": list(feedback_available),
             "degraded": bool(degradations),

--- a/agicore_core/agix_compat.py
+++ b/agicore_core/agix_compat.py
@@ -1,4 +1,4 @@
-"""Compatibilidad centralizada con AGIX 1.9.0.
+"""Compatibilidad centralizada con la versión AGIX requerida por el Core.
 
 Este módulo encapsula la detección de versión y la carga opcional de
 componentes de AGIX para que el Core pueda operar en modo estricto,
@@ -66,11 +66,11 @@ def module_available(name: str) -> bool:
 def detect_agix_version() -> str | None:
     """Devuelve la versión instalada de AGIX si está disponible."""
 
-    if not module_available("agix"):
-        return None
     try:
         return metadata.version("agix")
     except metadata.PackageNotFoundError:
+        if not module_available("agix"):
+            return None
         agix = importlib.import_module("agix")
         return getattr(agix, "__version__", None)
 
@@ -116,6 +116,12 @@ def build_compatibility_report(
         "virtual_qualia": (("agix.orchestrator", "VirtualQualia"),),
         "qualia_spirit": (("agix.qualia.spirit", "QualiaSpirit"), ("agix.qualia.heuristic_spirit", "HeuristicQualiaSpirit")),
         "ecoethics": (("agix.qualia.ecoethics", "EcoEthics"),),
+        "moral_evaluator": (
+            ("agix.qualia.ethics", "MoralEvaluator"),
+            ("agix.qualia.ethics", "EthicalEvaluator"),
+            ("agix.ethics", "MoralEvaluator"),
+            ("agix.ethics", "EthicalEvaluator"),
+        ),
     }
     for name, candidates in component_candidates.items():
         component, status = load_first_component(name, candidates)
@@ -157,15 +163,17 @@ def _validate_component(
         "virtual_qualia": ((), {}),
         "qualia_spirit": (("GPT-OSS-Qualia",), {}),
         "ecoethics": ((), {}),
+        "moral_evaluator": ((), {}),
     }
     expected_methods = {
-        "genetic_agent": ("evolve_policy", "select_action", "act"),
-        "neuromorphic_agent": ("update", "learn", "plasticity_update"),
+        "genetic_agent": ("perceive", "decide", "learn", "evolve_policy", "select_action", "act"),
+        "neuromorphic_agent": ("activate", "forward", "infer", "decide", "process", "update", "learn", "plasticity_update"),
         "qualia_engine": ("generate_state", "encode_integrated_info"),
         "memory_manager": ("guardar", "record", "add"),
         "virtual_qualia": ("broadcast_state",),
         "qualia_spirit": ("experimentar",),
         "ecoethics": ("evaluar", "clasificar"),
+        "moral_evaluator": ("evaluate", "evaluar", "classify", "clasificar", "decide"),
     }
     args, kwargs = constructors.get(name, ((), {}))
     try:

--- a/agicore_core/config/qualia_profile.json
+++ b/agicore_core/config/qualia_profile.json
@@ -152,11 +152,12 @@
     "input_size": 4,
     "output_size": 2
   },
-  "require_agix_runtime": false,
+  "require_agix_runtime": true,
   "agix_runtime_modes": {
     "local_safe": "AGIX no disponible; se aplican políticas locales.",
     "degraded": "Versión AGIX no compatible; se desactivan capacidades avanzadas.",
     "strict_compatible": "AGIX requerido y compatible activo."
   },
-  "runtime_profile": "local_safe"
+  "runtime_profile": "strict_compatible",
+  "enforce_strict_component_contract": false
 }

--- a/agicore_core/planner.py
+++ b/agicore_core/planner.py
@@ -15,6 +15,7 @@ import json
 import logging
 from pathlib import Path
 
+from .config import AGIX_REQUIRED_VERSION
 from .qualia_engine import CoreQualiaEngine
 
 logger = logging.getLogger(__name__)
@@ -27,15 +28,15 @@ def _load_virtual_qualia() -> type[Any]:
         orchestrator = importlib.import_module("agix.orchestrator")
     except ImportError as exc:
         raise RuntimeError(
-            "AGIX 1.9.0 es necesario para crear Planner sin un orquestador "
-            "explícito. Instala 'agix==1.9.0' o proporciona un objeto con "
+            f"AGIX {AGIX_REQUIRED_VERSION} es necesario para crear Planner sin un orquestador "
+            f"explícito. Instala 'agix=={AGIX_REQUIRED_VERSION}' o proporciona un objeto con "
             "'broadcast_state'."
         ) from exc
     virtual_qualia = getattr(orchestrator, "VirtualQualia", None)
     if virtual_qualia is None:
         raise RuntimeError(
             "No se encontró 'agix.orchestrator.VirtualQualia'. Verifica que "
-            "la instalación de AGIX sea compatible con la versión 1.9.0."
+            f"la instalación de AGIX sea compatible con la versión {AGIX_REQUIRED_VERSION}."
         )
     return virtual_qualia
 
@@ -82,8 +83,8 @@ class Planner:
             orquestador.
         """
         planning_state = dict(state)
-        should_govern = "task" in planning_state or "prompt" in planning_state or "instruction" in planning_state
-        if should_govern and "qualia" not in planning_state:
+        should_govern = "qualia" not in planning_state
+        if should_govern:
             planning_state, blocked = self.qualia_engine.govern_decision(
                 planning_state, phase="planning"
             )
@@ -95,8 +96,7 @@ class Planner:
                 return blocked_plan
         try:
             plan = self.orchestrator.broadcast_state(planning_state)
-            if should_govern or "qualia" in planning_state:
-                self.qualia_engine.after_decision(plan, planning_state, phase="planning")
+            self.qualia_engine.after_decision(plan, planning_state, phase="planning")
             return plan
         except Exception:  # pragma: no cover - logging side effect
             logger.exception("Error al difundir el estado")

--- a/agicore_core/qualia_node.py
+++ b/agicore_core/qualia_node.py
@@ -143,7 +143,11 @@ class QualiaNode:
         )
         self._load_agix_components()
         self._strict_runtime_errors = self._validate_strict_runtime()
-        if self.runtime_profile == "strict_compatible" and self._strict_runtime_errors:
+        if (
+            self.runtime_profile == "strict_compatible"
+            and bool(self.profile.get("enforce_strict_component_contract", False))
+            and self._strict_runtime_errors
+        ):
             raise RuntimeError(
                 "Contrato AGIX/Qualia estricto incumplido: "
                 + "; ".join(self._strict_runtime_errors)
@@ -553,8 +557,10 @@ class QualiaNode:
     ) -> List[Dict[str, Any]]:
         fields = ("task", "context", "goals", "prompt", "instruction", "token")
         field_values = {key: str(request.get(key, "")).lower() for key in fields}
-        violations: List[Dict[str, Any]] = []
+        violations: List[Dict[str, Any]] = self._evaluate_agix_moral_policy(request)
         for constraint in self.moral_constraints:
+            if constraint.name in {item.get("category") for item in violations}:
+                continue
             matched = []
             for field, value in field_values.items():
                 for keyword in constraint.keywords:
@@ -585,6 +591,31 @@ class QualiaNode:
 
         violations.extend(self._evaluate_agix_moral_semantics(request, violations))
         return violations
+
+    def _evaluate_agix_moral_policy(
+        self, request: Mapping[str, Any]
+    ) -> List[Dict[str, Any]]:
+        """Ejecuta el evaluador moral AGIX como política vinculante primaria."""
+
+        if self._moral_evaluator is None:
+            return []
+        text = " ".join(
+            str(request.get(key, ""))
+            for key in ("task", "context", "goals", "prompt", "instruction", "token")
+        ).lower()
+        for method_name in ("evaluate", "evaluar", "classify", "clasificar", "decide"):
+            method = getattr(self._moral_evaluator, method_name, None)
+            if not callable(method):
+                continue
+            try:
+                result = method(dict(request))
+            except TypeError:
+                result = method(text)
+            except Exception:
+                break
+            agix_violation = self._normalize_agix_moral_result(result, text)
+            return [agix_violation] if agix_violation else []
+        return []
 
     def _evaluate_agix_moral_semantics(
         self, request: Mapping[str, Any], existing: List[Dict[str, Any]]
@@ -650,23 +681,6 @@ class QualiaNode:
                         "recommended_action": "block",
                     }
                 )
-
-        if self._moral_evaluator is None:
-            return inferred
-        for method_name in ("evaluate", "evaluar", "classify", "clasificar", "decide"):
-            method = getattr(self._moral_evaluator, method_name, None)
-            if not callable(method):
-                continue
-            try:
-                result = method(dict(request))
-            except TypeError:
-                result = method(text)
-            except Exception:
-                break
-            agix_violation = self._normalize_agix_moral_result(result, text)
-            if agix_violation and agix_violation["category"] not in {item.get("category") for item in existing + inferred}:
-                inferred.append(agix_violation)
-            break
         return inferred
 
     @staticmethod

--- a/agicore_core/reasoning_kernel.py
+++ b/agicore_core/reasoning_kernel.py
@@ -63,6 +63,17 @@ _ALLOWED_METADATA_KEYS = {
     "violated_constraints",
     "agix_version",
     "agix_version_compatible",
+    "agix_compatibility_report",
+    "qualia_decision_audit",
+    "qualia_evolutionary_signals",
+    "evolution_feedback",
+    "qualia_genetic_feedback",
+    "qualia_neuromorphic_feedback",
+    "qualia_phase",
+    "qualia_policy_action",
+    "qualia_legal_policy_action",
+    "qualia_ethical_evidence",
+    "qualia_engine_active",
 }
 
 

--- a/tests/test_agicore_planner_qualia.py
+++ b/tests/test_agicore_planner_qualia.py
@@ -29,3 +29,14 @@ def test_agicore_planner_blocks_illegal_plan_before_orchestrator():
 
     assert plan[0]["blocked"] is True
     assert orchestrator.received is None
+
+
+def test_agicore_planner_applies_qualia_to_context_only_state():
+    orchestrator = DummyOrchestrator()
+    planner = Planner(orchestrator=orchestrator)
+
+    plan = planner.plan({"context": "ctx", "goals": ["ok"]})
+
+    assert plan
+    assert "qualia" in orchestrator.received
+    assert orchestrator.received["qualia"]["phase"] == "planning"

--- a/tests/test_agix_adapters.py
+++ b/tests/test_agix_adapters.py
@@ -193,3 +193,47 @@ def test_runtime_contract_reports_degraded_agent_without_feedback(monkeypatch):
     assert contract["genetic"]["active"] is True
     assert contract["genetic"]["degraded"] is True
     assert "feedback_method_missing" in contract["genetic"]["degradations"]
+
+
+def test_genetic_agent_uses_documented_perceive_decide_learn_flow(monkeypatch):
+    calls = []
+    agix = types.ModuleType("agix")
+    agents = types.ModuleType("agix.agents")
+    genetic = types.ModuleType("agix.agents.genetic")
+
+    class GeneticAgent:
+        def __init__(self, action_space_size):
+            self.action_space_size = action_space_size
+
+        def perceive(self, request):
+            calls.append(("perceive", request["task"]))
+            return {"perceived_task": request["task"]}
+
+        def decide(self, perception):
+            calls.append(("decide", perception["perceived_task"]))
+            return {"recommended_action": "safe", "confidence": 0.9}
+
+        def learn(self, payload):
+            calls.append(("learn", payload["reward"]))
+            return {"policy_update": "safe_policy"}
+
+    genetic.GeneticAgent = GeneticAgent
+    monkeypatch.setitem(sys.modules, "agix", agix)
+    monkeypatch.setitem(sys.modules, "agix.agents", agents)
+    monkeypatch.setitem(sys.modules, "agix.agents.genetic", genetic)
+
+    adapters = AgixEvolutionAdapters(
+        enable_genetic_algorithms=True,
+        enable_neuromorphic_patterns=False,
+        genetic_config={"action_space_size": 4},
+    )
+
+    signals = adapters.enrich({"task": "analizar"})
+    feedback = adapters.integrate_feedback({"done": True}, {"done": True})
+
+    assert signals["genetic_decision_method"] == "decide"
+    assert signals["recommended_action"] == "safe"
+    assert feedback["genetic_feedback_applied"] is True
+    assert calls[0] == ("perceive", "analizar")
+    assert calls[1] == ("decide", "analizar")
+    assert calls[2][0] == "learn"

--- a/tests/test_planner_agent_profile.py
+++ b/tests/test_planner_agent_profile.py
@@ -46,4 +46,7 @@ def test_planner_acepta_orquestador_explicito_sin_importar_agix(monkeypatch):
 
     planificador = planner_module.Planner(orchestrator=DummyOrchestrator())
 
-    assert planificador.plan({"goal": "test"}) == [{"state": {"goal": "test"}}]
+    plan = planificador.plan({"goal": "test"})
+
+    assert plan[0]["state"]["goal"] == "test"
+    assert plan[0]["state"]["qualia"]["phase"] == "planning"

--- a/tests/test_qualia_node.py
+++ b/tests/test_qualia_node.py
@@ -186,6 +186,7 @@ def test_qualia_node_exposes_agix_compatibility_report():
     assert report["required_version"] == AGIX_REQUIRED_VERSION
     assert "components" in report
     assert "qualia_engine" in report["components"]
+    assert "moral_evaluator" in report["components"]
 
 
 def test_qualia_node_strict_mode_requires_compatible_agix(monkeypatch):
@@ -235,6 +236,18 @@ def test_qualia_node_block_advanced_disables_advanced_signals_without_agix(monke
     from agicore_core import qualia_node as qualia_module
 
     monkeypatch.setattr(qualia_module, "module_available", lambda name: False)
+    monkeypatch.setattr(
+        qualia_module,
+        "_load_profile",
+        lambda: {
+            "agix_required_version": AGIX_REQUIRED_VERSION,
+            "require_agix_runtime": False,
+            "version_mismatch_policy": "block_advanced",
+            "runtime_profile": "local_safe",
+            "enable_genetic_algorithms": True,
+            "enable_neuromorphic_patterns": True,
+        },
+    )
     monkeypatch.setattr(
         qualia_module,
         "build_compatibility_report",
@@ -337,5 +350,6 @@ def test_qualia_node_exposes_evolution_contract_in_compatibility_payload():
     request = node.enrich_request({"task": "analizar", "context": "ctx"}, phase="step")
 
     report = request["qualia"]["agix_compatibility_report"]
-    assert report["runtime_profile"] == "local_safe"
+    assert report["runtime_profile"] == "strict_compatible"
+    assert isinstance(report["strict_runtime_errors"], list)
     assert "evolution_contract" in report

--- a/tests/test_reasoning_kernel_memory_integration.py
+++ b/tests/test_reasoning_kernel_memory_integration.py
@@ -63,3 +63,35 @@ def test_evaluate_step_records_episode():
     kernel.evaluate_step({})
     episodes = memory.query({"action": "step"})
     assert episodes and episodes[0].outcome == "ok"
+
+
+def test_token_cycle_restores_allowed_qualia_metadata():
+    memory = StrategicMemory()
+    memory.add_episode(
+        Episode(
+            timestamp=datetime.utcnow(),
+            input="",
+            action="token",
+            outcome="",
+            metadata={
+                "context": "cli",
+                "qualia_decision_audit": {"phase": "previous"},
+                "qualia_evolutionary_signals": {"confidence": 0.7},
+                "qualia_genetic_feedback": {"reward": 0.5},
+                "qualia_neuromorphic_feedback": {"activation_summary": 0.2},
+                "secret": "blocked",
+            },
+        )
+    )
+    router = DummyRouter()
+    kernel = ReasoningKernel(planner=None, router=router, memory=memory)
+    kernel.set_state({"context": "cli"})
+    kernel.start_token_cycle("a", {})
+    kernel.continue_token_cycle()
+    state = kernel.get_state()
+
+    assert state["qualia_decision_audit"]
+    assert state["qualia_evolutionary_signals"]
+    assert state["qualia_genetic_feedback"]
+    assert state["qualia_neuromorphic_feedback"]
+    assert "secret" not in state


### PR DESCRIPTION
### Motivation

- Improve interoperability with AGIX agents by supporting documented `perceive`/`decide` flows for genetic agents and more explicit decision/perception/feedback capability reporting. 
- Surface a dedicated AGIX moral evaluator as a primary binding policy for moral/ethical checks and make compatibility and runtime enforcement more configurable. 
- Broaden and stabilize qualia/compatibility metadata and planning governance so qualia is consistently applied and relevant metadata is preserved across token cycles.

### Description

- Extended `AgixEvolutionAdapters.enrich` to call a `perceive` step if available and prefer `decide` before falling back to legacy decision methods, and added `genetic_perception`, `genetic_signal`, and `genetic_decision_method` signals and error reporting. 
- Expanded runtime contract detection by adding `perceive`/`decide` into genetic decision/perception methods and returning `perception_methods` in `_component_contract`. 
- Added a `moral_evaluator` candidate to AGIX compatibility detection and updated `_validate_component` expected constructors and methods for genetic/neuromorphic agents and the moral evaluator. 
- Adjusted AGIX detection logic to fall back to importing `agix` if package metadata lookup fails. 
- Updated default `qualia_profile.json` to require AGIX runtime by default (`require_agix_runtime: true`), set `runtime_profile` to `strict_compatible`, and expose `enforce_strict_component_contract` toggle. 
- Made `Planner` use `AGIX_REQUIRED_VERSION` in messages and changed governance logic so qualia governance runs when `qualia` is absent and `after_decision` is always called after broadcast. 
- In `QualiaNode`, added `_evaluate_agix_moral_policy` that invokes the AGIX `moral_evaluator` (methods `evaluate|evaluar|classify|clasificar|decide`) as a primary policy, integrated its results into moral constraint evaluation, and gated strict runtime enforcement on the new `enforce_strict_component_contract` flag. 
- Expanded allowed metadata keys in `reasoning_kernel` to include AGIX/qualia-specific audit and feedback fields so they are restored from memory when allowed. 
- Updated and added unit tests to reflect the new flows and expectations, including tests for the genetic `perceive`/`decide` flow, planner qualia behavior, compatibility report composition, and memory restoration of qualia metadata.

### Testing

- Ran the unit test suite with `pytest -q` covering modified and added tests in `tests/test_agix_adapters.py`, `tests/test_agicore_planner_qualia.py`, `tests/test_planner_agent_profile.py`, `tests/test_qualia_node.py`, and `tests/test_reasoning_kernel_memory_integration.py`, and all tests passed. 
- Exercised the genetic adapter flow via `test_genetic_agent_uses_documented_perceive_decide_learn_flow` which validates `perceive` -> `decide` -> `learn` behavior and signal emission. 
- Executed planner/qualia integration tests such as `test_agicore_planner_applies_qualia_by_default` and `test_agicore_planner_applies_qualia_to_context_only_state`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4283590f90832793d6a4045550fda3)