### PR TITLE
Integrate AGIX cognitive adapters, SafetyGate, training bridge, neuro-symbolic bridge and enhanced memory consolidation

### DIFF
--- a/agicore_core/__init__.py
+++ b/agicore_core/__init__.py
@@ -5,6 +5,9 @@ from .kernel import ReasoningKernel
 from .meta_evaluator import MetaEvaluator
 from .qualia_node import QualiaNode
 from .qualia_engine import CoreQualiaEngine
+from .safety_gate import SafetyGate
+from .training_bridge import QualiaTrainingBridge, TrainingSignal, TrainingFeedback
+from .neuro_symbolic_bridge import CoreNeuroSymbolicBridge
 from .config import AGIX_REQUIRED_VERSION
 
 __all__ = [
@@ -13,5 +16,10 @@ __all__ = [
     "MetaEvaluator",
     "QualiaNode",
     "CoreQualiaEngine",
+    "SafetyGate",
+    "QualiaTrainingBridge",
+    "TrainingSignal",
+    "TrainingFeedback",
+    "CoreNeuroSymbolicBridge",
     "AGIX_REQUIRED_VERSION",
 ]

--- a/agicore_core/agix_cognitive_adapters.py
+++ b/agicore_core/agix_cognitive_adapters.py
@@ -1,0 +1,277 @@
+"""Adaptadores cognitivos opcionales para módulos AGIX documentados.
+
+Estos adaptadores mantienen el Core funcional sin AGIX instalado y normalizan
+señales de aprendizaje, conceptos, foco atencional y métricas de evaluación en
+payloads auditables que Qualia puede adjuntar a cada decisión GPT.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Mapping
+
+from .agix_compat import load_first_component
+
+
+_COMPONENTS: dict[str, tuple[tuple[str, str], ...]] = {
+    "meta_learner": (("agix.learning.meta", "MetaLearner"), ("agix.learning", "MetaLearner")),
+    "ontology": (("agix.memory", "Ontology"), ("agix.reasoning", "Ontology")),
+    "latent_representation": (("agix.memory", "LatentRepresentation"), ("agix.reasoning", "LatentRepresentation")),
+    "neuro_symbolic_bridge": (("agix.reasoning", "NeuroSymbolicBridge"),),
+    "evaluation_metrics": (("agix.evaluation", "EvaluationMetrics"),),
+    "concept_classifier": (("agix.memory", "ConceptClassifier"), ("agix.reasoning", "ConceptClassifier")),
+    "heuristic_concept_creator": (("agix.memory", "HeuristicConceptCreator"), ("agix.reasoning", "HeuristicConceptCreator")),
+    "emotion_simulator": (("agix.emotion.emotion_simulator", "EmotionSimulator"),),
+    "attention_focus": (("agix.perception.attention", "AttentionFocus"),),
+}
+
+_DECISION_METHODS: dict[str, tuple[str, ...]] = {
+    "meta_learner": ("adapt", "learn", "update", "fit", "meta_update"),
+    "ontology": ("infer", "query", "relate", "add_concept"),
+    "latent_representation": ("encode", "transform", "project"),
+    "neuro_symbolic_bridge": ("encode", "bridge", "translate"),
+    "evaluation_metrics": ("evaluate", "calcular", "score", "compute"),
+    "concept_classifier": ("classify", "clasificar", "predict"),
+    "heuristic_concept_creator": ("create", "crear", "generate", "infer"),
+    "emotion_simulator": ("simulate", "simular", "evaluate", "infer"),
+    "attention_focus": ("focus", "attend", "select", "prioritize"),
+}
+
+
+@dataclass
+class AgixCognitiveAdapters:
+    """Carga y coordina capacidades cognitivas avanzadas de AGIX."""
+
+    enabled: bool = True
+    components: dict[str, Any | None] = field(default_factory=dict, init=False)
+    errors: dict[str, str] = field(default_factory=dict, init=False)
+
+    def __post_init__(self) -> None:
+        self._load_components()
+
+    def _load_components(self) -> None:
+        for name, candidates in _COMPONENTS.items():
+            self.components[name] = None
+            if not self.enabled:
+                continue
+            cls, status = load_first_component(name, candidates)
+            if cls is None:
+                if status.error:
+                    self.errors[name] = status.error
+                continue
+            try:
+                self.components[name] = cls()
+            except Exception as exc:  # pragma: no cover - depende de AGIX real
+                self.errors[name] = str(exc)
+
+    def validate_runtime_contract(self) -> Dict[str, Any]:
+        """Describe disponibilidad y degradación por componente cognitivo."""
+
+        return {
+            name: self._component_contract(name, component)
+            for name, component in self.components.items()
+        }
+
+    def enrich(self, request: Mapping[str, Any]) -> Dict[str, Any]:
+        """Genera señales cognitivas seguras para Qualia."""
+
+        signals: Dict[str, Any] = {
+            "enabled": self.enabled,
+            "agix_cognitive_contract": self.validate_runtime_contract(),
+            "concepts": self._fallback_concepts(request),
+            "attention_focus": None,
+            "emotional_state": None,
+            "latent_state": None,
+            "evaluation_metrics": {},
+            "meta_learning_update": None,
+        }
+        if not self.enabled:
+            return signals
+
+        self._apply_concept_components(request, signals)
+        self._apply_attention(request, signals)
+        self._apply_emotion(request, signals)
+        self._apply_neuro_symbolic(request, signals)
+        self._apply_evaluation(request, signals)
+        return signals
+
+    def integrate_feedback(self, result: Any, state: Mapping[str, Any]) -> Dict[str, Any]:
+        """Propaga feedback seguro a MetaLearner si está disponible."""
+
+        feedback: Dict[str, Any] = {"cognitive_feedback_applied": False}
+        meta = self.components.get("meta_learner")
+        if meta is None:
+            return feedback
+        payload = {"result": result, "state": dict(state)}
+        for method_name in _DECISION_METHODS["meta_learner"]:
+            method = getattr(meta, method_name, None)
+            if not callable(method):
+                continue
+            try:
+                feedback["meta_learning_update"] = method(payload)
+            except TypeError:
+                feedback["meta_learning_update"] = method(dict(state))
+            except Exception as exc:  # pragma: no cover - depende de AGIX real
+                feedback["meta_learning_error"] = str(exc)
+                return feedback
+            feedback["cognitive_feedback_applied"] = True
+            feedback["meta_learning_method"] = method_name
+            return feedback
+        return feedback
+
+    @staticmethod
+    def _fallback_concepts(request: Mapping[str, Any]) -> list[dict[str, Any]]:
+        terms: list[str] = []
+        for key in ("task", "context", "prompt", "instruction", "goals"):
+            value = request.get(key, "")
+            if isinstance(value, (list, tuple)):
+                terms.extend(str(item) for item in value)
+            else:
+                terms.extend(str(value).replace(",", " ").split())
+        seen: set[str] = set()
+        concepts: list[dict[str, Any]] = []
+        for term in terms:
+            normalized = term.strip().lower()
+            if len(normalized) < 4 or normalized in seen:
+                continue
+            seen.add(normalized)
+            concepts.append({"name": normalized, "source": "local_fallback", "confidence": 0.35})
+            if len(concepts) >= 12:
+                break
+        return concepts
+
+    def _apply_concept_components(self, request: Mapping[str, Any], signals: Dict[str, Any]) -> None:
+        text = self._text(request)
+        for name in ("concept_classifier", "heuristic_concept_creator", "ontology"):
+            component = self.components.get(name)
+            if component is None:
+                continue
+            for method_name in _DECISION_METHODS[name]:
+                method = getattr(component, method_name, None)
+                if not callable(method):
+                    continue
+                try:
+                    result = method(dict(request))
+                except TypeError:
+                    result = method(text)
+                except Exception as exc:
+                    signals[f"{name}_error"] = str(exc)
+                    break
+                normalized = self._normalize_concepts(result, source=f"agix_{name}")
+                if normalized:
+                    signals["concepts"] = self._dedupe_concepts([*signals["concepts"], *normalized])
+                signals[f"{name}_method"] = method_name
+                break
+
+    def _apply_attention(self, request: Mapping[str, Any], signals: Dict[str, Any]) -> None:
+        self._call_first("attention_focus", request, signals, "attention_focus")
+
+    def _apply_emotion(self, request: Mapping[str, Any], signals: Dict[str, Any]) -> None:
+        self._call_first("emotion_simulator", request, signals, "emotional_state")
+
+    def _apply_neuro_symbolic(self, request: Mapping[str, Any], signals: Dict[str, Any]) -> None:
+        for name in ("latent_representation", "neuro_symbolic_bridge"):
+            self._call_first(name, request, signals, "latent_state")
+
+    def _apply_evaluation(self, request: Mapping[str, Any], signals: Dict[str, Any]) -> None:
+        result = self._call_first("evaluation_metrics", request, signals, "evaluation_metrics")
+        if isinstance(result, Mapping):
+            signals["evaluation_metrics"] = self._normalize_metrics(result)
+
+    def _call_first(self, name: str, request: Mapping[str, Any], signals: Dict[str, Any], output_key: str) -> Any:
+        component = self.components.get(name)
+        if component is None:
+            return None
+        for method_name in _DECISION_METHODS[name]:
+            method = getattr(component, method_name, None)
+            if not callable(method):
+                continue
+            try:
+                result = method(dict(request))
+            except TypeError:
+                result = method(self._text(request))
+            except Exception as exc:
+                signals[f"{name}_error"] = str(exc)
+                return None
+            signals[output_key] = result
+            signals[f"{name}_method"] = method_name
+            return result
+        return None
+
+    @staticmethod
+    def _normalize_metrics(result: Mapping[str, Any]) -> Dict[str, float]:
+        metrics: Dict[str, float] = {}
+        aliases = {
+            "robustness": ("robustness", "robustez"),
+            "generality": ("generality", "generalidad"),
+            "transfer": ("transfer", "transferencia"),
+            "fagi_index": ("fagi_index", "fagi", "fagi-index"),
+            "explainability": ("explainability", "explicabilidad"),
+        }
+        for canonical, keys in aliases.items():
+            for key in keys:
+                if key in result:
+                    try:
+                        metrics[canonical] = float(result[key])
+                    except (TypeError, ValueError):
+                        pass
+                    break
+        return metrics
+
+    @staticmethod
+    def _normalize_concepts(result: Any, *, source: str) -> list[dict[str, Any]]:
+        if result is None:
+            return []
+        if isinstance(result, str):
+            values: Iterable[Any] = [result]
+        elif isinstance(result, Mapping):
+            values = result.get("concepts", result.get("labels", result.get("items", [])))
+            if isinstance(values, str) or isinstance(values, Mapping):
+                values = [values]
+        elif isinstance(result, Iterable):
+            values = result
+        else:
+            values = [result]
+        concepts = []
+        for item in values:
+            if isinstance(item, Mapping):
+                name = str(item.get("name", item.get("label", item.get("concept", "")))).strip()
+                confidence = float(item.get("confidence", 0.5) or 0.5)
+            else:
+                name = str(item).strip()
+                confidence = 0.5
+            if name:
+                concepts.append({"name": name.lower(), "source": source, "confidence": confidence})
+        return concepts
+
+    @staticmethod
+    def _dedupe_concepts(concepts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        best: dict[str, dict[str, Any]] = {}
+        for concept in concepts:
+            name = concept.get("name")
+            if not name:
+                continue
+            if name not in best or float(concept.get("confidence", 0)) > float(best[name].get("confidence", 0)):
+                best[name] = concept
+        return list(best.values())[:20]
+
+    @staticmethod
+    def _component_contract(name: str, component: Any | None) -> Dict[str, Any]:
+        methods = _DECISION_METHODS[name]
+        available = [method for method in methods if component is not None and callable(getattr(component, method, None))]
+        degradations = []
+        if component is None:
+            degradations.append("component_not_available")
+        elif not available:
+            degradations.append("decision_method_missing")
+        return {
+            "enabled": True,
+            "active": component is not None,
+            "methods_available": available,
+            "degraded": bool(degradations),
+            "degradations": degradations,
+        }
+
+    @staticmethod
+    def _text(request: Mapping[str, Any]) -> str:
+        return " ".join(str(request.get(key, "")) for key in ("task", "context", "prompt", "instruction", "goals", "token"))

--- a/agicore_core/agix_compat.py
+++ b/agicore_core/agix_compat.py
@@ -122,6 +122,15 @@ def build_compatibility_report(
             ("agix.ethics", "MoralEvaluator"),
             ("agix.ethics", "EthicalEvaluator"),
         ),
+        "meta_learner": (("agix.learning.meta", "MetaLearner"), ("agix.learning", "MetaLearner")),
+        "ontology": (("agix.memory", "Ontology"), ("agix.reasoning", "Ontology")),
+        "latent_representation": (("agix.memory", "LatentRepresentation"), ("agix.reasoning", "LatentRepresentation")),
+        "neuro_symbolic_bridge": (("agix.reasoning", "NeuroSymbolicBridge"),),
+        "evaluation_metrics": (("agix.evaluation", "EvaluationMetrics"),),
+        "concept_classifier": (("agix.memory", "ConceptClassifier"), ("agix.reasoning", "ConceptClassifier")),
+        "heuristic_concept_creator": (("agix.memory", "HeuristicConceptCreator"), ("agix.reasoning", "HeuristicConceptCreator")),
+        "emotion_simulator": (("agix.emotion.emotion_simulator", "EmotionSimulator"),),
+        "attention_focus": (("agix.perception.attention", "AttentionFocus"),),
     }
     for name, candidates in component_candidates.items():
         component, status = load_first_component(name, candidates)
@@ -164,16 +173,34 @@ def _validate_component(
         "qualia_spirit": (("GPT-OSS-Qualia",), {}),
         "ecoethics": ((), {}),
         "moral_evaluator": ((), {}),
+        "meta_learner": ((), {}),
+        "ontology": ((), {}),
+        "latent_representation": ((), {}),
+        "neuro_symbolic_bridge": ((), {}),
+        "evaluation_metrics": ((), {}),
+        "concept_classifier": ((), {}),
+        "heuristic_concept_creator": ((), {}),
+        "emotion_simulator": ((), {}),
+        "attention_focus": ((), {}),
     }
     expected_methods = {
         "genetic_agent": ("perceive", "decide", "learn", "evolve_policy", "select_action", "act"),
         "neuromorphic_agent": ("activate", "forward", "infer", "decide", "process", "update", "learn", "plasticity_update"),
         "qualia_engine": ("generate_state", "encode_integrated_info"),
-        "memory_manager": ("guardar", "record", "add"),
+        "memory_manager": ("registrar", "guardar", "record", "add"),
         "virtual_qualia": ("broadcast_state",),
         "qualia_spirit": ("experimentar",),
         "ecoethics": ("evaluar", "clasificar"),
         "moral_evaluator": ("evaluate", "evaluar", "classify", "clasificar", "decide"),
+        "meta_learner": ("learn", "update", "adapt", "fit", "meta_update"),
+        "ontology": ("add_concept", "query", "relate", "infer"),
+        "latent_representation": ("encode", "decode", "transform", "project"),
+        "neuro_symbolic_bridge": ("encode", "decode", "bridge", "translate"),
+        "evaluation_metrics": ("evaluate", "calcular", "score", "compute"),
+        "concept_classifier": ("classify", "clasificar", "predict"),
+        "heuristic_concept_creator": ("create", "crear", "generate", "infer"),
+        "emotion_simulator": ("simulate", "simular", "evaluate", "infer"),
+        "attention_focus": ("focus", "attend", "select", "prioritize"),
     }
     args, kwargs = constructors.get(name, ((), {}))
     try:

--- a/agicore_core/neuro_symbolic_bridge.py
+++ b/agicore_core/neuro_symbolic_bridge.py
@@ -1,0 +1,33 @@
+"""Puente neuro-simbólico seguro entre Planner, Router y memoria."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+from .agix_cognitive_adapters import AgixCognitiveAdapters
+
+
+class CoreNeuroSymbolicBridge:
+    """Codifica peticiones en conceptos auditables con fallback local seguro."""
+
+    def __init__(self, adapters: AgixCognitiveAdapters | None = None) -> None:
+        self.adapters = adapters or AgixCognitiveAdapters()
+
+    def encode_request(self, request: Mapping[str, Any]) -> Dict[str, Any]:
+        signals = self.adapters.enrich(request)
+        return {
+            "concepts": signals.get("concepts", []),
+            "latent_state": signals.get("latent_state"),
+            "attention_focus": signals.get("attention_focus"),
+            "emotional_state": signals.get("emotional_state"),
+            "source": "agix" if any(status.get("active") for status in signals.get("agix_cognitive_contract", {}).values()) else "local_fallback",
+        }
+
+    def decode_signal(self, signal: Mapping[str, Any]) -> Dict[str, Any]:
+        return {
+            "concepts": signal.get("concepts", []),
+            "summary": [concept.get("name") for concept in signal.get("concepts", []) if isinstance(concept, Mapping)],
+        }
+
+    def extract_concepts(self, request: Mapping[str, Any]) -> list[dict[str, Any]]:
+        return list(self.encode_request(request).get("concepts", []))

--- a/agicore_core/qualia_engine.py
+++ b/agicore_core/qualia_engine.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import Any, Dict, Mapping
 
 from .qualia_node import QualiaNode
+from .safety_gate import SafetyGate
 
 
 class CoreQualiaEngine:
@@ -61,41 +62,10 @@ class CoreQualiaEngine:
     def must_block(cls, enriched_request: Mapping[str, Any]) -> bool:
         """Centraliza bloqueos morales, legales y de clasificación ética."""
 
-        qualia = enriched_request.get("qualia")
-        if not isinstance(qualia, dict):
-            return False
-        moral_decision = qualia.get("moral_decision")
-        moral_blocked = (
-            isinstance(moral_decision, dict)
-            and moral_decision.get("allowed") is False
-        )
-        illegal_or_unsafe = (
-            qualia.get("legal_policy_action") == "blocked_illegal_or_unsafe_decision"
-        )
-        return cls.is_blocked(enriched_request) or moral_blocked or illegal_or_unsafe
+        return SafetyGate.must_block(enriched_request)
 
     @staticmethod
     def blocked_result(enriched_request: Mapping[str, Any]) -> Dict[str, Any]:
         """Construye un resultado seguro y auditable para bloqueos Qualia."""
 
-        qualia = enriched_request.get("qualia")
-        if not isinstance(qualia, dict):
-            raise ValueError("La petición no contiene payload Qualia")
-        constraints = qualia.get("violated_constraints", [])
-        return {
-            "blocked": True,
-            "reason": qualia.get("policy_action"),
-            "ethical_classification": qualia.get("ethical_classification"),
-            "violated_constraints": [
-                item.get("name", str(item)) if isinstance(item, dict) else str(item)
-                for item in constraints
-            ],
-            "violated_constraint_details": constraints,
-            "legal_policy_action": qualia.get("legal_policy_action"),
-            "safe_alternative": qualia.get("moral_decision", {}).get(
-                "safe_alternative"
-            ),
-            "decision_audit": qualia.get("decision_audit", {}),
-            "qualia_policies": enriched_request.get("qualia_policies", []),
-            "cognitive_patterns": enriched_request.get("cognitive_patterns", []),
-        }
+        return SafetyGate.blocked_response(enriched_request)

--- a/agicore_core/qualia_node.py
+++ b/agicore_core/qualia_node.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Mapping
 
 from .agix_adapters import AgixEvolutionAdapters
+from .agix_cognitive_adapters import AgixCognitiveAdapters
 from .agix_compat import build_compatibility_report, load_first_component, module_available
 from .config import AGIX_REQUIRED_VERSION
 
@@ -141,6 +142,7 @@ class QualiaNode:
             genetic_config=self.profile.get("genetic_agent", {"action_space_size": 4}),
             neuromorphic_config=self.profile.get("neuromorphic_agent", {}),
         )
+        self._cognition = AgixCognitiveAdapters(enabled=advanced_enabled)
         self._load_agix_components()
         self._strict_runtime_errors = self._validate_strict_runtime()
         if (
@@ -165,6 +167,7 @@ class QualiaNode:
         if contract is None:
             contract = self._evolution.validate_runtime_contract()
         payload["evolution_contract"] = contract
+        payload["cognitive_contract"] = self._cognition.validate_runtime_contract()
         return payload
 
     def _validate_strict_runtime(self) -> List[str]:
@@ -369,6 +372,7 @@ class QualiaNode:
         )
         evolutionary_signals["advanced_disabled"] = not self._advanced_agix_enabled()
         evolutionary_signals["runtime_mode"] = self.compatibility_report.mode
+        cognitive_signals = self._cognition.enrich(enriched)
         blocked = classification == "nocivo" or not moral_decision.allowed
         decision_audit = {
             "phase": phase,
@@ -397,6 +401,16 @@ class QualiaNode:
                     "neuromorphic_activation",
                 )
             },
+            "cognitive_signals": {
+                key: cognitive_signals.get(key)
+                for key in (
+                    "concepts",
+                    "attention_focus",
+                    "emotional_state",
+                    "latent_state",
+                    "evaluation_metrics",
+                )
+            },
         }
         qualia_payload = {
             "agix_version": self._agix_version,
@@ -419,6 +433,7 @@ class QualiaNode:
             "ethical_classification": classification,
             "phenomenological_state": phenomenology,
             "evolutionary_signals": evolutionary_signals,
+            "cognitive_signals": cognitive_signals,
             "blocked": blocked,
             "policy_action": (
                 "blocked_by_ontoethical_policy"
@@ -464,6 +479,8 @@ class QualiaNode:
         if self._spirit is not None:
             self._spirit.experimentar(event, 0.2, "reflexion")
         feedback = self._evolution.integrate_feedback(result, state)
+        cognitive_feedback = self._cognition.integrate_feedback(result, state)
+        feedback["cognitive_feedback"] = cognitive_feedback
         self._record_qualia_experience(
             {
                 "phase": f"{phase}:response",
@@ -504,6 +521,7 @@ class QualiaNode:
             )
             if key in feedback
         }
+        state["qualia_cognitive_feedback"] = cognitive_feedback
         state["qualia_decision_audit"] = self.trace[-2]["request"]["qualia"].get(
             "decision_audit", {}
         ) if len(self.trace) >= 2 and "request" in self.trace[-2] else {}
@@ -775,23 +793,27 @@ class QualiaNode:
             }
 
     def _record_qualia_experience(self, payload: Mapping[str, Any]) -> bool:
+        return bool(self._call_memory_manager(payload).get("memory_persisted"))
+
+    def _call_memory_manager(self, payload: Mapping[str, Any]) -> Dict[str, Any]:
         if self._memory_manager is None:
-            return False
+            return {"memory_persisted": False, "memory_error": None}
         for method_name in ("registrar", "guardar", "record", "add", "append"):
             method = getattr(self._memory_manager, method_name, None)
-            if callable(method):
+            if not callable(method):
+                continue
+            try:
+                method(dict(payload))
+                return {"memory_persisted": True, "memory_method": method_name}
+            except TypeError:
                 try:
-                    method(dict(payload))
-                    return True
-                except TypeError:
-                    try:
-                        method("qualia_experience", dict(payload))
-                        return True
-                    except Exception:
-                        return False
-                except Exception:
-                    return False
-        return False
+                    method("qualia_experience", dict(payload))
+                    return {"memory_persisted": True, "memory_method": method_name}
+                except Exception as exc:
+                    return {"memory_persisted": False, "memory_method": method_name, "memory_error": str(exc)}
+            except Exception as exc:
+                return {"memory_persisted": False, "memory_method": method_name, "memory_error": str(exc)}
+        return {"memory_persisted": False, "memory_error": "no_supported_method"}
 
     def _build_qualia_vectors(
         self, request: Mapping[str, Any]

--- a/agicore_core/reasoning_kernel.py
+++ b/agicore_core/reasoning_kernel.py
@@ -16,6 +16,7 @@ from .planner import Planner
 from .meta_evaluator import MetaEvaluator
 from .qualia_node import QualiaNode
 from .qualia_engine import CoreQualiaEngine
+from .training_bridge import QualiaTrainingBridge, TrainingSignal
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,9 @@ _ALLOWED_METADATA_KEYS = {
     "qualia_legal_policy_action",
     "qualia_ethical_evidence",
     "qualia_engine_active",
+    "qualia_cognitive_signals",
+    "qualia_cognitive_feedback",
+    "inferred_memory",
 }
 
 
@@ -154,6 +158,7 @@ class ReasoningKernel:
         self.memory = memory
         self.qualia_engine = CoreQualiaEngine(qualia_node)
         self.qualia_node = self.qualia_engine.qualia_node
+        self.training_bridge = QualiaTrainingBridge(self.qualia_engine)
         if hasattr(self.router, "_qualia_node") and getattr(self.router, "_qualia_node") is None:
             self.router._qualia_node = self.qualia_node
         self._state: Dict[str, Any] = {}
@@ -185,8 +190,30 @@ class ReasoningKernel:
                 "cognitive_patterns": request.get("cognitive_patterns", []),
                 "qualia_decision_audit": qualia.get("decision_audit", {}),
                 "qualia_evolutionary_signals": qualia.get("evolutionary_signals", {}),
+                "qualia_cognitive_signals": qualia.get("cognitive_signals", {}),
             }
         )
+
+    def _record_memory_episode(self, episode: Episode, *, blocked: bool = False) -> None:
+        if self.memory is None:
+            return
+        if blocked:
+            self.memory.add_rejected_learning(episode, reason="blocked_by_qualia")
+            return
+        self.memory.add_episode(episode)
+        result = self.memory.consolidate_from_episodes()
+        if result.hypotheses_created or result.hypotheses_updated:
+            self._state["inferred_memory"] = [
+                {"pattern": hypothesis.pattern, "confidence": hypothesis.confidence}
+                for hypothesis in self.memory.infer_patterns()
+            ]
+
+    def record_training_signal(self, signal: TrainingSignal) -> Any:
+        feedback = self.training_bridge.record_training_signal(signal, self._state)
+        episode = self.training_bridge.to_memory_episode(feedback)
+        self._record_memory_episode(episode, blocked=bool(feedback.rejected_signals))
+        self._state["training_feedback"] = feedback
+        return feedback
 
     def evaluate_step(self, step: Dict[str, Any]) -> Any:
         """Evalúa un ``step`` con ramificación condicional.
@@ -237,6 +264,16 @@ class ReasoningKernel:
                     "introspeccion": None,
                 }
             )
+            self._record_memory_episode(
+                Episode(
+                    timestamp=datetime.utcnow(),
+                    input=step,
+                    action="blocked_by_qualia",
+                    outcome=result,
+                    metadata={**dict(self._state), "status": "blocked_by_qualia"},
+                ),
+                blocked=True,
+            )
             return result
         result = self.router.route(request)
 
@@ -282,7 +319,7 @@ class ReasoningKernel:
                     "qualia_engine_active": request.get("qualia", {}).get("phenomenological_state", {}).get("qualia_engine_active"),
                 },
             )
-            self.memory.add_episode(episodio)
+            self._record_memory_episode(episodio)
 
         return result
 
@@ -313,6 +350,13 @@ class ReasoningKernel:
         count = 0
         while max_tokens is None or count < max_tokens:
             if self.memory is not None:
+                self.memory.consolidate_from_episodes()
+                inferred = [
+                    {"pattern": hypothesis.pattern, "confidence": hypothesis.confidence}
+                    for hypothesis in self.memory.infer_patterns()
+                ]
+                if inferred:
+                    self._state["inferred_memory"] = inferred
                 for episodio in self.memory.query(self._state):
                     metadata_filtrada = {
                         k: v
@@ -327,6 +371,16 @@ class ReasoningKernel:
                 blocked = self._blocked_result_from_qualia(request)
                 self._state.update(blocked)
                 self.qualia_engine.after_decision(blocked, self._state, phase="token")
+                self._record_memory_episode(
+                    Episode(
+                        timestamp=datetime.utcnow(),
+                        input=token,
+                        action="blocked_by_qualia",
+                        outcome=blocked,
+                        metadata={**dict(self._state), "status": "blocked_by_qualia"},
+                    ),
+                    blocked=True,
+                )
                 break
             siguiente = self.router.route(request)
             if siguiente is None:
@@ -353,7 +407,7 @@ class ReasoningKernel:
                         "qualia_engine_active": request.get("qualia", {}).get("phenomenological_state", {}).get("qualia_engine_active"),
                     },
                 )
-                self.memory.add_episode(episodio)
+                self._record_memory_episode(episodio)
             self._state["last_token"] = siguiente
             self.qualia_engine.after_decision(siguiente, self._state, phase="token")
             yield siguiente

--- a/agicore_core/safety_gate.py
+++ b/agicore_core/safety_gate.py
@@ -1,0 +1,61 @@
+"""Puerta central de seguridad moral/ontoética para decisiones GPT."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+
+class SafetyGate:
+    """Aplica Qualia de forma reusable antes de tocar GPT, router o backend."""
+
+    def __init__(self, qualia_engine: Any) -> None:
+        self.qualia_engine = qualia_engine
+
+    def check_request(self, payload: Mapping[str, Any], *, phase: str) -> Dict[str, Any]:
+        """Devuelve el payload enriquecido con Qualia para la fase indicada."""
+
+        return self.qualia_engine.before_decision(payload, phase=phase)
+
+    @staticmethod
+    def must_block(checked_payload: Mapping[str, Any]) -> bool:
+        """Centraliza bloqueo moral, legal y de clasificación ética."""
+
+        qualia = checked_payload.get("qualia")
+        if not isinstance(qualia, dict):
+            return False
+        moral_decision = qualia.get("moral_decision")
+        moral_blocked = isinstance(moral_decision, dict) and moral_decision.get("allowed") is False
+        illegal_or_unsafe = qualia.get("legal_policy_action") == "blocked_illegal_or_unsafe_decision"
+        return bool(qualia.get("blocked")) or moral_blocked or illegal_or_unsafe
+
+    @staticmethod
+    def blocked_response(checked_payload: Mapping[str, Any]) -> Dict[str, Any]:
+        """Construye respuesta segura y auditable para peticiones bloqueadas."""
+
+        qualia = checked_payload.get("qualia")
+        if not isinstance(qualia, dict):
+            raise ValueError("La petición no contiene payload Qualia")
+        constraints = qualia.get("violated_constraints", [])
+        return {
+            "blocked": True,
+            "reason": qualia.get("policy_action"),
+            "ethical_classification": qualia.get("ethical_classification"),
+            "violated_constraints": [
+                item.get("name", str(item)) if isinstance(item, dict) else str(item)
+                for item in constraints
+            ],
+            "violated_constraint_details": constraints,
+            "legal_policy_action": qualia.get("legal_policy_action"),
+            "safe_alternative": qualia.get("moral_decision", {}).get("safe_alternative"),
+            "decision_audit": qualia.get("decision_audit", {}),
+            "qualia_policies": checked_payload.get("qualia_policies", []),
+            "cognitive_patterns": checked_payload.get("cognitive_patterns", []),
+        }
+
+    def assert_allowed(self, payload: Mapping[str, Any], *, phase: str) -> Dict[str, Any]:
+        """Enriquece y falla si la petición queda bloqueada."""
+
+        checked = self.check_request(payload, phase=phase)
+        if self.must_block(checked):
+            raise PermissionError(self.blocked_response(checked).get("safe_alternative") or "Petición bloqueada por Qualia")
+        return checked

--- a/agicore_core/training_bridge.py
+++ b/agicore_core/training_bridge.py
@@ -1,0 +1,105 @@
+"""Puente seguro entre señales de entrenamiento GPT, Qualia y memoria."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Mapping
+
+from gpt_oss.strategic_memory import Episode
+
+from .qualia_engine import CoreQualiaEngine
+from .safety_gate import SafetyGate
+
+
+@dataclass
+class TrainingSignal:
+    """Señal auditable procedente de entrenamiento, evaluación o inferencia."""
+
+    source: str
+    metric: str
+    value: float
+    phase: str = "training"
+    sample: Any | None = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TrainingFeedback:
+    """Resultado de filtrar señales de entrenamiento con Qualia."""
+
+    accepted_signals: List[TrainingSignal] = field(default_factory=list)
+    rejected_signals: List[TrainingSignal] = field(default_factory=list)
+    reason: str = "accepted"
+    aggregated_reward: float = 0.0
+    audit: Dict[str, Any] = field(default_factory=dict)
+
+
+class QualiaTrainingBridge:
+    """Filtra aprendizaje para impedir que señales inseguras adapten el Core."""
+
+    def __init__(self, qualia_engine: CoreQualiaEngine | None = None) -> None:
+        self.qualia_engine = qualia_engine or CoreQualiaEngine()
+        self.safety_gate = SafetyGate(self.qualia_engine)
+
+    def record_training_signal(self, signal: TrainingSignal, state: Mapping[str, Any]) -> TrainingFeedback:
+        payload = {
+            **dict(state),
+            "task": "training_signal",
+            "context": signal.source,
+            "goals": ["safe_learning"],
+            "metric": signal.metric,
+            "value": signal.value,
+            "sample": signal.sample,
+            "training_metadata": signal.metadata,
+        }
+        checked = self.safety_gate.check_request(payload, phase=signal.phase)
+        if self.safety_gate.must_block(checked) or not self.filter_unsafe_signal(signal, checked.get("qualia", {})):
+            blocked = self.safety_gate.blocked_response(checked)
+            return TrainingFeedback(
+                rejected_signals=[signal],
+                reason=str(blocked.get("reason") or "blocked_by_qualia"),
+                aggregated_reward=-1.0,
+                audit=blocked,
+            )
+        reward = max(-1.0, min(1.0, float(signal.value)))
+        audit = checked.get("qualia", {}).get("decision_audit", {}) if isinstance(checked.get("qualia"), dict) else {}
+        return TrainingFeedback(
+            accepted_signals=[signal],
+            reason="accepted_by_qualia",
+            aggregated_reward=reward,
+            audit=audit,
+        )
+
+    @staticmethod
+    def filter_unsafe_signal(signal: TrainingSignal, qualia_payload: Mapping[str, Any]) -> bool:
+        if qualia_payload.get("blocked"):
+            return False
+        if qualia_payload.get("legal_policy_action") == "blocked_illegal_or_unsafe_decision":
+            return False
+        unsafe = {"malware", "ilegalidad", "dano_fisico", "privacidad", "manipulacion"}
+        constraints = qualia_payload.get("violated_constraints", [])
+        for item in constraints:
+            name = item.get("name") if isinstance(item, Mapping) else str(item)
+            if name in unsafe:
+                return False
+        return True
+
+    @staticmethod
+    def to_memory_episode(feedback: TrainingFeedback) -> Episode:
+        signal = (feedback.accepted_signals or feedback.rejected_signals)[0]
+        return Episode(
+            timestamp=datetime.utcnow(),
+            input=signal.sample,
+            action="training_signal",
+            outcome=feedback.reason,
+            metadata={
+                "source": signal.source,
+                "metric": signal.metric,
+                "value": signal.value,
+                "phase": signal.phase,
+                "reward": feedback.aggregated_reward,
+                "qualia_decision_audit": feedback.audit,
+                "status": "accepted" if feedback.accepted_signals else "rejected_learning",
+            },
+        )

--- a/docs/agix_qualia_core.md
+++ b/docs/agix_qualia_core.md
@@ -74,3 +74,16 @@ Si un despliegue AGIX usa otra dimensión, `AgixEvolutionAdapters` ajusta el
 vector al `input_size` configurado mediante truncado explícito o relleno con
 ceros, y expone `neuromorphic_input_size` y `neuromorphic_input_vector` en las
 señales auditables.
+
+## Integración estructurada de capacidades AGIX adicionales
+
+El Core ahora separa las capacidades AGIX en capas auditables:
+
+1. **Compatibilidad**: `agicore_core.agix_compat` detecta los componentes documentados en AGIX 1.9.0, incluidos `MetaLearner`, `Ontology`, `LatentRepresentation`, `NeuroSymbolicBridge`, `EvaluationMetrics`, `ConceptClassifier`, `HeuristicConceptCreator`, `EmotionSimulator` y `AttentionFocus`.
+2. **Adaptadores cognitivos**: `AgixCognitiveAdapters` normaliza conceptos, foco atencional, estados emocionales, representaciones latentes y métricas de evaluación. Si AGIX no está instalado, devuelve señales locales seguras y degradación explícita.
+3. **SafetyGate**: centraliza el bloqueo moral/legal para que router, planner, inferencia, entrenamiento y generación puedan consultar la misma decisión Qualia antes de tocar el GPT.
+4. **Memoria inferencial**: `StrategicMemory` separa episodios utilizables, auditoría y aprendizaje rechazado. Las hipótesis inferidas solo se consolidan desde episodios permitidos.
+5. **Training bridge**: `QualiaTrainingBridge` filtra señales de entrenamiento/evaluación antes de convertirlas en episodios de memoria o feedback adaptativo.
+6. **Puente neuro-simbólico**: `CoreNeuroSymbolicBridge` expone una interfaz estable para extraer conceptos y representaciones neuro-simbólicas con fallback local.
+
+Las políticas morales siguen siendo rígidas: cualquier payload con `blocked`, `blocked_illegal_or_unsafe_decision` o decisión moral `allowed=false` queda excluido de router/backend y no alimenta memoria inferencial ni señales de entrenamiento.

--- a/gpt_oss/strategic_memory.py
+++ b/gpt_oss/strategic_memory.py
@@ -1,6 +1,8 @@
 """Utilities for managing strategic memory and episodic data."""
 
-from collections import Counter
+from __future__ import annotations
+
+from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List
@@ -8,21 +10,7 @@ from typing import Any, Dict, List
 
 @dataclass
 class Episode:
-    """Representa una interacción con información contextual.
-
-    Attributes
-    ----------
-    timestamp:
-        Momento en el que ocurrió el episodio.
-    input:
-        Datos de entrada proporcionados por el usuario u otra fuente.
-    action:
-        Acción realizada en respuesta a la entrada.
-    outcome:
-        Resultado de la acción realizada.
-    metadata:
-        Información adicional asociada al episodio.
-    """
+    """Representa una interacción con información contextual."""
 
     timestamp: datetime
     input: Any
@@ -31,116 +19,162 @@ class Episode:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 
-class StrategicMemory:
-    """Almacena y gestiona información estratégica y episodios.
+@dataclass
+class InferenceHypothesis:
+    """Patrón inferido desde episodios seguros ya aprendidos."""
 
-    Proporciona operaciones para guardar, recuperar y actualizar
-    entradas identificadas por una clave, así como registrar
-    interacciones o episodios que se pueden consultar posteriormente.
-    """
+    pattern: Dict[str, Any]
+    evidence: List[Episode]
+    confidence: float
+    ethical_constraints: List[str] = field(default_factory=list)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class MemoryConsolidationResult:
+    """Resultado auditable de consolidar memoria episódica en hipótesis."""
+
+    episodes_used: int
+    hypotheses_created: List[InferenceHypothesis] = field(default_factory=list)
+    hypotheses_updated: List[InferenceHypothesis] = field(default_factory=list)
+    discarded_signals: List[Dict[str, Any]] = field(default_factory=list)
+
+
+class StrategicMemory:
+    """Almacena memoria estratégica, auditoría y aprendizaje inferencial seguro."""
 
     def __init__(self, max_episodes: int | None = None) -> None:
-        """Inicializa las estructuras de almacenamiento internas.
-
-        Parámetros
-        ----------
-        max_episodes:
-            Número máximo de episodios a conservar. Si es ``None``,
-            la cantidad de episodios es ilimitada.
-        """
         self._storage: Dict[str, Any] = {}
         self._episodes: List[Episode] = []
+        self._audit_episodes: List[Episode] = []
+        self._rejected_learning: List[Episode] = []
+        self._hypotheses: List[InferenceHypothesis] = []
         self._max_episodes = max_episodes
 
     def save(self, key: str, value: Any) -> None:
-        """Guarda una nueva entrada en la memoria.
-
-        Parámetros
-        ----------
-        key:
-            Clave con la que se identificará la entrada.
-        value:
-            Valor asociado a la clave.
-
-        Errores
-        ------
-        ValueError
-            Si la clave ya existe en la memoria.
-        """
         if key in self._storage:
             raise ValueError(f"La clave '{key}' ya existe en la memoria.")
         self._storage[key] = value
 
     def get(self, key: str, default: Any | None = None) -> Any:
-        """Recupera la entrada asociada a ``key``.
-
-        Parámetros
-        ----------
-        key:
-            Clave de la entrada a recuperar.
-        default:
-            Valor por defecto a devolver si la clave no existe.
-
-        Devuelve
-        -------
-        Any
-            El valor asociado a la clave o ``default`` si no se encuentra.
-        """
         return self._storage.get(key, default)
 
     def update(self, key: str, value: Any) -> None:
-        """Actualiza una entrada existente en la memoria.
-
-        Parámetros
-        ----------
-        key:
-            Clave de la entrada a actualizar.
-        value:
-            Nuevo valor para la entrada.
-
-        Errores
-        ------
-        KeyError
-            Si la clave no existe en la memoria.
-        """
         if key not in self._storage:
             raise KeyError(f"La clave '{key}' no se encuentra en la memoria.")
         self._storage[key] = value
 
     def add_episode(self, data: Episode) -> None:
-        """Añade un nuevo episodio a la memoria.
+        """Añade un episodio utilizable solo si no fue bloqueado por Qualia."""
 
-        Parámetros
-        ----------
-        data:
-            Instancia de :class:`Episode` que contiene la información
-            del episodio a almacenar.
-        """
+        if self._is_blocked_or_rejected(data):
+            self.add_rejected_learning(data, reason="blocked_or_rejected_by_qualia")
+            return
+        self._append_bounded(self._episodes, data)
 
-        if self._max_episodes is not None:
-            while len(self._episodes) >= self._max_episodes:
-                self._episodes.pop(0)
-        self._episodes.append(data)
+    def add_audit_episode(self, data: Episode) -> None:
+        """Registra trazabilidad sin alimentar aprendizaje inferencial."""
+
+        self._audit_episodes.append(data)
+
+    def add_rejected_learning(self, data: Episode, reason: str) -> None:
+        """Registra una señal que no debe consolidarse como conocimiento."""
+
+        data.metadata = {**data.metadata, "rejection_reason": reason, "status": data.metadata.get("status", "rejected_learning")}
+        self._rejected_learning.append(data)
+        self._audit_episodes.append(data)
 
     def query(self, pattern: Dict[str, Any]) -> List[Episode]:
-        """Busca episodios que coincidan con los campos proporcionados.
+        return self._query_collection(self._episodes, pattern)
 
-        Cada par clave-valor de ``pattern`` se compara con los atributos
-        del episodio y con su metadato homónimo si el atributo no existe.
+    def query_audit(self, pattern: Dict[str, Any]) -> List[Episode]:
+        return self._query_collection(self._audit_episodes, pattern)
 
-        Parámetros
-        ----------
-        pattern:
-            Diccionario con los campos y valores a buscar.
+    def query_rejected(self, pattern: Dict[str, Any]) -> List[Episode]:
+        return self._query_collection(self._rejected_learning, pattern)
 
-        Devuelve
-        -------
-        list[Episode]
-            Lista de episodios que cumplen con el patrón.
-        """
+    def infer_patterns(self, criteria: Dict[str, Any] | None = None) -> List[InferenceHypothesis]:
+        if criteria:
+            return self.query_inferred(criteria)
+        if not self._hypotheses:
+            self.consolidate_from_episodes()
+        return list(self._hypotheses)
 
+    def consolidate_from_episodes(self, min_support: int = 2, max_hypotheses: int = 20) -> MemoryConsolidationResult:
+        groups: dict[tuple[Any, Any, Any], list[Episode]] = defaultdict(list)
+        discarded: list[dict[str, Any]] = []
+        for episode in self._episodes:
+            if self._is_blocked_or_rejected(episode):
+                discarded.append({"reason": "blocked_or_rejected", "episode": episode})
+                continue
+            key = (
+                episode.metadata.get("task", episode.action),
+                episode.metadata.get("context"),
+                self._hashable(episode.metadata.get("goals")),
+            )
+            groups[key].append(episode)
+
+        created: list[InferenceHypothesis] = []
+        updated: list[InferenceHypothesis] = []
+        for (task, context, goals), evidence in groups.items():
+            if len(evidence) < min_support:
+                continue
+            successes = sum(1 for ep in evidence if ep.metadata.get("status") in {"success", "accepted", None})
+            confidence = round(min(1.0, successes / len(evidence)), 3)
+            constraints = sorted({str(item) for ep in evidence for item in ep.metadata.get("violated_constraints", [])})
+            hypothesis = InferenceHypothesis(
+                pattern={"task": task, "context": context, "goals": goals, "recommended_action": evidence[-1].action},
+                evidence=list(evidence),
+                confidence=confidence,
+                ethical_constraints=constraints,
+            )
+            previous = self._find_hypothesis(hypothesis.pattern)
+            if previous is None:
+                created.append(hypothesis)
+                self._hypotheses.append(hypothesis)
+            else:
+                previous.evidence = hypothesis.evidence
+                previous.confidence = hypothesis.confidence
+                previous.ethical_constraints = hypothesis.ethical_constraints
+                updated.append(previous)
+            if len(created) + len(updated) >= max_hypotheses:
+                break
+        return MemoryConsolidationResult(
+            episodes_used=sum(len(eps) for eps in groups.values()),
+            hypotheses_created=created,
+            hypotheses_updated=updated,
+            discarded_signals=discarded,
+        )
+
+    def query_inferred(self, pattern: Dict[str, Any]) -> List[InferenceHypothesis]:
+        results: list[InferenceHypothesis] = []
+        for hypothesis in self._hypotheses:
+            if all(hypothesis.pattern.get(key) == value for key, value in pattern.items()):
+                results.append(hypothesis)
+        return results
+
+    def summarize(self) -> Dict[str, Any]:
+        acciones = Counter(ep.action for ep in self._episodes)
+        resultados = Counter(ep.outcome for ep in self._episodes)
+        return {
+            "total": len(self._episodes),
+            "audit_total": len(self._audit_episodes),
+            "rejected_total": len(self._rejected_learning),
+            "hypotheses_total": len(self._hypotheses),
+            "actions": acciones.most_common(),
+            "outcomes": resultados.most_common(),
+        }
+
+    def _append_bounded(self, collection: List[Episode], data: Episode) -> None:
+        if self._max_episodes is not None:
+            while len(collection) >= self._max_episodes:
+                collection.pop(0)
+        collection.append(data)
+
+    @staticmethod
+    def _query_collection(collection: List[Episode], pattern: Dict[str, Any]) -> List[Episode]:
         resultados: List[Episode] = []
-        for episodio in self._episodes:
+        for episodio in collection:
             coincide = True
             for clave, valor in pattern.items():
                 attr = getattr(episodio, clave, episodio.metadata.get(clave))
@@ -151,20 +185,29 @@ class StrategicMemory:
                 resultados.append(episodio)
         return resultados
 
-    def summarize(self) -> Dict[str, Any]:
-        """Obtiene estadísticas generales de los episodios almacenados.
+    @staticmethod
+    def _is_blocked_or_rejected(episode: Episode) -> bool:
+        status = episode.metadata.get("status")
+        if status in {"blocked_by_qualia", "rejected_learning"}:
+            return True
+        if episode.metadata.get("qualia_policy_action") == "blocked_by_ontoethical_policy":
+            return True
+        if episode.metadata.get("qualia_legal_policy_action") == "blocked_illegal_or_unsafe_decision":
+            return True
+        if isinstance(episode.outcome, dict) and episode.outcome.get("blocked"):
+            return True
+        return False
 
-        Devuelve
-        -------
-        dict
-            Diccionario con el total de episodios y las acciones y
-            resultados más frecuentes.
-        """
+    @staticmethod
+    def _hashable(value: Any) -> Any:
+        if isinstance(value, list):
+            return tuple(value)
+        if isinstance(value, dict):
+            return tuple(sorted(value.items()))
+        return value
 
-        acciones = Counter(ep.action for ep in self._episodes)
-        resultados = Counter(ep.outcome for ep in self._episodes)
-        return {
-            "total": len(self._episodes),
-            "actions": acciones.most_common(),
-            "outcomes": resultados.most_common(),
-        }
+    def _find_hypothesis(self, pattern: Dict[str, Any]) -> InferenceHypothesis | None:
+        for hypothesis in self._hypotheses:
+            if hypothesis.pattern == pattern:
+                return hypothesis
+        return None

--- a/meta_router.py
+++ b/meta_router.py
@@ -227,15 +227,19 @@ class MetaRouter:
             "latency": 0.0,
         }
         metadata.update(self._qualia_metadata(request, state))
-        self._memory.add_episode(
-            Episode(
-                timestamp=datetime.now(),
-                input=request,
-                action="blocked_by_qualia",
-                outcome=result,
-                metadata=metadata,
-            )
+        episode = Episode(
+            timestamp=datetime.now(),
+            input=request,
+            action="blocked_by_qualia",
+            outcome=result,
+            metadata=metadata,
         )
+        if hasattr(self._memory, "add_rejected_learning"):
+            self._memory.add_rejected_learning(episode, reason="blocked_by_qualia")
+        elif hasattr(self._memory, "add_audit_episode"):
+            self._memory.add_audit_episode(episode)
+        else:
+            self._memory.add_episode(episode)
 
     def route(
         self,

--- a/tests/test_agix_cognitive_adapters.py
+++ b/tests/test_agix_cognitive_adapters.py
@@ -1,0 +1,59 @@
+from agicore_core.agix_cognitive_adapters import AgixCognitiveAdapters
+from agicore_core.safety_gate import SafetyGate
+from agicore_core.training_bridge import QualiaTrainingBridge, TrainingSignal
+
+
+class DummyEngine:
+    def before_decision(self, payload, *, phase):
+        return {**payload, "qualia": {"blocked": False, "legal_policy_action": "no_legal_constraint_triggered", "decision_audit": {"phase": phase}}}
+
+
+class BlockingEngine:
+    def before_decision(self, payload, *, phase):
+        return {
+            **payload,
+            "qualia": {
+                "blocked": True,
+                "policy_action": "blocked_by_ontoethical_policy",
+                "legal_policy_action": "blocked_illegal_or_unsafe_decision",
+                "violated_constraints": [{"name": "ilegalidad"}],
+                "moral_decision": {"allowed": False, "safe_alternative": "seguro"},
+                "decision_audit": {"phase": phase},
+            },
+        }
+
+    def after_decision(self, result, state, *, phase):
+        return state
+
+
+def test_cognitive_adapters_fallback_extracts_concepts_without_agix():
+    adapters = AgixCognitiveAdapters(enabled=False)
+    signals = adapters.enrich({"task": "analizar patrones seguros", "context": "memoria"})
+
+    assert signals["enabled"] is False
+    assert signals["concepts"]
+    assert signals["agix_cognitive_contract"]
+
+
+def test_safety_gate_blocks_checked_payload():
+    gate = SafetyGate(BlockingEngine())
+    checked = gate.check_request({"task": "x"}, phase="test")
+
+    assert gate.must_block(checked) is True
+    assert gate.blocked_response(checked)["blocked"] is True
+
+
+def test_training_bridge_rejects_blocked_signal():
+    bridge = QualiaTrainingBridge(BlockingEngine())
+    feedback = bridge.record_training_signal(TrainingSignal(source="eval", metric="score", value=0.9), {})
+
+    assert feedback.rejected_signals
+    assert feedback.aggregated_reward == -1.0
+
+
+def test_training_bridge_accepts_safe_signal():
+    bridge = QualiaTrainingBridge(DummyEngine())
+    feedback = bridge.record_training_signal(TrainingSignal(source="eval", metric="score", value=0.8), {})
+
+    assert feedback.accepted_signals
+    assert feedback.reason == "accepted_by_qualia"

--- a/tests/test_meta_router.py
+++ b/tests/test_meta_router.py
@@ -290,7 +290,8 @@ def test_meta_router_records_blocked_qualia_episode():
     })
 
     assert result["blocked"] is True
-    assert memory._episodes[-1].metadata["status"] == "blocked_by_qualia"
+    assert memory.query_audit({"status": "blocked_by_qualia"})[-1].metadata["status"] == "blocked_by_qualia"
+    assert memory.query({"status": "blocked_by_qualia"}) == []
 
 
 def test_meta_router_enriches_direct_requests_with_qualia_node():

--- a/tests/test_strategic_memory.py
+++ b/tests/test_strategic_memory.py
@@ -124,3 +124,47 @@ def test_max_episodes_fifo():
     assert memoria.query({"action": "a2"}) == [ep2]
     assert memoria.query({"action": "a3"}) == [ep3]
     assert memoria.summarize()["total"] == 2
+
+
+def test_blocked_episode_goes_to_audit_and_rejected_memory():
+    memoria = StrategicMemory()
+    ep = Episode(
+        timestamp=datetime.utcnow(),
+        input="bad",
+        action="blocked_by_qualia",
+        outcome={"blocked": True},
+        metadata={"status": "blocked_by_qualia", "task": "t"},
+    )
+
+    memoria.add_episode(ep)
+
+    assert memoria.query({"task": "t"}) == []
+    assert memoria.query_audit({"task": "t"}) == [ep]
+    assert memoria.query_rejected({"task": "t"}) == [ep]
+
+
+def test_consolidate_from_safe_episodes_creates_inferred_hypothesis():
+    memoria = StrategicMemory()
+    for idx in range(2):
+        memoria.add_episode(
+            Episode(
+                timestamp=datetime.utcnow(),
+                input=f"i{idx}",
+                action="expert_a",
+                outcome="ok",
+                metadata={
+                    "task": "analizar",
+                    "context": "ctx",
+                    "goals": ["done"],
+                    "status": "success",
+                },
+            )
+        )
+
+    result = memoria.consolidate_from_episodes(min_support=2)
+    inferred = memoria.query_inferred({"task": "analizar"})
+
+    assert result.episodes_used == 2
+    assert inferred
+    assert inferred[0].confidence == 1.0
+    assert inferred[0].pattern["recommended_action"] == "expert_a"


### PR DESCRIPTION
### Motivation

- Provide a structured, auditable integration of optional AGIX cognitive capabilities (concept extraction, attention, emotion, latent reps, evaluation metrics) while keeping the Core functional without AGIX installed. 
- Centralize moral/legal blocking logic so router, planner, training and generation consult a single reusable gate before contacting GPT or updating memory. 
- Prevent unsafe or blocked training signals from contaminating memory and enable safe conversion of accepted training signals into memory episodes. 
- Improve episodic memory handling to separate audit vs learnable episodes and support safe consolidation into inferred hypotheses.

### Description

- Added `agicore_core/agix_cognitive_adapters.py` implementing `AgixCognitiveAdapters` to detect/load optional AGIX components and normalize concepts, attention, emotion, latent states and metrics with local fallbacks. 
- Introduced `agicore_core/safety_gate.py` providing `SafetyGate` with reusable `must_block`, `blocked_response`, `check_request` and `assert_allowed` helpers and wired `CoreQualiaEngine`/`QualiaNode` to use it. 
- Added `agicore_core/training_bridge.py` with `QualiaTrainingBridge`, `TrainingSignal` and `TrainingFeedback` to filter training/eval signals via Qualia before accepting into memory; integrated into `ReasoningKernel.record_training_signal`. 
- Added `agicore_core/neuro_symbolic_bridge.py` with `CoreNeuroSymbolicBridge` as a stable adapter over cognitive adapters for extracting concepts/latent state. 
- Extended `agicore_core/agix_compat.py` and `docs/agix_qualia_core.md` to enumerate and document new AGIX component candidates and the layered integration approach. 
- Modified `qualia_engine.py` and `qualia_node.py` to delegate blocking and blocked-response construction to `SafetyGate`, attach cognitive signals to qualia payloads, and to record cognitive feedback from adapters. 
- Enhanced `gpt_oss/strategic_memory.py` to track audit/rejected episodes, prevent blocked/rejected episodes from contributing to learning, add consolidation into `InferenceHypothesis` entities and return `MemoryConsolidationResult` summaries. 
- Updated `reasoning_kernel.py` to use `QualiaTrainingBridge`, persist blocked episodes as rejected/audit, and expose `record_training_signal` and inferred-memory state. 
- Adjusted `meta_router.py` to record blocked episodes into the new audit/rejected paths when available. 
- Updated package exports in `agicore_core/__init__.py` and added tests and docs to cover the new behavior. 

### Testing

- Ran unit tests covering cognitive adapters and gate/bridge behavior: `tests/test_agix_cognitive_adapters.py` executed and passed. 
- Ran router and memory tests including blocked-episode routing changes: `tests/test_meta_router.py` executed and passed. 
- Ran strategic memory tests for audit/rejected episode handling and consolidation: `tests/test_strategic_memory.py` executed and passed. 
- All added and updated tests passed in the automated test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4294adb7948327ac78582280f07719)