### PR TITLE
Fix MetaRouter Qualia import cycle

### DIFF
--- a/meta_router.py
+++ b/meta_router.py
@@ -13,8 +13,22 @@ from datetime import datetime
 from time import perf_counter
 from typing import Any, Dict, List, Optional
 
-from agicore_core.qualia_engine import CoreQualiaEngine
 from gpt_oss.strategic_memory import Episode, StrategicMemory
+
+
+def _core_qualia_engine():
+    """Return ``CoreQualiaEngine`` without importing ``agicore_core`` at module load.
+
+    Importing :mod:`agicore_core.qualia_engine` while :mod:`meta_router` is
+    still being initialized can re-enter this module through
+    ``agicore_core.__init__`` -> ``agicore_core.kernel``.  Keeping this import
+    local lets ``from meta_router import MetaRouter`` finish defining the class
+    before Qualia helpers are resolved.
+    """
+
+    from agicore_core.qualia_engine import CoreQualiaEngine
+
+    return CoreQualiaEngine
 
 
 @dataclass
@@ -203,7 +217,7 @@ class MetaRouter:
 
     @staticmethod
     def _blocked_qualia_result(request: Dict[str, Any]) -> Dict[str, Any]:
-        return CoreQualiaEngine.blocked_result(request)
+        return _core_qualia_engine().blocked_result(request)
 
     def _record_blocked_episode(
         self,
@@ -276,7 +290,7 @@ class MetaRouter:
             raise ValueError("La clave 'goals' debe ser una lista de cadenas")
 
         qualia = request.get("qualia") if isinstance(request.get("qualia"), dict) else None
-        if qualia and CoreQualiaEngine.must_block(request):
+        if qualia and _core_qualia_engine().must_block(request):
             result = self._blocked_qualia_result(request)
             self._record_blocked_episode(request, result, task, context, goals)
             return result

--- a/tests/test_meta_router.py
+++ b/tests/test_meta_router.py
@@ -17,6 +17,20 @@ class DummyModule:
         return "ok"
 
 
+def test_meta_router_imports_before_agicore_core_package():
+    import subprocess
+    import sys
+
+    completed = subprocess.run(
+        [sys.executable, "-c", "from meta_router import MetaRouter; print(MetaRouter.__name__)"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stdout.strip() == "MetaRouter"
+
+
 def test_register_duplicate_name_raises_error():
     router = MetaRouter()
     dummy = DummyModule()


### PR DESCRIPTION
### Motivation
- Avoid a circular import when `meta_router` is imported as the first project module that causes `ImportError: cannot import name 'MetaRouter'` due to `agicore_core.__init__` re-entering `meta_router` during package initialization.

### Description
- Remove the top-level `from agicore_core.qualia_engine import CoreQualiaEngine` and add a lazy helper `def _core_qualia_engine()` that imports and returns `CoreQualiaEngine` on demand.
- Update calls that used `CoreQualiaEngine.blocked_result` and `CoreQualiaEngine.must_block` to use `_core_qualia_engine()` so Qualia helpers are resolved only when needed.
- Add a regression test `test_meta_router_imports_before_agicore_core_package` that spawns a fresh Python subprocess to verify `from meta_router import MetaRouter` succeeds before `agicore_core` is imported.

### Testing
- Ran the import smoke check with `python -c "from meta_router import MetaRouter; print(MetaRouter.__name__)"`, which succeeded and printed `MetaRouter`.
- Attempted to run `pytest tests/test_meta_router.py`, but the test run was aborted during test collection due to an `ImportError` in `tests/conftest.py` caused by a missing optional dependency `tenacity` after installing other missing packages (`structlog`, `tiktoken`, `aiohttp`, `chz`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a8c3bf6d8832799a6f73a36c212d1)