### PR TITLE
Define explicit AGIX Qualia runtime profiles

### DIFF
--- a/agicore_core/agix_compat.py
+++ b/agicore_core/agix_compat.py
@@ -29,6 +29,12 @@ class AgixComponentStatus:
     methods_available: tuple[str, ...] = ()
     validation_error: str | None = None
 
+    @property
+    def contract_valid(self) -> bool:
+        """Indica si el componente cargado cumple un contrato mínimo."""
+
+        return self.available and self.instantiable and not self.validation_error
+
 
 @dataclass(frozen=True)
 class AgixCompatibilityReport:
@@ -40,6 +46,8 @@ class AgixCompatibilityReport:
     version_compatible: bool = False
     components: dict[str, AgixComponentStatus] = field(default_factory=dict)
     mode: str = "local_safe"
+    degradation_reasons: tuple[str, ...] = ()
+    minimum_components: tuple[str, ...] = ()
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -49,8 +57,11 @@ class AgixCompatibilityReport:
             "version_compatible": self.version_compatible,
             "mode": self.mode,
             "components": {
-                key: status.__dict__ for key, status in self.components.items()
+                key: {**status.__dict__, "contract_valid": status.contract_valid}
+                for key, status in self.components.items()
             },
+            "degradation_reasons": list(self.degradation_reasons),
+            "minimum_components": list(self.minimum_components),
         }
 
 
@@ -98,23 +109,56 @@ def load_first_component(
     return None, AgixComponentStatus(name=name, available=False, error=last_error)
 
 
-def build_compatibility_report(
-    *, required_version: str = AGIX_REQUIRED_VERSION,
-    version_mismatch_policy: str = "block_advanced",
-) -> AgixCompatibilityReport:
-    """Construye un informe de componentes AGIX usados por el Core."""
+MINIMUM_STRICT_COMPONENTS = (
+    "qualia_engine",
+    "moral_evaluator",
+    "genetic_agent",
+    "neuromorphic_agent",
+)
 
+
+class AgixStrictCompatibilityError(RuntimeError):
+    """Error de dominio para perfiles AGIX estrictos no satisfechos."""
+
+
+def build_compatibility_report(
+    *,
+    required_version: str = AGIX_REQUIRED_VERSION,
+    version_mismatch_policy: str = "block_advanced",
+    runtime_profile: str = "local_safe",
+    minimum_components: Iterable[str] = MINIMUM_STRICT_COMPONENTS,
+) -> AgixCompatibilityReport:
+    """Construye un informe de componentes AGIX usados por el Core.
+
+    ``local_safe`` es deliberadamente local: no inspecciona ni activa componentes
+    avanzados aunque AGIX esté instalado. ``degraded`` audita componentes
+    parciales/incompatibles sin fallar. ``strict_compatible`` exige versión y
+    contratos mínimos válidos.
+    """
+
+    normalized_profile = runtime_profile.strip().lower() or "local_safe"
+    minimum = tuple(minimum_components)
     detected = detect_agix_version()
     compatible = detected == required_version
     available = detected is not None
     components: dict[str, AgixComponentStatus] = {}
+    degradation_reasons: list[str] = []
     component_candidates = {
-        "genetic_agent": (("agix.agents.genetic", "GeneticAgent"), ("agix.agents", "GeneticAgent")),
-        "neuromorphic_agent": (("agix.agents.neuromorphic", "NeuromorphicAgent"), ("agix.agents", "NeuromorphicAgent")),
+        "genetic_agent": (
+            ("agix.agents.genetic", "GeneticAgent"),
+            ("agix.agents", "GeneticAgent"),
+        ),
+        "neuromorphic_agent": (
+            ("agix.agents.neuromorphic", "NeuromorphicAgent"),
+            ("agix.agents", "NeuromorphicAgent"),
+        ),
         "qualia_engine": (("agix.qualia", "QualiaEngine"),),
         "memory_manager": (("agix.memory", "GestorDeMemoria"),),
         "virtual_qualia": (("agix.orchestrator", "VirtualQualia"),),
-        "qualia_spirit": (("agix.qualia.spirit", "QualiaSpirit"), ("agix.qualia.heuristic_spirit", "HeuristicQualiaSpirit")),
+        "qualia_spirit": (
+            ("agix.qualia.spirit", "QualiaSpirit"),
+            ("agix.qualia.heuristic_spirit", "HeuristicQualiaSpirit"),
+        ),
         "ecoethics": (("agix.qualia.ecoethics", "EcoEthics"),),
         "moral_evaluator": (
             ("agix.qualia.ethics", "MoralEvaluator"),
@@ -122,32 +166,72 @@ def build_compatibility_report(
             ("agix.ethics", "MoralEvaluator"),
             ("agix.ethics", "EthicalEvaluator"),
         ),
-        "meta_learner": (("agix.learning.meta", "MetaLearner"), ("agix.learning", "MetaLearner")),
+        "meta_learner": (
+            ("agix.learning.meta", "MetaLearner"),
+            ("agix.learning", "MetaLearner"),
+        ),
         "ontology": (("agix.memory", "Ontology"), ("agix.reasoning", "Ontology")),
-        "latent_representation": (("agix.memory", "LatentRepresentation"), ("agix.reasoning", "LatentRepresentation")),
+        "latent_representation": (
+            ("agix.memory", "LatentRepresentation"),
+            ("agix.reasoning", "LatentRepresentation"),
+        ),
         "neuro_symbolic_bridge": (("agix.reasoning", "NeuroSymbolicBridge"),),
         "evaluation_metrics": (("agix.evaluation", "EvaluationMetrics"),),
-        "concept_classifier": (("agix.memory", "ConceptClassifier"), ("agix.reasoning", "ConceptClassifier")),
-        "heuristic_concept_creator": (("agix.memory", "HeuristicConceptCreator"), ("agix.reasoning", "HeuristicConceptCreator")),
+        "concept_classifier": (
+            ("agix.memory", "ConceptClassifier"),
+            ("agix.reasoning", "ConceptClassifier"),
+        ),
+        "heuristic_concept_creator": (
+            ("agix.memory", "HeuristicConceptCreator"),
+            ("agix.reasoning", "HeuristicConceptCreator"),
+        ),
         "emotion_simulator": (("agix.emotion.emotion_simulator", "EmotionSimulator"),),
         "attention_focus": (("agix.perception.attention", "AttentionFocus"),),
     }
-    for name, candidates in component_candidates.items():
-        component, status = load_first_component(name, candidates)
-        if component is not None:
-            status = _validate_component(name, component, status)
-        components[name] = status
-
-    if not available:
+    if normalized_profile == "local_safe":
         mode = "local_safe"
-    elif compatible:
-        mode = "strict_compatible"
-    elif version_mismatch_policy == "warn":
-        mode = "version_warn"
-    elif version_mismatch_policy == "degrade":
-        mode = "degraded"
+        if not available:
+            degradation_reasons.append("agix_not_installed_local_safe")
     else:
-        mode = "advanced_blocked"
+        for name, candidates in component_candidates.items():
+            component, status = load_first_component(name, candidates)
+            if component is not None:
+                status = _validate_component(name, component, status)
+            components[name] = status
+
+        if not available:
+            mode = (
+                "degraded" if normalized_profile == "degraded" else "strict_compatible"
+            )
+            degradation_reasons.append("agix_not_installed")
+        elif compatible and normalized_profile == "strict_compatible":
+            mode = "strict_compatible"
+        elif normalized_profile == "degraded" or version_mismatch_policy == "degrade":
+            mode = "degraded"
+            if not compatible:
+                degradation_reasons.append(
+                    f"agix_version_mismatch_required={required_version}_detected={detected}"
+                )
+        elif version_mismatch_policy == "warn":
+            mode = "version_warn"
+        else:
+            mode = "advanced_blocked"
+            if not compatible:
+                degradation_reasons.append(
+                    f"agix_version_mismatch_required={required_version}_detected={detected}"
+                )
+
+        if normalized_profile == "degraded":
+            for name, status in components.items():
+                if not status.contract_valid:
+                    degradation_reasons.append(f"{name}_contract_unavailable")
+        if normalized_profile == "strict_compatible":
+            for name in minimum:
+                status = components.get(name)
+                if status is None or not status.contract_valid:
+                    degradation_reasons.append(
+                        f"strict_minimum_component_missing={name}"
+                    )
 
     return AgixCompatibilityReport(
         required_version=required_version,
@@ -156,6 +240,8 @@ def build_compatibility_report(
         version_compatible=compatible,
         components=components,
         mode=mode,
+        degradation_reasons=tuple(dict.fromkeys(degradation_reasons)),
+        minimum_components=minimum,
     )
 
 
@@ -184,8 +270,24 @@ def _validate_component(
         "attention_focus": ((), {}),
     }
     expected_methods = {
-        "genetic_agent": ("perceive", "decide", "learn", "evolve_policy", "select_action", "act"),
-        "neuromorphic_agent": ("activate", "forward", "infer", "decide", "process", "update", "learn", "plasticity_update"),
+        "genetic_agent": (
+            "perceive",
+            "decide",
+            "learn",
+            "evolve_policy",
+            "select_action",
+            "act",
+        ),
+        "neuromorphic_agent": (
+            "activate",
+            "forward",
+            "infer",
+            "decide",
+            "process",
+            "update",
+            "learn",
+            "plasticity_update",
+        ),
         "qualia_engine": ("generate_state", "encode_integrated_info"),
         "memory_manager": ("registrar", "guardar", "record", "add"),
         "virtual_qualia": ("broadcast_state",),

--- a/agicore_core/qualia_node.py
+++ b/agicore_core/qualia_node.py
@@ -12,7 +12,12 @@ from typing import Any, Dict, List, Mapping
 
 from .agix_adapters import AgixEvolutionAdapters
 from .agix_cognitive_adapters import AgixCognitiveAdapters
-from .agix_compat import build_compatibility_report, load_first_component, module_available
+from .agix_compat import (
+    AgixStrictCompatibilityError,
+    build_compatibility_report,
+    load_first_component,
+    module_available,
+)
 from .config import AGIX_REQUIRED_VERSION
 
 
@@ -121,15 +126,25 @@ class QualiaNode:
         self.version_mismatch_policy = str(
             self.profile.get("version_mismatch_policy", "block_advanced")
         )
-        self.runtime_profile = str(self.profile.get("runtime_profile", "local_safe"))
+        self.runtime_profile = (
+            str(self.profile.get("runtime_profile", "local_safe")).strip().lower()
+        )
+        if self.runtime_profile not in {"local_safe", "degraded", "strict_compatible"}:
+            self.runtime_profile = "local_safe"
+        if self.runtime_profile == "degraded":
+            self.version_mismatch_policy = "degrade"
         self.compatibility_report = build_compatibility_report(
             required_version=self.required_agix_version,
             version_mismatch_policy=self.version_mismatch_policy,
+            runtime_profile=self.runtime_profile,
         )
         self._agix_version = self.compatibility_report.detected_version
         self._version_compatible = self.compatibility_report.version_compatible
-        if self.profile.get("require_agix_runtime", False) and not self._version_compatible:
-            raise RuntimeError(
+        if (
+            self.profile.get("require_agix_runtime", False)
+            and not self._version_compatible
+        ):
+            raise AgixStrictCompatibilityError(
                 f"AGIX {self.required_agix_version} es obligatorio; "
                 f"detectado={self._agix_version!r}"
             )
@@ -145,12 +160,8 @@ class QualiaNode:
         self._cognition = AgixCognitiveAdapters(enabled=advanced_enabled)
         self._load_agix_components()
         self._strict_runtime_errors = self._validate_strict_runtime()
-        if (
-            self.runtime_profile == "strict_compatible"
-            and bool(self.profile.get("enforce_strict_component_contract", False))
-            and self._strict_runtime_errors
-        ):
-            raise RuntimeError(
+        if self.runtime_profile == "strict_compatible" and self._strict_runtime_errors:
+            raise AgixStrictCompatibilityError(
                 "Contrato AGIX/Qualia estricto incumplido: "
                 + "; ".join(self._strict_runtime_errors)
             )
@@ -173,7 +184,13 @@ class QualiaNode:
     def _validate_strict_runtime(self) -> List[str]:
         if self.runtime_profile != "strict_compatible":
             return []
-        errors: List[str] = []
+        errors: List[str] = [
+            reason
+            for reason in self.compatibility_report.degradation_reasons
+            if reason.startswith("strict_minimum_component_missing=")
+            or reason.startswith("agix_not_installed")
+            or reason.startswith("agix_version_mismatch")
+        ]
         if not self._version_compatible:
             errors.append(
                 f"agix_version_required={self.required_agix_version}, detected={self._agix_version!r}"
@@ -276,25 +293,44 @@ class QualiaNode:
         ]
 
     def _advanced_agix_enabled(self) -> bool:
+        if self.runtime_profile == "local_safe":
+            return False
+        if self.runtime_profile == "strict_compatible":
+            return self._version_compatible
+        if self.runtime_profile == "degraded":
+            return self._agix_version is not None
         if self._version_compatible:
             return True
         if self._agix_version is None:
-            return self.version_mismatch_policy == "warn"
+            return False
         return self.version_mismatch_policy not in {"block_advanced", "degrade"}
 
     def _version_policy_action(self) -> str:
+        if self.runtime_profile == "local_safe":
+            return "local_safe_no_agix_adapters"
         if self._agix_version is None:
-            return "agix_not_available_local_safe_mode"
+            return (
+                "agix_not_available_degraded"
+                if self.runtime_profile == "degraded"
+                else "agix_not_available_strict_failure"
+            )
         if self._version_compatible:
             return "agix_version_compatible"
         if self.version_mismatch_policy == "warn":
             return "agix_version_mismatch_warn"
-        if self.version_mismatch_policy == "degrade":
+        if (
+            self.runtime_profile == "degraded"
+            or self.version_mismatch_policy == "degrade"
+        ):
             return "agix_version_mismatch_degraded"
         return "agix_version_mismatch_advanced_blocked"
 
     def _load_agix_components(self) -> None:
-        if not self.enabled or not module_available("agix"):
+        if (
+            self.runtime_profile == "local_safe"
+            or not self.enabled
+            or not module_available("agix")
+        ):
             return
         eco_cls, _ = load_first_component(
             "ecoethics", (("agix.qualia.ecoethics", "EcoEthics"),)
@@ -522,9 +558,11 @@ class QualiaNode:
             if key in feedback
         }
         state["qualia_cognitive_feedback"] = cognitive_feedback
-        state["qualia_decision_audit"] = self.trace[-2]["request"]["qualia"].get(
-            "decision_audit", {}
-        ) if len(self.trace) >= 2 and "request" in self.trace[-2] else {}
+        state["qualia_decision_audit"] = (
+            self.trace[-2]["request"]["qualia"].get("decision_audit", {})
+            if len(self.trace) >= 2 and "request" in self.trace[-2]
+            else {}
+        )
         return state
 
     def _build_moral_decision(
@@ -678,14 +716,22 @@ class QualiaNode:
         for constraint in self.moral_constraints:
             if constraint.name in existing_categories:
                 continue
-            matched = [pattern for pattern in semantic_patterns.get(constraint.name, ()) if pattern in text]
+            matched = [
+                pattern
+                for pattern in semantic_patterns.get(constraint.name, ())
+                if pattern in text
+            ]
             if matched:
                 inferred.append(
                     {
                         "name": constraint.name,
                         "category": constraint.name,
                         "description": constraint.description,
-                        "severity": "block" if constraint.severity == "block" else constraint.severity,
+                        "severity": (
+                            "block"
+                            if constraint.severity == "block"
+                            else constraint.severity
+                        ),
                         "matched_keywords": matched,
                         "evidence": [
                             {
@@ -707,13 +753,46 @@ class QualiaNode:
             return None
         if isinstance(result, str):
             label = result.lower()
-            blocked = label in {"illegal", "ilegal", "unsafe", "nocivo", "block", "bloquear"}
-            category = "ilegalidad" if "ilegal" in label or "illegal" in label else "agix_ontoethical"
+            blocked = label in {
+                "illegal",
+                "ilegal",
+                "unsafe",
+                "nocivo",
+                "block",
+                "bloquear",
+            }
+            category = (
+                "ilegalidad"
+                if "ilegal" in label or "illegal" in label
+                else "agix_ontoethical"
+            )
         elif isinstance(result, Mapping):
-            label = str(result.get("category", result.get("classification", result.get("label", "")))).lower()
-            blocked = bool(result.get("blocked", result.get("block", result.get("unsafe", False))))
-            blocked = blocked or label in {"illegal", "ilegal", "unsafe", "nocivo", "block", "bloquear"}
-            category = str(result.get("category", "ilegalidad" if "ilegal" in label or "illegal" in label else "agix_ontoethical"))
+            label = str(
+                result.get(
+                    "category", result.get("classification", result.get("label", ""))
+                )
+            ).lower()
+            blocked = bool(
+                result.get("blocked", result.get("block", result.get("unsafe", False)))
+            )
+            blocked = blocked or label in {
+                "illegal",
+                "ilegal",
+                "unsafe",
+                "nocivo",
+                "block",
+                "bloquear",
+            }
+            category = str(
+                result.get(
+                    "category",
+                    (
+                        "ilegalidad"
+                        if "ilegal" in label or "illegal" in label
+                        else "agix_ontoethical"
+                    ),
+                )
+            )
         else:
             return None
         if not blocked:
@@ -735,7 +814,9 @@ class QualiaNode:
             "recommended_action": "block",
         }
 
-    def _phenomenological_state(self, request: Mapping[str, Any], *, phase: str) -> Dict[str, Any]:
+    def _phenomenological_state(
+        self, request: Mapping[str, Any], *, phase: str
+    ) -> Dict[str, Any]:
         base_state = {
             "task": request.get("task"),
             "context": request.get("context"),
@@ -781,7 +862,12 @@ class QualiaNode:
             }
         except Exception as exc:
             persisted = self._record_qualia_experience(
-                {"phase": phase, "request": dict(request), "state": base_state, "error": str(exc)}
+                {
+                    "phase": phase,
+                    "request": dict(request),
+                    "state": base_state,
+                    "error": str(exc),
+                }
             )
             return {
                 "qualia_engine_active": False,
@@ -810,9 +896,17 @@ class QualiaNode:
                     method("qualia_experience", dict(payload))
                     return {"memory_persisted": True, "memory_method": method_name}
                 except Exception as exc:
-                    return {"memory_persisted": False, "memory_method": method_name, "memory_error": str(exc)}
+                    return {
+                        "memory_persisted": False,
+                        "memory_method": method_name,
+                        "memory_error": str(exc),
+                    }
             except Exception as exc:
-                return {"memory_persisted": False, "memory_method": method_name, "memory_error": str(exc)}
+                return {
+                    "memory_persisted": False,
+                    "memory_method": method_name,
+                    "memory_error": str(exc),
+                }
         return {"memory_persisted": False, "memory_error": "no_supported_method"}
 
     def _build_qualia_vectors(

--- a/tests/test_agix_qualia_config.py
+++ b/tests/test_agix_qualia_config.py
@@ -14,8 +14,8 @@ def test_agix_version_is_consistent_across_project_files():
         )
     )
 
-    assert f'agix=={AGIX_REQUIRED_VERSION}' in pyproject
-    assert f'agix=={AGIX_REQUIRED_VERSION}' in requirements
+    assert f"agix=={AGIX_REQUIRED_VERSION}" in pyproject
+    assert f"agix=={AGIX_REQUIRED_VERSION}" in requirements
     assert profile["agix_required_version"] == AGIX_REQUIRED_VERSION
 
 
@@ -37,3 +37,211 @@ def test_qualia_profile_can_be_overridden_by_environment(tmp_path, monkeypatch):
 
     assert profile["require_agix_runtime"] is True
     assert profile["runtime_profile"] == "strict_compatible"
+
+
+def _write_profile(tmp_path, monkeypatch, payload):
+    profile_path = tmp_path / "qualia_profile.json"
+    profile_path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setenv("AGICORE_QUALIA_PROFILE", str(profile_path))
+    return profile_path
+
+
+def _purge_fake_agix(monkeypatch):
+    import sys
+
+    for name in list(sys.modules):
+        if name == "agix" or name.startswith("agix."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def _install_fake_agix(monkeypatch, version="1.9.0", *, compatible=True):
+    import importlib.machinery
+    import sys
+    import types
+
+    def module(name):
+        mod = types.ModuleType(name)
+        mod.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
+        monkeypatch.setitem(sys.modules, name, mod)
+        return mod
+
+    agix = module("agix")
+    agix.__version__ = version
+    agents = module("agix.agents")
+    module("agix.agents.genetic")
+    module("agix.agents.neuromorphic")
+    qualia = module("agix.qualia")
+    ethics = module("agix.qualia.ethics")
+
+    if compatible:
+
+        class GeneticAgent:
+            def __init__(self, action_space_size=4):
+                self.action_space_size = action_space_size
+
+            def perceive(self, request=None):
+                return request or {}
+
+            def decide(self, perception=None):
+                return {"recommended_action": "continue", "confidence": 0.9}
+
+            def learn(self, payload=None):
+                return {"ok": True}
+
+        class NeuromorphicAgent:
+            def __init__(self, input_size=2, output_size=2):
+                self.input_size = input_size
+                self.output_size = output_size
+
+            def activate(self, vector=None):
+                return {"activation": 0.5, "confidence": 0.8}
+
+            def update(self, state=None, reward=0.0):
+                return {"plasticity_delta": reward}
+
+        class QualiaEngine:
+            def generate_state(self, payload=None):
+                return {"state": "ok"}
+
+            def encode_integrated_info(self, payload=None):
+                return {"phi": 1.0}
+
+        class MoralEvaluator:
+            def evaluate(self, text=None):
+                return {"allowed": True}
+
+        sys.modules["agix.agents.genetic"].GeneticAgent = GeneticAgent
+        sys.modules["agix.agents.neuromorphic"].NeuromorphicAgent = NeuromorphicAgent
+        agents.GeneticAgent = GeneticAgent
+        agents.NeuromorphicAgent = NeuromorphicAgent
+        qualia.QualiaEngine = QualiaEngine
+        ethics.MoralEvaluator = MoralEvaluator
+    else:
+
+        class BrokenQualiaEngine:
+            pass
+
+        qualia.QualiaEngine = BrokenQualiaEngine
+
+    return agix
+
+
+def test_local_safe_starts_without_agix_and_keeps_advanced_adapters_disabled(
+    tmp_path, monkeypatch
+):
+    from agicore_core import agix_compat
+    from agicore_core.qualia_node import QualiaNode
+
+    _purge_fake_agix(monkeypatch)
+    _write_profile(
+        tmp_path,
+        monkeypatch,
+        {"agix_required_version": "1.9.0", "runtime_profile": "local_safe"},
+    )
+    monkeypatch.setattr(
+        agix_compat.metadata,
+        "version",
+        lambda name: (_ for _ in ()).throw(
+            agix_compat.metadata.PackageNotFoundError(name)
+        ),
+    )
+
+    node = QualiaNode()
+    enriched = node.enrich_request({"task": "saludo local"}, phase="test")
+
+    assert node.runtime_profile == "local_safe"
+    assert node.compatibility_report.mode == "local_safe"
+    assert node._evolution.genetic_agent is None
+    assert node._cognition.enabled is False
+    assert enriched["qualia"]["version_policy_action"] == "local_safe_no_agix_adapters"
+
+
+def test_degraded_allows_partial_incompatible_agix_and_reports_degradation(
+    tmp_path, monkeypatch
+):
+    from agicore_core import agix_compat
+    from agicore_core.qualia_node import QualiaNode
+
+    _purge_fake_agix(monkeypatch)
+    _install_fake_agix(monkeypatch, version="1.8.0", compatible=False)
+    _write_profile(
+        tmp_path,
+        monkeypatch,
+        {"agix_required_version": "1.9.0", "runtime_profile": "degraded"},
+    )
+    monkeypatch.setattr(agix_compat.metadata, "version", lambda name: "1.8.0")
+
+    node = QualiaNode()
+    report = node.enrich_request({"task": "analizar"}, phase="test")["qualia"][
+        "agix_compatibility_report"
+    ]
+
+    assert node.runtime_profile == "degraded"
+    assert report["mode"] == "degraded"
+    assert report["detected_version"] == "1.8.0"
+    assert any(
+        "agix_version_mismatch" in reason for reason in report["degradation_reasons"]
+    )
+    assert report["components"]["genetic_agent"]["contract_valid"] is False
+
+
+def test_strict_compatible_fails_clearly_without_agix_or_with_wrong_version(
+    tmp_path, monkeypatch
+):
+    import pytest
+    from agicore_core import agix_compat
+    from agicore_core.qualia_node import QualiaNode
+
+    _purge_fake_agix(monkeypatch)
+    _write_profile(
+        tmp_path,
+        monkeypatch,
+        {"agix_required_version": "1.9.0", "runtime_profile": "strict_compatible"},
+    )
+    monkeypatch.setattr(
+        agix_compat.metadata,
+        "version",
+        lambda name: (_ for _ in ()).throw(
+            agix_compat.metadata.PackageNotFoundError(name)
+        ),
+    )
+
+    with pytest.raises(
+        agix_compat.AgixStrictCompatibilityError, match="agix_version_required=1.9.0"
+    ):
+        QualiaNode()
+
+    _install_fake_agix(monkeypatch, version="1.8.0", compatible=True)
+    monkeypatch.setattr(agix_compat.metadata, "version", lambda name: "1.8.0")
+
+    with pytest.raises(
+        agix_compat.AgixStrictCompatibilityError, match="detected='1.8.0'"
+    ):
+        QualiaNode()
+
+
+def test_strict_compatible_starts_with_simulated_compatible_components(
+    tmp_path, monkeypatch
+):
+    from agicore_core import agix_compat
+    from agicore_core.qualia_node import QualiaNode
+
+    _purge_fake_agix(monkeypatch)
+    _install_fake_agix(monkeypatch, version="1.9.0", compatible=True)
+    _write_profile(
+        tmp_path,
+        monkeypatch,
+        {"agix_required_version": "1.9.0", "runtime_profile": "strict_compatible"},
+    )
+    monkeypatch.setattr(agix_compat.metadata, "version", lambda name: "1.9.0")
+
+    node = QualiaNode()
+    report = node.enrich_request({"task": "estricto compatible"}, phase="test")[
+        "qualia"
+    ]["agix_compatibility_report"]
+
+    assert node.runtime_profile == "strict_compatible"
+    assert report["mode"] == "strict_compatible"
+    assert report["degradation_reasons"] == []
+    assert report["components"]["qualia_engine"]["contract_valid"] is True
+    assert report["evolution_contract"]["genetic"]["degraded"] is False


### PR DESCRIPTION
### Motivation
- Hacer explícitos y auditablemente distinguibles los modos de ejecución de Qualia frente a la presencia y versión de AGIX. 
- Evitar que el Core active adaptadores avanzados cuando se ejecuta en un perfil local sin dependencias externas. 
- Permitir un modo degradado que informe qué componentes están presentes o degradados sin fallar la inicialización. 
- Exigir un modo estricto que valide versión y contratos mínimos y falle con errores de dominio claros si no se cumplen.

### Description
- Se añadió la propiedad `contract_valid` a `AgixComponentStatus` y se añadió información de degradación y mínimos en `AgixCompatibilityReport` con los campos `degradation_reasons` y `minimum_components` en `agicore_core/agix_compat.py`.
- Se implementó `MINIMUM_STRICT_COMPONENTS` y la excepción de dominio `AgixStrictCompatibilityError`, además de ajustar `build_compatibility_report` para soportar `runtime_profile` en `local_safe`, `degraded` y `strict_compatible` y generar razones de degradación auditables.
- Se actualizó `QualiaNode` en `agicore_core/qualia_node.py` para normalizar y validar el `runtime_profile`, desactivar adaptadores avanzados en `local_safe`, permitir carga parcial en `degraded` y elevar `AgixStrictCompatibilityError` durante la inicialización cuando el perfil `strict_compatible` no cumple versión o contratos mínimos.
- Se añadieron tests en `tests/test_agix_qualia_config.py` que simulan presencia/ausencia de AGIX para validar arranque en `local_safe`, informe y degradación en `degraded`, fallo claro en `strict_compatible` cuando falta o hay versión distinta, y éxito estricto con componentes simulados compatibles.

### Testing
- Se formatearon los archivos con `python -m black agicore_core/agix_compat.py agicore_core/qualia_node.py tests/test_agix_qualia_config.py` y no hubo conflictos de formateo.
- Se ejecutó `pytest -q tests/test_agix_qualia_config.py` y todos los tests añadidos pasaron (`6 passed, 4 warnings`).
- Se comprobó la coherencia del cambio con `git diff --check` y la batería de tests específica para Qualia/AGIX quedó verde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552afeac0883279a74fe70e19c998e)