### PR TITLE
Run Responses API tests with official openai-harmony; add pytest markers and CI test job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,11 +1,14 @@
 name: CI
 
 on:
-  release:
-    types: [published]
+  pull_request:
   push:
+    branches:
+      - "**"
     tags:
       - "v*"
+  release:
+    types: [published]
   workflow_dispatch:
 
 # Minimal repo-level permissions; job-level permissions override where needed.
@@ -14,8 +17,31 @@ permissions:
   id-token: write
 
 jobs:
+
+  test:
+    name: Unit and Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]"
+
+      - name: Run tests without Harmony stubs
+        run: |
+          pytest tests/test_responses_api.py -m "unit or integration"
   publish:
     name: Build & Publish to PyPI (Trusted Publishing)
+    if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
 
     # Run in the GitHub environment named "release" so you can gate it with approvals.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ version = "0.0.1"
 triton = ["triton", "safetensors>=0.5.3", "torch>=2.7.0"]
 torch = ["safetensors>=0.5.3", "torch>=2.7.0"]
 metal = ["numpy", "tqdm", "safetensors", "torch"]
-test = ["pytest>=8.4.1", "httpx>=0.28.1"]
+test = ["pytest>=8.4.1", "httpx>=0.28.1", "openai-harmony"]
 eval = ["pandas", "numpy", "openai", "jinja2", "tqdm", "blobfile"]
 agix-neuro = ["agix[neuro]==1.9.0"]
 agix-ml = ["agix[ml]==1.9.0"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,35 @@ from openai_harmony import (
 from gpt_oss.responses_api.api_server import create_api_server
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "unit: unit tests that run locally with official openai-harmony encoding",
+    )
+    config.addinivalue_line(
+        "markers",
+        "integration: integration tests that may compose multiple components",
+    )
+    config.addinivalue_line(
+        "markers",
+        (
+            "external_resource: tests that require resources outside the Python "
+            "process, such as Docker or network services"
+        ),
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        if item.get_closest_marker("external_resource") is not None:
+            item.add_marker(pytest.mark.integration)
+        elif (
+            item.get_closest_marker("integration") is None
+            and item.get_closest_marker("unit") is None
+        ):
+            item.add_marker(pytest.mark.unit)
+
+
 @pytest.fixture(scope="session")
 def harmony_encoding():
     return load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)

--- a/tests/test_python_docker.py
+++ b/tests/test_python_docker.py
@@ -1,7 +1,8 @@
 import docker
 import pytest
 
-from gpt_oss.tools.python_docker.docker_tool import call_python_script
+
+pytestmark = [pytest.mark.integration, pytest.mark.external_resource]
 
 
 try:
@@ -11,11 +12,18 @@ except Exception:
     pytest.skip("Docker is not available", allow_module_level=True)
 
 
+
+def _call_python_script(script: str) -> str:
+    from gpt_oss.tools.python_docker.docker_tool import call_python_script
+
+    return call_python_script(script)
+
+
 def test_infinite_script_times_out_and_cleans_up():
     client = docker.from_env()
     before = {c.id for c in client.containers.list(all=True)}
 
-    output = call_python_script("while True: pass")
+    output = _call_python_script("while True: pass")
 
     after = {c.id for c in client.containers.list(all=True)}
 
@@ -34,7 +42,7 @@ def test_container_runs_as_nobody_and_is_read_only():
         "except Exception as e:\n"
         "    print(type(e).__name__)\n"
     )
-    output = call_python_script(script)
+    output = _call_python_script(script)
     lines = [line.strip() for line in output.strip().splitlines() if line.strip()]
     assert lines[0] == 'nobody'
     assert lines[1] != 'writable'

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -2,38 +2,38 @@ import time
 
 import pytest
 from fastapi.testclient import TestClient
-from openai_harmony import (
-    HarmonyEncodingName,
-    Role,
-    load_harmony_encoding,
-)
+from openai_harmony import Role
 
 from gpt_oss.responses_api.api_server import create_api_server
 
-encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
-
-fake_tokens = encoding.encode(
-    "<|channel|>final<|message|>Hey there<|return|>", allowed_special="all"
-)
-
-token_queue = fake_tokens.copy()
+pytestmark = pytest.mark.unit
 
 
-def stub_infer_next_token(
-    tokens: list[int], temperature: float = 0.0, new_request: bool = False
-) -> int:
-    global token_queue
-    next_tok = token_queue.pop(0)
-    if len(token_queue) == 0:
-        token_queue = fake_tokens.copy()
-    time.sleep(0.1)
-    return next_tok
+def _build_token_infer(harmony_encoding, message: str = "Hey there"):
+    """Create a deterministic token generator using the official Harmony encoding."""
+    fake_tokens = harmony_encoding.encode(
+        f"<|channel|>final<|message|>{message}<|return|>", allowed_special="all"
+    )
+    token_queue = fake_tokens.copy()
+
+    def infer_next_token(
+        tokens: list[int], temperature: float = 0.0, new_request: bool = False
+    ) -> int:
+        nonlocal token_queue
+        next_tok = token_queue.pop(0)
+        if len(token_queue) == 0:
+            token_queue = fake_tokens.copy()
+        time.sleep(0.1)
+        return next_tok
+
+    return infer_next_token, fake_tokens
 
 
 @pytest.fixture
-def test_client():
+def test_client(harmony_encoding):
+    infer_next_token, _ = _build_token_infer(harmony_encoding)
     return TestClient(
-        create_api_server(infer_next_token=stub_infer_next_token, encoding=encoding)
+        create_api_server(infer_next_token=infer_next_token, encoding=harmony_encoding)
     )
 
 
@@ -49,16 +49,16 @@ def test_health_check(test_client):
     assert response.status_code == 200
 
 
-def test_system_message_in_input_reflected(test_client, monkeypatch):
+def test_system_message_in_input_reflected(test_client, harmony_encoding, monkeypatch):
     captured = {}
 
-    original_render = encoding.render_conversation_for_completion
+    original_render = harmony_encoding.render_conversation_for_completion
 
     def capture(conv, role):
         captured["messages"] = conv.messages
         return original_render(conv, role)
 
-    monkeypatch.setattr(encoding, "render_conversation_for_completion", capture)
+    monkeypatch.setattr(harmony_encoding, "render_conversation_for_completion", capture)
 
     response = test_client.post(
         "/v1/responses",
@@ -74,15 +74,18 @@ def test_system_message_in_input_reflected(test_client, monkeypatch):
     assert captured["messages"][0].to_dict()["role"] == Role.SYSTEM
 
 
-def test_responses_api_blocks_illegal_request_before_inference():
+def test_responses_api_blocks_illegal_request_before_inference(harmony_encoding):
     called = {"count": 0}
+    infer_next_token, fake_tokens = _build_token_infer(harmony_encoding)
 
-    def infer_should_not_run(tokens: list[int], temperature: float = 0.0, new_request: bool = False) -> int:
+    def infer_should_not_run(
+        tokens: list[int], temperature: float = 0.0, new_request: bool = False
+    ) -> int:
         called["count"] += 1
         return fake_tokens[0]
 
     client = TestClient(
-        create_api_server(infer_next_token=infer_should_not_run, encoding=encoding)
+        create_api_server(infer_next_token=infer_should_not_run, encoding=harmony_encoding)
     )
 
     response = client.post(


### PR DESCRIPTION
### Motivation
- Evitar skips globales y stubs por `openai_harmony` y permitir ejecutar los tests de Responses API con la implementación oficial de `openai-harmony` cuando esté disponible. 
- Separar claramente tests unitarios e integración para que los segundos requieran marcadores explícitos y recursos externos (p. ej. Docker).
- Asegurar que CI instale las dependencias de test (incluyendo `openai-harmony`) y ejecute los tests relevantes sin depender de stubs locales.

### Description
- Reescribí `tests/test_responses_api.py` para eliminar el estado global de encoding y construir un generador determinista de tokens usando la fixture `harmony_encoding` proporcionada por `openai-harmony`, y marqué el módulo como `unit`. (cambios en `tests/test_responses_api.py`)
- Actualicé `tests/conftest.py` para registrar marcadores pytest `unit`, `integration` y `external_resource`, y para auto-marcar tests sin marcador explícito como `unit`. (cambios en `tests/conftest.py`)
- Marqué explícitamente los tests Docker como `integration` y `external_resource`, y retrasé la importación de la función `call_python_script` hasta después de verificar la disponibilidad de Docker para evitar fallos de import en entornos sin Docker. (cambios en `tests/test_python_docker.py`)
- Añadí `openai-harmony` al extras de test en `pyproject.toml` para que CI lo instale como dependencia de pruebas. (cambios en `pyproject.toml`)
- Añadí un job de `test` en el workflow CI que corre en `pull_request`/`push` y que instala `.[test]` y ejecuta los tests de Responses API marcados como `unit or integration`; el job de publicación queda restringido a releases/tags. (cambios en `.github/workflows/CI.yml`)

### Testing
- Instalación de dependencias de test: `python -m pip install -e ".[test]"` se ejecutó correctamente y trajo `openai-harmony`.
- Ejecuté `python -m pytest tests/test_responses_api.py -m "unit or integration" -q` y los tests relevantes pasaron (`3 passed, 1 warning`).
- Comprobé recolección de tests Docker con `python -m pytest --collect-only tests/test_python_docker.py -q`, y en el entorno actual no hay Docker disponible, por lo que no se colectaron tests de integración (limitación de entorno, no un fallo del cambio).
- Corrí `git diff --check` para validar el diff sin errores de formato (sin errores de whitespace en el repo).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552940879083278528cee7042e5197)