### PR TITLE
Validate Responses API inputs strictly

### DIFF
--- a/gpt_oss/responses_api/api_server.py
+++ b/gpt_oss/responses_api/api_server.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import math
 import uuid
 from typing import Callable, Literal, Optional
 import json
 
-from fastapi import FastAPI, Request
-from fastapi.responses import StreamingResponse
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse, StreamingResponse
 from openai_harmony import (
     Author,
     Conversation,
@@ -81,6 +83,28 @@ def create_api_server(
     infer_next_token: Callable[[list[int], float], int], encoding: HarmonyEncoding
 ) -> FastAPI:
     app = FastAPI()
+
+    def _sanitize_validation_detail(value):
+        if isinstance(value, BaseException):
+            return str(value)
+        if isinstance(value, float) and not math.isfinite(value):
+            if math.isnan(value):
+                return "NaN"
+            return "Infinity" if value > 0 else "-Infinity"
+        if isinstance(value, list):
+            return [_sanitize_validation_detail(item) for item in value]
+        if isinstance(value, tuple):
+            return [_sanitize_validation_detail(item) for item in value]
+        if isinstance(value, dict):
+            return {key: _sanitize_validation_detail(child) for key, child in value.items()}
+        return value
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(request: Request, exc: RequestValidationError):
+        return JSONResponse(
+            status_code=422,
+            content={"detail": _sanitize_validation_detail(exc.errors())},
+        )
     responses_store: dict[str, tuple[ResponsesRequest, ResponseObject]] = {}
     qualia_engine = CoreQualiaEngine()
 
@@ -113,7 +137,7 @@ def create_api_server(
             "instruction": body.instructions or "",
             "model": body.model,
             "tools": [getattr(tool, "type", None) for tool in (body.tools or [])],
-            "metadata": body.metadata or {},
+            "metadata": body.metadata.model_dump() if body.metadata is not None else {},
         }
 
     def _blocked_response_object(
@@ -382,7 +406,12 @@ def create_api_server(
             self.request_body = request_body
             self.parser = StreamableParser(encoding, role=Role.ASSISTANT)
             self.as_sse = as_sse
-            self.debug_mode = request_body.metadata.get(
+            metadata = (
+                request_body.metadata.model_dump()
+                if request_body.metadata is not None
+                else {}
+            )
+            self.debug_mode = metadata.get(
                 "__debug", False
             )  # lo usamos con fines de demostración
             # Establecer la temperatura para este flujo, usar DEFAULT_TEMPERATURE si no está definida
@@ -1021,7 +1050,10 @@ def create_api_server(
                 elif item.type == "function_call_output":
                     function_call = function_call_map.get(item.call_id, None)
                     if not function_call:
-                        raise ValueError(f"Function call {item.call_id} not found")
+                        raise HTTPException(
+                            status_code=400,
+                            detail=f"Function call output references unknown call_id '{item.call_id}'",
+                        )
 
                     messages.append(
                         Message.from_author_and_content(

--- a/gpt_oss/responses_api/types.py
+++ b/gpt_oss/responses_api/types.py
@@ -1,152 +1,294 @@
-from typing import Any, Dict, Literal, Optional, Union
+from __future__ import annotations
+
+import math
+from typing import Any, Literal, Optional, Union
 
 from openai_harmony import ReasoningEffort
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field, FiniteFloat, StrictBool, StrictInt, StrictStr, field_validator, model_validator
 
 MODEL_IDENTIFIER = "gpt-oss-120b"
 DEFAULT_TEMPERATURE = 0.0
 REASONING_EFFORT = ReasoningEffort.LOW
 DEFAULT_MAX_OUTPUT_TOKENS = 10_000
 
-class UrlCitation(BaseModel):
-    type: Literal["url_citation"]
-    end_index: int
-    start_index: int
-    url: str
-    title: str
+RESERVED_INTERNAL_FIELDS = frozenset(
+    {
+        "pro_vida",
+        "no_dano",
+        "respeto",
+        "qualia",
+        "qualia_policies",
+        "ethical_score",
+        "violated_constraints",
+        "governance_score",
+        "governance_scores",
+        "internal_governance_score",
+        "internal_governance_scores",
+        "government_score",
+        "government_scores",
+        "policy_score",
+        "policy_scores",
+        "safety_score",
+        "safety_scores",
+        "risk_score",
+        "risk_scores",
+    }
+)
 
-class TextContentItem(BaseModel):
+JsonScalar = Union[StrictStr, StrictInt, FiniteFloat, StrictBool, None]
+JsonValue = Any
+
+
+def _validate_json_value(value: Any, *, location: str) -> Any:
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{location} no acepta NaN ni Infinity")
+    elif isinstance(value, (str, int, bool)) or value is None:
+        return value
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _validate_json_value(child, location=f"{location}[{index}]")
+    elif isinstance(value, dict):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise ValueError(f"{location} solo acepta claves string")
+            _validate_json_value(child, location=f"{location}.{key}")
+    else:
+        raise ValueError(f"{location} contiene un valor JSON inválido")
+    return value
+
+
+def _contains_reserved_internal_name(name: str) -> bool:
+    normalized = name.strip().lower()
+    return normalized in RESERVED_INTERNAL_FIELDS or (
+        normalized.endswith("_score")
+        and any(marker in normalized for marker in ("govern", "policy", "safety", "risk", "ethical"))
+    )
+
+
+def _validate_no_reserved_internal_fields(value: Any, *, location: str) -> Any:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if not isinstance(key, str):
+                raise ValueError(f"{location} solo acepta claves string")
+            if _contains_reserved_internal_name(key):
+                raise ValueError(
+                    f"{location} no puede contener el campo interno reservado '{key}'"
+                )
+            _validate_no_reserved_internal_fields(child, location=f"{location}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _validate_no_reserved_internal_fields(child, location=f"{location}[{index}]")
+    return value
+
+
+class StrictApiModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+
+class StrictMetadata(StrictApiModel):
+    """Client metadata: JSON-only values and no Qualia/governance internals."""
+
+    model_config = ConfigDict(extra="allow", strict=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_metadata(cls, value: Any) -> Any:
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise ValueError("metadata debe ser un objeto JSON")
+        _validate_json_value(value, location="metadata")
+        return _validate_no_reserved_internal_fields(value, location="metadata")
+
+
+class InternalQualiaFields(StrictApiModel):
+    """Server-only Qualia fields. Never accept this model from client input."""
+
+    pro_vida: Optional[FiniteFloat] = None
+    no_dano: Optional[FiniteFloat] = None
+    respeto: Optional[FiniteFloat] = None
+    qualia: Optional[dict[str, JsonValue]] = None
+    qualia_policies: Optional[list[StrictStr]] = None
+    ethical_score: Optional[FiniteFloat] = None
+    violated_constraints: Optional[list[StrictStr]] = None
+    governance_scores: Optional[dict[str, FiniteFloat]] = None
+
+
+class NumericSignal(StrictApiModel):
+    name: StrictStr
+    value: FiniteFloat
+
+
+class UrlCitation(StrictApiModel):
+    type: Literal["url_citation"]
+    end_index: StrictInt
+    start_index: StrictInt
+    url: StrictStr
+    title: StrictStr
+
+
+class TextContentItem(StrictApiModel):
     type: Union[Literal["text"], Literal["input_text"], Literal["output_text"]]
-    text: str
-    status: Optional[str] = "completed"
+    text: StrictStr
+    status: Optional[StrictStr] = "completed"
     annotations: Optional[list[UrlCitation]] = None
 
 
-class SummaryTextContentItem(BaseModel):
-    # using summary for compatibility with the existing API
+class SummaryTextContentItem(StrictApiModel):
     type: Literal["summary_text"]
-    text: str
+    text: StrictStr
 
 
-class ReasoningTextContentItem(BaseModel):
+class ReasoningTextContentItem(StrictApiModel):
     type: Literal["reasoning_text"]
-    text: str
+    text: StrictStr
 
 
-class ReasoningItem(BaseModel):
-    id: str = "rs_1234"
+class ReasoningItem(StrictApiModel):
+    id: StrictStr = "rs_1234"
     type: Literal["reasoning"]
     summary: list[SummaryTextContentItem]
-    content: Optional[list[ReasoningTextContentItem]] = []
+    content: Optional[list[ReasoningTextContentItem]] = Field(default_factory=list)
 
 
-class Item(BaseModel):
+class Item(StrictApiModel):
     type: Optional[Literal["message"]] = "message"
     role: Literal["user", "assistant", "system"]
-    content: Union[list[TextContentItem], str]
+    content: Union[list[TextContentItem], StrictStr]
     status: Union[Literal["in_progress", "completed", "incomplete"], None] = None
 
 
-class FunctionCallItem(BaseModel):
+class FunctionCallItem(StrictApiModel):
     type: Literal["function_call"]
-    name: str
-    arguments: str
+    name: StrictStr = Field(min_length=1)
+    arguments: StrictStr
     status: Literal["in_progress", "completed", "incomplete"] = "completed"
-    id: str = "fc_1234"
-    call_id: str = "call_1234"
+    id: StrictStr = "fc_1234"
+    call_id: StrictStr = "call_1234"
 
 
-class FunctionCallOutputItem(BaseModel):
+class FunctionCallOutputItem(StrictApiModel):
     type: Literal["function_call_output"]
-    call_id: str = "call_1234"
-    output: str
+    call_id: StrictStr = "call_1234"
+    output: StrictStr
 
-class WebSearchActionSearch(BaseModel):
+
+class WebSearchActionSearch(StrictApiModel):
     type: Literal["search"]
-    query: Optional[str] = None
+    query: Optional[StrictStr] = None
 
-class WebSearchActionOpenPage(BaseModel):
+
+class WebSearchActionOpenPage(StrictApiModel):
     type: Literal["open_page"]
-    url: Optional[str] = None
+    url: Optional[StrictStr] = None
 
-class WebSearchActionFind(BaseModel):
+
+class WebSearchActionFind(StrictApiModel):
     type: Literal["find"]
-    pattern: Optional[str] = None
-    url: Optional[str] = None
+    pattern: Optional[StrictStr] = None
+    url: Optional[StrictStr] = None
 
-class WebSearchCallItem(BaseModel):
+
+class WebSearchCallItem(StrictApiModel):
     type: Literal["web_search_call"]
-    id: str = "ws_1234"
+    id: StrictStr = "ws_1234"
     status: Literal["in_progress", "completed", "incomplete"] = "completed"
     action: Union[WebSearchActionSearch, WebSearchActionOpenPage, WebSearchActionFind]
 
-class Error(BaseModel):
-    code: str
-    message: str
+
+class Error(StrictApiModel):
+    code: StrictStr
+    message: StrictStr
 
 
-class IncompleteDetails(BaseModel):
-    reason: str
+class IncompleteDetails(StrictApiModel):
+    reason: StrictStr
 
 
-class Usage(BaseModel):
-    input_tokens: int
-    output_tokens: int
-    total_tokens: int
+class Usage(StrictApiModel):
+    input_tokens: StrictInt
+    output_tokens: StrictInt
+    total_tokens: StrictInt
 
 
-class FunctionToolDefinition(BaseModel):
+class FunctionToolDefinition(StrictApiModel):
     type: Literal["function"]
-    name: str
-    parameters: dict  # this should be typed stricter if you add strict mode
-    strict: bool = False  # change this if you support strict mode
-    description: Optional[str] = ""
+    name: StrictStr = Field(min_length=1)
+    parameters: dict[str, JsonValue]
+    strict: StrictBool = False
+    description: Optional[StrictStr] = ""
+
+    @field_validator("parameters")
+    @classmethod
+    def validate_parameters(cls, value: dict[str, JsonValue]) -> dict[str, JsonValue]:
+        _validate_json_value(value, location="tools.parameters")
+        _validate_no_reserved_internal_fields(value, location="tools.parameters")
+        return value
 
 
-class BrowserToolConfig(BaseModel):
+class BrowserToolConfig(StrictApiModel):
     type: Literal["browser_search"]
 
 
-class ReasoningConfig(BaseModel):
-    effort: Literal["low", "medium", "high"] = REASONING_EFFORT
+class ReasoningConfig(StrictApiModel):
+    effort: Literal["low", "medium", "high"] = "low"
 
 
-class ResponsesRequest(BaseModel):
-    instructions: Optional[str] = None
-    max_output_tokens: Optional[int] = DEFAULT_MAX_OUTPUT_TOKENS
+class ResponsesRequest(StrictApiModel):
+    instructions: Optional[StrictStr] = None
+    max_output_tokens: Optional[StrictInt] = DEFAULT_MAX_OUTPUT_TOKENS
     input: Union[
-        str, list[Union[Item, ReasoningItem, FunctionCallItem, FunctionCallOutputItem, WebSearchCallItem]]
+        StrictStr, list[Union[Item, ReasoningItem, FunctionCallItem, FunctionCallOutputItem, WebSearchCallItem]]
     ]
-    model: Optional[str] = MODEL_IDENTIFIER
-    stream: Optional[bool] = False
-    tools: Optional[list[Union[FunctionToolDefinition, BrowserToolConfig]]] = []
-    reasoning: Optional[ReasoningConfig] = ReasoningConfig()
-    metadata: Optional[Dict[str, Any]] = {}
+    model: Optional[StrictStr] = MODEL_IDENTIFIER
+    stream: Optional[StrictBool] = False
+    tools: Optional[list[Union[FunctionToolDefinition, BrowserToolConfig]]] = Field(default_factory=list)
+    reasoning: Optional[ReasoningConfig] = Field(default_factory=ReasoningConfig)
+    metadata: Optional[StrictMetadata] = Field(default_factory=StrictMetadata)
     tool_choice: Optional[Literal["auto", "none"]] = "auto"
-    parallel_tool_calls: Optional[bool] = False
-    store: Optional[bool] = False
-    previous_response_id: Optional[str] = None
-    temperature: Optional[float] = DEFAULT_TEMPERATURE
-    include: Optional[list[str]] = None
+    parallel_tool_calls: Optional[StrictBool] = False
+    store: Optional[StrictBool] = False
+    previous_response_id: Optional[StrictStr] = None
+    temperature: Optional[FiniteFloat] = DEFAULT_TEMPERATURE
+    include: Optional[list[StrictStr]] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_client_internal_fields(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            _validate_no_reserved_internal_fields(value, location="request")
+        return value
+
+    @field_validator("temperature")
+    @classmethod
+    def validate_temperature(cls, value: Optional[float]) -> Optional[float]:
+        if value is None:
+            return value
+        if not math.isfinite(value):
+            raise ValueError("temperature debe ser un número finito")
+        if value < 0 or value > 2:
+            raise ValueError("temperature debe estar entre 0 y 2")
+        return value
 
 
-class ResponseObject(BaseModel):
+class ResponseObject(StrictApiModel):
     output: list[Union[Item, ReasoningItem, FunctionCallItem, FunctionCallOutputItem, WebSearchCallItem]]
-    created_at: int
+    created_at: StrictInt
     usage: Optional[Usage] = None
     status: Literal["completed", "failed", "incomplete", "in_progress"] = "in_progress"
     background: None = None
     error: Optional[Error] = None
     incomplete_details: Optional[IncompleteDetails] = None
-    instructions: Optional[str] = None
-    max_output_tokens: Optional[int] = None
-    max_tool_calls: Optional[int] = None
-    metadata: Optional[Dict[str, Any]] = {}
-    model: Optional[str] = MODEL_IDENTIFIER
-    parallel_tool_calls: Optional[bool] = False
-    previous_response_id: Optional[str] = None
-    id: Optional[str] = "resp_1234"
-    object: Optional[str] = "response"
-    text: Optional[Dict[str, Any]] = None
-    tool_choice: Optional[str] = "auto"
-    top_p: Optional[int] = 1
+    instructions: Optional[StrictStr] = None
+    max_output_tokens: Optional[StrictInt] = None
+    max_tool_calls: Optional[StrictInt] = None
+    metadata: Optional[dict[str, JsonValue]] = Field(default_factory=dict)
+    model: Optional[StrictStr] = MODEL_IDENTIFIER
+    parallel_tool_calls: Optional[StrictBool] = False
+    previous_response_id: Optional[StrictStr] = None
+    id: Optional[StrictStr] = "resp_1234"
+    object: Optional[StrictStr] = "response"
+    text: Optional[dict[str, JsonValue]] = None
+    tool_choice: Optional[StrictStr] = "auto"
+    top_p: Optional[StrictInt] = 1

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -102,3 +102,81 @@ def test_responses_api_blocks_illegal_request_before_inference(harmony_encoding)
     assert payload["error"]["code"] == "blocked_by_qualia"
     assert payload["metadata"]["qualia"]["legal_policy_action"] == "blocked_illegal_or_unsafe_decision"
     assert "malware" in payload["metadata"]["qualia"]["violated_constraints"]
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"qualia": {"ethical_score": 1.0}},
+        {"nested": {"violated_constraints": []}},
+        {"governance_score": 0.99},
+    ],
+)
+def test_responses_api_rejects_malicious_metadata(test_client, metadata):
+    response = test_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-oss-120b",
+            "input": "Hello, world!",
+            "metadata": metadata,
+        },
+    )
+
+    assert response.status_code == 422
+    assert "campo interno reservado" in response.text
+
+
+@pytest.mark.parametrize("raw_float", ["NaN", "Infinity", "-Infinity"])
+def test_responses_api_rejects_non_finite_temperature(test_client, raw_float):
+    response = test_client.post(
+        "/v1/responses",
+        data=(
+            '{"model":"gpt-oss-120b",'
+            '"input":"Hello, world!",'
+            f'"temperature":{raw_float}'
+            "}"
+        ),
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 422
+    assert "finite" in response.text.lower() or "finito" in response.text.lower()
+
+
+def test_responses_api_rejects_invalid_tool_call_shape(test_client):
+    response = test_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-oss-120b",
+            "input": [
+                {
+                    "type": "function_call",
+                    "name": "lookup",
+                    "arguments": {"not": "a json string"},
+                    "call_id": "call_lookup",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+    assert "arguments" in response.text
+
+
+def test_responses_api_rejects_unknown_function_call_output(test_client):
+    response = test_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-oss-120b",
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "missing_call",
+                    "output": "{}",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    assert "unknown call_id" in response.text


### PR DESCRIPTION
### Motivation

- Harden the Responses API input boundary to prevent clients from injecting or overriding internal governance/Qualia signals and to ensure strict, predictable typing.  
- Reject invalid numeric signals such as `NaN`, `Infinity` and `-Infinity` with clear 4xx responses instead of causing server serialization crashes.  
- Validate tool call shapes and function call references early to avoid runtime exceptions during request handling.

### Description

- Replace lax Pydantic models with strict models (`StrictApiModel`) and `extra="forbid"`, tighten types across request/response models in `gpt_oss/responses_api/types.py`, including explicit models for `metadata`, numeric signals, tool calls and server-only Qualia fields.  
- Add recursive JSON validation for `metadata` and `FunctionToolDefinition.parameters` to forbid reserved internal fields (examples: `pro_vida`, `no_dano`, `respeto`, `qualia`, `qualia_policies`, `ethical_score`, `violated_constraints` and other governance score fields), and to reject non-string keys and non-finite floats.  
- Enforce finite-range `temperature` using `FiniteFloat` and a validator that rejects non-finite values and values outside `0..2`.  
- Sanitize validation errors in `gpt_oss/responses_api/api_server.py` with a `RequestValidationError` handler that converts `NaN`/`Infinity`/`-Infinity` and embedded exceptions into JSON-serializable messages and returns `422` instead of crashing.  
- Ensure Qualia receives only validated metadata by serializing with `model_dump()` before forwarding, and make unknown `function_call_output` `call_id` references return a `400` with a clear `detail` instead of raising an uncontrolled exception.  
- Add regression tests in `tests/test_responses_api.py` that exercise malicious metadata, non-finite temperatures, invalid tool-call shapes, and unknown `function_call_output` references.

### Testing

- Ran `AGIX_RUNTIME_PROFILE=degraded pytest -q tests/test_responses_api.py` which completed successfully with `11 passed` (4 warnings).  
- Ran `python -m compileall gpt_oss/responses_api tests/test_responses_api.py` to validate modules compile without syntax errors.  
- Note: running the tests without `AGIX_RUNTIME_PROFILE=degraded` in this environment fails at Qualia/AGIX initialization because strict AGIX runtime components (`qualia_engine`, `moral_evaluator`) are not available, so CI or environments that provide full AGIX runtime should be used to exercise strict AGIX behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552f02cc608327ac3759070bd1a3c5)