### PR TITLE
Preserve caller task and respect pre-enriched Qualia blocks

### DIFF
--- a/agicore_core/planner.py
+++ b/agicore_core/planner.py
@@ -49,7 +49,9 @@ class Planner:
         se crea una instancia sin clientes registrados.
     """
 
-    def __init__(self, orchestrator: Optional[Any] = None, qualia_node: Optional[Any] = None) -> None:
+    def __init__(
+        self, orchestrator: Optional[Any] = None, qualia_node: Optional[Any] = None
+    ) -> None:
         self.orchestrator = orchestrator or _load_virtual_qualia()()
         self.qualia_node = qualia_node
 
@@ -79,25 +81,37 @@ class Planner:
             orquestador.
         """
         planning_state = dict(state)
+        enriched_by_planner = False
         if self.qualia_node is not None and "qualia" not in planning_state:
             planning_state = self.qualia_node.enrich_request(
                 planning_state, phase="planning"
             )
-            if planning_state.get("qualia", {}).get("blocked"):
-                blocked_plan = [{
+            enriched_by_planner = True
+
+        if planning_state.get("qualia", {}).get("blocked"):
+            blocked_plan = [
+                {
                     "blocked": True,
                     "reason": planning_state["qualia"]["policy_action"],
-                    "ethical_classification": planning_state["qualia"]["ethical_classification"],
-                    "violated_constraints": planning_state["qualia"].get("violated_constraints", []),
-                }]
+                    "ethical_classification": planning_state["qualia"][
+                        "ethical_classification"
+                    ],
+                    "violated_constraints": planning_state["qualia"].get(
+                        "violated_constraints", []
+                    ),
+                }
+            ]
+            if self.qualia_node is not None:
                 self.qualia_node.integrate_response(
                     blocked_plan, planning_state, phase="planning"
                 )
-                return blocked_plan
+            return blocked_plan
         try:
             plan = self.orchestrator.broadcast_state(planning_state)
-            if self.qualia_node is not None and "qualia" not in planning_state:
-                self.qualia_node.integrate_response(plan, planning_state, phase="planning")
+            if self.qualia_node is not None and enriched_by_planner:
+                self.qualia_node.integrate_response(
+                    plan, planning_state, phase="planning"
+                )
             return plan
         except Exception:  # pragma: no cover - logging side effect
             logger.exception("Error al difundir el estado")

--- a/agicore_core/reasoning_kernel.py
+++ b/agicore_core/reasoning_kernel.py
@@ -141,7 +141,10 @@ class ReasoningKernel:
         self.evaluator = evaluator
         self.memory = memory
         self.qualia_node = qualia_node or QualiaNode()
-        if hasattr(self.router, "_qualia_node") and getattr(self.router, "_qualia_node") is None:
+        if (
+            hasattr(self.router, "_qualia_node")
+            and getattr(self.router, "_qualia_node") is None
+        ):
             self.router._qualia_node = self.qualia_node
         self._state: Dict[str, Any] = {}
         self.history: List[Dict[str, Any]] = []
@@ -256,11 +259,21 @@ class ReasoningKernel:
                     "qualia_policies": request.get("qualia_policies", []),
                     "cognitive_patterns": request.get("cognitive_patterns", []),
                     "qualia_phase": request.get("qualia", {}).get("phase"),
-                    "qualia_policy_action": request.get("qualia", {}).get("policy_action"),
-                    "qualia_legal_policy_action": request.get("qualia", {}).get("legal_policy_action"),
-                    "qualia_ethical_evidence": request.get("qualia", {}).get("ethical_evidence", {}),
-                    "qualia_evolutionary_signals": request.get("qualia", {}).get("evolutionary_signals", {}),
-                    "qualia_engine_active": request.get("qualia", {}).get("phenomenological_state", {}).get("qualia_engine_active"),
+                    "qualia_policy_action": request.get("qualia", {}).get(
+                        "policy_action"
+                    ),
+                    "qualia_legal_policy_action": request.get("qualia", {}).get(
+                        "legal_policy_action"
+                    ),
+                    "qualia_ethical_evidence": request.get("qualia", {}).get(
+                        "ethical_evidence", {}
+                    ),
+                    "qualia_evolutionary_signals": request.get("qualia", {}).get(
+                        "evolutionary_signals", {}
+                    ),
+                    "qualia_engine_active": request.get("qualia", {})
+                    .get("phenomenological_state", {})
+                    .get("qualia_engine_active"),
                 },
             )
             self.memory.add_episode(episodio)
@@ -324,11 +337,21 @@ class ReasoningKernel:
                         "qualia_policies": request.get("qualia_policies", []),
                         "cognitive_patterns": request.get("cognitive_patterns", []),
                         "qualia_phase": request.get("qualia", {}).get("phase"),
-                        "qualia_policy_action": request.get("qualia", {}).get("policy_action"),
-                        "qualia_legal_policy_action": request.get("qualia", {}).get("legal_policy_action"),
-                        "qualia_ethical_evidence": request.get("qualia", {}).get("ethical_evidence", {}),
-                        "qualia_evolutionary_signals": request.get("qualia", {}).get("evolutionary_signals", {}),
-                        "qualia_engine_active": request.get("qualia", {}).get("phenomenological_state", {}).get("qualia_engine_active"),
+                        "qualia_policy_action": request.get("qualia", {}).get(
+                            "policy_action"
+                        ),
+                        "qualia_legal_policy_action": request.get("qualia", {}).get(
+                            "legal_policy_action"
+                        ),
+                        "qualia_ethical_evidence": request.get("qualia", {}).get(
+                            "ethical_evidence", {}
+                        ),
+                        "qualia_evolutionary_signals": request.get("qualia", {}).get(
+                            "evolutionary_signals", {}
+                        ),
+                        "qualia_engine_active": request.get("qualia", {})
+                        .get("phenomenological_state", {})
+                        .get("qualia_engine_active"),
                     },
                 )
                 self.memory.add_episode(episodio)
@@ -410,8 +433,11 @@ class ReasoningKernel:
                 )
                 self.history.append({"planning": "blocked", "result": result})
                 return self._state
+            planner_state = dict(planning_request)
+            if "task" in self._state:
+                planner_state["task"] = self._state["task"]
             try:
-                plan = self.planner.plan(planning_request)
+                plan = self.planner.plan(planner_state)
             except Exception as exc:  # pragma: no cover - planificación fallida
                 self.history.append({"error": str(exc)})
                 return self._state

--- a/tests/test_planner_agent_profile.py
+++ b/tests/test_planner_agent_profile.py
@@ -42,8 +42,60 @@ def test_planner_acepta_orquestador_explicito_sin_importar_agix(monkeypatch):
         def broadcast_state(self, state):
             return [{"state": state}]
 
-    monkeypatch.setattr(planner_module, "_load_virtual_qualia", fail_load_virtual_qualia)
+    monkeypatch.setattr(
+        planner_module, "_load_virtual_qualia", fail_load_virtual_qualia
+    )
 
     planificador = planner_module.Planner(orchestrator=DummyOrchestrator())
 
     assert planificador.plan({"goal": "test"}) == [{"state": {"goal": "test"}}]
+
+
+def test_planner_blocks_existing_qualia_before_broadcast():
+    """El planificador debe respetar bloqueos Qualia ya enriquecidos."""
+
+    from agicore_core import planner as planner_module
+
+    class DummyOrchestrator:
+        def __init__(self):
+            self.calls = []
+
+        def broadcast_state(self, state):
+            self.calls.append(state)
+            return [{"state": state}]
+
+    class DummyQualiaNode:
+        def __init__(self):
+            self.integrated = []
+
+        def enrich_request(self, state, phase):  # pragma: no cover - no debe llamarse
+            raise AssertionError("No debe reenriquecer Qualia existente")
+
+        def integrate_response(self, response, state, phase):
+            self.integrated.append((response, state, phase))
+
+    orchestrator = DummyOrchestrator()
+    qualia_node = DummyQualiaNode()
+    planificador = planner_module.Planner(
+        orchestrator=orchestrator, qualia_node=qualia_node
+    )
+    state = {
+        "goal": "test",
+        "qualia": {
+            "blocked": True,
+            "policy_action": "blocked_by_ontoethical_policy",
+            "ethical_classification": "unsafe",
+            "violated_constraints": ["constraint"],
+        },
+    }
+
+    assert planificador.plan(state) == [
+        {
+            "blocked": True,
+            "reason": "blocked_by_ontoethical_policy",
+            "ethical_classification": "unsafe",
+            "violated_constraints": ["constraint"],
+        }
+    ]
+    assert orchestrator.calls == []
+    assert qualia_node.integrated

--- a/tests/test_stateful_reasoning_kernel.py
+++ b/tests/test_stateful_reasoning_kernel.py
@@ -133,3 +133,26 @@ def test_run_respects_iteration_limit():
     assert kernel.get_state()["count"] == 3
     assert "done" not in kernel.get_state()
     assert planner.calls == 3
+
+
+def test_run_preserves_task_when_planning_request_is_enriched():
+    """El kernel no debe sustituir la tarea real por el centinela de planificación."""
+
+    kernel, _, _ = make_kernel()
+
+    class CapturingPlanner:
+        def __init__(self):
+            self.seen_states = []
+
+        def plan(self, state):
+            self.seen_states.append(state)
+            return []
+
+    planner = CapturingPlanner()
+    kernel.planner = planner
+    kernel.set_state({"task": "solve-user-objective", "context": "ctx", "goals": []})
+
+    kernel.run(max_iterations=1)
+
+    assert planner.seen_states[0]["task"] == "solve-user-objective"
+    assert "qualia" in planner.seen_states[0]


### PR DESCRIPTION
### Motivation

- Prevent Qualia enrichment from replacing the caller's original planning `task` so planners receive the user objective rather than the sentinel `"planning"` value.
- Ensure requests that already include a Qualia payload with `blocked: true` are treated as blocked and not broadcast to the orchestrator, avoiding bypass of the planner safety gate.

### Description

- In `ReasoningKernel.run()` copy the Qualia-enriched planning request to a new `planner_state` and restore the original `task` from the kernel state before calling `planner.plan` so the planner sees the caller's task.
- In `Planner.plan()` introduce an `enriched_by_planner` flag to avoid double-enrichment, always check `planning_state.get("qualia", {}).get("blocked")` and return a blocked plan when present, and only call `qualia_node.integrate_response` for broadcasts that the planner itself enriched.
- Add regression tests covering a pre-enriched blocked Qualia request being returned without broadcasting and the kernel preserving the original `task` when the planning request is Qualia-enriched.

### Testing

- Ran inline Python sanity checks that exercise the two fixes (`planner` respects pre-enriched blocked Qualia and `ReasoningKernel` preserves the original `task`) and both succeeded.
- Compiled the modified modules with `python -m py_compile agicore_core/planner.py agicore_core/reasoning_kernel.py` and compilation succeeded.
- Attempted `pytest tests/test_planner_agent_profile.py tests/test_stateful_reasoning_kernel.py -q` but the run was blocked in this environment due to `tiktoken` attempting to fetch a remote encoding file and failing SSL verification; full CI or a developer environment is required to run the pytest suite to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a885d40ac83279aaea9179849da33)