### PR TITLE
Documentar sincronización con upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Este proyecto se distribuye bajo la Licencia Apache 2.0. Puedes encontrar el tex
 
 [harmony]: https://github.com/openai/harmony
 
+## Sincronización con upstream
+
+Consulta [`docs/upstream_sync.md`](docs/upstream_sync.md) para ver el remoto upstream configurado, el commit base usado para comparación y las extensiones del fork que deben preservarse durante futuras sincronizaciones.
+
 ## Integración AGIX/Qualia
 
 El Core fija `agix==1.9.0` y usa `agicore_core.QualiaNode` como capa rectora de planificación, enrutado y ciclo de tokens. Qualia aplica políticas ontoéticas, restricciones morales/legales, patrones cognitivos y señales evolutivas antes de que una solicitud llegue al GPT o al `MetaRouter`.

--- a/docs/upstream_sync.md
+++ b/docs/upstream_sync.md
@@ -1,0 +1,41 @@
+# Sincronización con upstream
+
+Este documento registra el punto de referencia usado para comparar este fork con el repositorio upstream oficial de OpenAI.
+
+## Upstream configurado
+
+- **URL upstream:** `https://github.com/openai/gpt-oss`
+- **Remoto Git local:** `upstream`
+- **Commit exacto de `openai/gpt-oss` usado como base común:** `4931694686fadfa74a80554473d32f7dd4d059f3`
+- **Commit actual observado en `upstream/main` durante la sincronización:** `d21f34ec3c1ede813adfbd83f07d2ad2eec7ff02`
+- **Fecha de sincronización:** `2026-07-13` (UTC)
+
+## Resumen de conflictos resueltos
+
+No se realizó una fusión automática de `upstream/main` en esta actualización documental. Por tanto, no hubo conflictos de Git que resolver en este paso. El fork mantiene sus cambios locales sobre el punto base indicado y deja documentado el remoto upstream para futuras sincronizaciones controladas.
+
+Al sincronizar en el futuro, deben preservarse explícitamente las extensiones AGI/AGIX añadidas en este fork y revisar cualquier conflicto que afecte a los módulos listados abajo.
+
+## Extensiones preservadas
+
+Las siguientes extensiones del fork deben conservarse durante comparaciones, rebases o fusiones contra upstream:
+
+- `agicore_core`
+- `gpt_oss/planner.py`
+- `meta_router.py`
+- `gpt_oss/strategic_memory.py`
+- `agicore_core/reasoning_kernel.py`
+
+## Comando recomendado para comparar contra upstream
+
+Después de ejecutar `git fetch upstream`, usa este comando para comparar el fork actual contra la rama principal upstream:
+
+```bash
+git diff upstream/main...HEAD
+```
+
+Para revisar únicamente el resumen de archivos modificados:
+
+```bash
+git diff --stat upstream/main...HEAD
+```


### PR DESCRIPTION
### Motivation

- Registrar la referencia upstream usada para comparar y sincronizar este fork con el repositorio oficial de OpenAI.
- Dejar constancia de las extensiones AGIX/AGI del fork que deben preservarse en futuras fusiones o rebases.

### Description

- Añadido `docs/upstream_sync.md` que incluye la URL del upstream (`https://github.com/openai/gpt-oss`), el commit base utilizado para comparación, el commit observado en `upstream/main` durante la verificación, la fecha de sincronización, un resumen de conflictos resueltos y la lista de extensiones preservadas (`agicore_core`, `gpt_oss/planner.py`, `meta_router.py`, `gpt_oss/strategic_memory.py`, `agicore_core/reasoning_kernel.py`).
- Incluye comandos recomendados para comparar el fork contra el upstream (en el propio documento de `docs/upstream_sync.md`).
- Actualizado `README.md` para añadir un enlace a `docs/upstream_sync.md` y exponer la información de sincronización desde la documentación principal.
- Se configuró el remoto local `upstream` apuntando al repositorio oficial y se obtuvo la referencia actual de `upstream/main` para registrar el estado observado.

### Testing

- Ejecutado `git diff --check` para verificar problemas de formato y salidas; resultado: sin errores.
- Ejecutado `git status --short` tras los cambios para confirmar archivos modificados; resultado: estado esperado con el nuevo archivo `docs/upstream_sync.md` y la modificación en `README.md`.
- Los checks documentales y de consistencia locales descritos arriba finalizaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5524c432508327a3a377e47213bc6e)