### PR TITLE
Add OutputSafetyScanner for chunked output safety checks in Responses API

### DIFF
--- a/gpt_oss/responses_api/api_server.py
+++ b/gpt_oss/responses_api/api_server.py
@@ -26,6 +26,7 @@ from openai_harmony import (
 
 from agicore_core.qualia_engine import CoreQualiaEngine
 from agicore_core.qualia_responses import format_blocked_response
+from gpt_oss.responses_api.inference.qualia_guard import OutputSafetyScanner
 
 SAFE_DOMAINS = {"openai.com"}
 
@@ -139,6 +140,19 @@ def create_api_server(
             "tools": [getattr(tool, "type", None) for tool in (body.tools or [])],
             "metadata": body.metadata.model_dump() if body.metadata is not None else {},
         }
+
+    def _response_output_to_text(response: ResponseObject) -> str:
+        parts: list[str] = []
+        for item in response.output:
+            item_type = getattr(item, "type", "")
+            if item_type == "function_call":
+                parts.append(f"tool={getattr(item, 'name', '')}\narguments={getattr(item, 'arguments', '')}")
+            else:
+                for content_item in (getattr(item, "content", []) or []):
+                    text = getattr(content_item, "text", "")
+                    if text:
+                        parts.append(str(text))
+        return "\n".join(parts)
 
     def _blocked_response_object(
         blocked_result: dict,
@@ -398,6 +412,7 @@ def create_api_server(
                 Callable[[str, ResponsesRequest, ResponseObject], None]
             ] = None,
             browser_tool: Optional[object] = None,
+            safety_scanner: Optional[OutputSafetyScanner] = None,
         ):
             self.initial_tokens = initial_tokens
             self.tokens = initial_tokens.copy()
@@ -429,6 +444,10 @@ def create_api_server(
             self.browser_tool = browser_tool
             self.use_browser_tool = browser_tool is not None
             self.browser_call_ids: list[str] = []
+            self.safety_scanner = safety_scanner or OutputSafetyScanner(
+                qualia_engine=qualia_engine,
+                base_request=_qualia_request_from_body(request_body, phase="responses_api"),
+            )
 
         def _send_event(self, event: ResponseEvent):
             event.sequence_number = self.sequence_number
@@ -504,6 +523,27 @@ def create_api_server(
                                 not recipient.startswith("browser.")
                                 and not recipient == "python"
                             ):
+                                _, tool_blocked = self.safety_scanner.scan_tool_call(
+                                    previous_item.recipient,
+                                    previous_item.content[0].text,
+                                )
+                                if tool_blocked is not None:
+                                    response = _blocked_response_object(
+                                        tool_blocked,
+                                        self.request_body,
+                                        response_id=self.response_id,
+                                        previous_response_id=self.request_body.previous_response_id,
+                                        channel="responses_api_tool_call",
+                                    )
+                                    if self.store_callback and self.request_body.store:
+                                        self.store_callback(self.response_id, self.request_body, response)
+                                    yield self._send_event(
+                                        ResponseCompletedEvent(
+                                            type="response.completed",
+                                            response=response,
+                                        )
+                                    )
+                                    return
                                 fc_id = f"fc_{uuid.uuid4().hex}"
                                 call_id = f"call_{uuid.uuid4().hex}"
                                 self.function_call_ids.append((fc_id, call_id))
@@ -659,6 +699,26 @@ def create_api_server(
 
 
                     if should_send_output_text_delta:
+                        _, stream_blocked = self.safety_scanner.scan_stream_chunk(
+                            output_delta_buffer
+                        )
+                        if stream_blocked is not None:
+                            response = _blocked_response_object(
+                                stream_blocked,
+                                self.request_body,
+                                response_id=self.response_id,
+                                previous_response_id=self.request_body.previous_response_id,
+                                channel="responses_api_stream",
+                            )
+                            if self.store_callback and self.request_body.store:
+                                self.store_callback(self.response_id, self.request_body, response)
+                            yield self._send_event(
+                                ResponseCompletedEvent(
+                                    type="response.completed",
+                                    response=response,
+                                )
+                            )
+                            return
                         yield self._send_event(
                             ResponseOutputTextDelta(
                                 type="response.output_text.delta",
@@ -704,47 +764,11 @@ def create_api_server(
                     )
 
                 try:
-                    # solo con fines de depuración
+                    # solo con fines de depuración; la seguridad de salida se evalúa
+                    # por chunks/ventanas solapadas para evitar ejecutar Qualia por token.
                     output_token_text = encoding.decode_utf8([next_tok])
-                    token_request = _qualia_request_from_body(
-                        self.request_body, phase="responses_api_token"
-                    )
-                    token_request.update(
-                        {
-                            "token": output_token_text,
-                            "last_token": output_token_text,
-                            "decoded_text": self.output_text + output_token_text,
-                        }
-                    )
-                    token_state, token_blocked = qualia_engine.govern_decision(
-                        token_request, phase="responses_api_token"
-                    )
-                    if token_blocked is not None:
-                        formatted = format_blocked_response(
-                            token_blocked, channel="responses_api_token"
-                        )
-                        qualia_engine.after_decision(
-                            formatted, token_state, phase="responses_api_token"
-                        )
-                        response = _blocked_response_object(
-                            token_blocked,
-                            self.request_body,
-                            response_id=self.response_id,
-                            previous_response_id=self.request_body.previous_response_id,
-                            channel="responses_api_token",
-                        )
-                        if self.store_callback and self.request_body.store:
-                            self.store_callback(self.response_id, self.request_body, response)
-                        yield self._send_event(
-                            ResponseCompletedEvent(
-                                type="response.completed",
-                                response=response,
-                            )
-                        )
-                        return
                     self.output_text += output_token_text
                     print(output_token_text, end="", flush=True)
-
                 except RuntimeError:
                     pass
 
@@ -777,6 +801,27 @@ def create_api_server(
                                 )
 
                             if action is not None:
+                                _, tool_blocked = self.safety_scanner.scan_tool_call(
+                                    last_message.recipient,
+                                    last_message.content[0].text,
+                                )
+                                if tool_blocked is not None:
+                                    response = _blocked_response_object(
+                                        tool_blocked,
+                                        self.request_body,
+                                        response_id=self.response_id,
+                                        previous_response_id=self.request_body.previous_response_id,
+                                        channel="responses_api_tool_call",
+                                    )
+                                    if self.store_callback and self.request_body.store:
+                                        self.store_callback(self.response_id, self.request_body, response)
+                                    yield self._send_event(
+                                        ResponseCompletedEvent(
+                                            type="response.completed",
+                                            response=response,
+                                        )
+                                    )
+                                    return
                                 web_search_call_id = f"ws_{uuid.uuid4().hex}"
                                 self.browser_call_ids.append(web_search_call_id)
                                 yield self._send_event(ResponseOutputItemAdded(
@@ -868,6 +913,16 @@ def create_api_server(
                     browser_tool=self.browser_tool,
                     browser_call_ids=self.browser_call_ids,
                 )
+                final_text = _response_output_to_text(response)
+                _, final_blocked = self.safety_scanner.scan_final_response(final_text)
+                if final_blocked is not None:
+                    response = _blocked_response_object(
+                        final_blocked,
+                        self.request_body,
+                        response_id=self.response_id,
+                        previous_response_id=self.request_body.previous_response_id,
+                        channel="responses_api_final",
+                    )
                 if self.store_callback and self.request_body.store:
                     self.store_callback(self.response_id, self.request_body, response)
                 yield self._send_event(
@@ -923,8 +978,13 @@ def create_api_server(
 
 
         qualia_request = _qualia_request_from_body(body, phase="responses_api")
-        qualia_state, blocked = qualia_engine.govern_decision(
-            qualia_request, phase="responses_api"
+        safety_scanner = OutputSafetyScanner(
+            qualia_engine=qualia_engine,
+            base_request=qualia_request,
+        )
+        qualia_state, blocked = safety_scanner.evaluate_initial_prompt(
+            f"{qualia_request.get('instruction', '')}\n{qualia_request.get('prompt', '')}",
+            phase="responses_api",
         )
         response_id = f"resp_{uuid.uuid4().hex}"
         if blocked is not None:
@@ -1080,6 +1140,7 @@ def create_api_server(
             response_id=response_id,
             store_callback=store_callback,
             browser_tool=browser_tool,
+            safety_scanner=safety_scanner,
         )
 
         if body.stream:

--- a/gpt_oss/responses_api/inference/qualia_guard.py
+++ b/gpt_oss/responses_api/inference/qualia_guard.py
@@ -2,10 +2,141 @@
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass, field
 from typing import Any, Callable, Mapping
 
 from agicore_core.qualia_engine import CoreQualiaEngine
 from agicore_core.qualia_responses import format_blocked_response
+
+
+_DANGEROUS_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(pattern, re.IGNORECASE | re.DOTALL)
+    for pattern in (
+        r"\bmal\s*ware\b",
+        r"\bex\s*filtr\w*\b.{0,80}\bcredenciales\b",
+        r"\bcredenciales\b.{0,80}\bex\s*filtr\w*\b",
+        r"\brob\w*\b.{0,80}\bcredenciales\b",
+        r"\bphish\w*\b",
+        r"\bkey\s*logger\b",
+        r"\bransom\s*ware\b",
+        r"\bpassword\s*steal\w*\b",
+        r"\bcurl\b.{0,120}\b(sh|bash)\b",
+        r"\brm\s+-rf\s+/(?:\s|$)",
+        r"\bdd\s+if=/dev/zero\s+of=/dev/",
+    )
+)
+
+
+@dataclass
+class OutputSafetyScanner:
+    """Escáner incremental de salida para Responses API.
+
+    El escáner mantiene texto acumulado y evalúa ventanas solapadas para atrapar
+    expresiones dañinas aunque aparezcan divididas entre tokens. Para reducir el
+    coste, ejecuta heurísticas locales por chunk y solo llama a Qualia/AGIX cuando
+    una ventana supera umbral de riesgo, cuando se inspecciona una tool call o en
+    la evaluación final obligatoria.
+    """
+
+    qualia_engine: CoreQualiaEngine | None = None
+    base_request: Mapping[str, Any] | None = None
+    window_size: int = 512
+    overlap_size: int = 128
+    min_chunk_chars_for_qualia: int = 80
+    accumulated_text: str = ""
+    _qualia_calls: int = 0
+    _seen_windows: set[tuple[str, int, int]] = field(default_factory=set)
+
+    def __post_init__(self) -> None:
+        self.qualia_engine = self.qualia_engine or CoreQualiaEngine()
+        self.base_request = dict(self.base_request or {})
+
+    @property
+    def qualia_calls(self) -> int:
+        return self._qualia_calls
+
+    def evaluate_initial_prompt(self, prompt: str, *, phase: str = "responses_api") -> tuple[dict[str, Any], dict[str, Any] | None]:
+        self.accumulated_text += f"\n[PROMPT]\n{prompt}"
+        return self._run_qualia(prompt, phase=phase, reason="initial_prompt")
+
+    def scan_stream_chunk(self, chunk: str, *, phase: str = "responses_api_stream") -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        if not chunk:
+            return None, None
+        self.accumulated_text += chunk
+        candidates = self._candidate_windows(final=False)
+        risky = [window for window in candidates if self._local_risk_score(window) > 0]
+        if not risky and len(chunk) < self.min_chunk_chars_for_qualia:
+            return None, None
+        if risky:
+            return self._run_qualia(risky[-1], phase=phase, reason="stream_window")
+        return None, None
+
+    def scan_tool_call(self, name: str, arguments: str, *, phase: str = "responses_api_tool_call") -> tuple[dict[str, Any], dict[str, Any] | None]:
+        text = f"tool={name}\narguments={arguments}"
+        self.accumulated_text += f"\n[TOOL_CALL]\n{text}"
+        return self._run_qualia(text, phase=phase, reason="tool_call")
+
+    def scan_final_response(self, text: str | None = None, *, phase: str = "responses_api_final") -> tuple[dict[str, Any], dict[str, Any] | None]:
+        if text:
+            self.accumulated_text += f"\n[FINAL]\n{text}"
+        final_text = text if text is not None else self.accumulated_text
+        windows = self._candidate_windows(final=True, text=final_text)
+        risky = [window for window in windows if self._local_risk_score(window) > 0]
+        target = risky[-1] if risky else final_text[-self.window_size :]
+        return self._run_qualia(target, phase=phase, reason="final_response")
+
+    def _candidate_windows(self, *, final: bool, text: str | None = None) -> list[str]:
+        source = text if text is not None else self.accumulated_text
+        if not source:
+            return []
+        windows: list[str] = []
+        step = max(1, self.window_size - self.overlap_size)
+        if final:
+            starts = range(0, len(source), step)
+        else:
+            start = max(0, len(source) - self.window_size - self.overlap_size)
+            starts = range(start, len(source), step)
+        for start in starts:
+            end = min(len(source), start + self.window_size)
+            if start >= end:
+                continue
+            key = ("final" if final else "stream", start, end)
+            if key in self._seen_windows and not final:
+                continue
+            self._seen_windows.add(key)
+            windows.append(source[start:end])
+        return windows
+
+    def _local_risk_score(self, text: str) -> int:
+        normalized = self._normalize_for_scan(text)
+        return sum(1 for pattern in _DANGEROUS_PATTERNS if pattern.search(normalized))
+
+    def _normalize_for_scan(self, text: str) -> str:
+        # Une divisiones artificiales entre tokens: "mal\n ware", "ex filtrar", etc.
+        lowered = text.lower()
+        compact_words = re.sub(r"(?<=\w)[\s_\-./]+(?=\w)", "", lowered)
+        spaced = re.sub(r"[\s_\-./]+", " ", lowered)
+        return f"{spaced}\n{compact_words}"
+
+    def _run_qualia(self, text: str, *, phase: str, reason: str) -> tuple[dict[str, Any], dict[str, Any] | None]:
+        request = dict(self.base_request or {})
+        request.update(
+            {
+                "task": request.get("task", "responses_api_output_safety"),
+                "context": phase,
+                "scan_reason": reason,
+                "prompt": text,
+                "decoded_text": text,
+                "accumulated_output_tail": self.accumulated_text[-self.window_size :],
+            }
+        )
+        self._qualia_calls += 1
+        enriched, blocked = self.qualia_engine.govern_decision(request, phase=phase)
+        if blocked is not None:
+            formatted = format_blocked_response(blocked, channel=phase)
+            self.qualia_engine.after_decision(formatted, enriched, phase=phase)
+        return enriched, blocked
 
 
 class QualiaGuardedInference:

--- a/tests/test_qualia_guard.py
+++ b/tests/test_qualia_guard.py
@@ -1,6 +1,40 @@
 import pytest
 
-from gpt_oss.responses_api.inference.qualia_guard import QualiaGuardedInference
+from gpt_oss.responses_api.inference.qualia_guard import (
+    OutputSafetyScanner,
+    QualiaGuardedInference,
+)
+
+
+class FakeQualiaEngine:
+    def __init__(self):
+        self.calls = []
+
+    def govern_decision(self, request, phase="test"):
+        self.calls.append((phase, request))
+        text = (
+            str(request.get("task", ""))
+            + "\n"
+            + str(request.get("goals", ""))
+            + "\n"
+            + request.get("prompt", "")
+            + "\n"
+            + request.get("decoded_text", "")
+            + "\n"
+            + request.get("accumulated_output_tail", "")
+        ).lower()
+        compact = "".join(ch for ch in text if ch.isalnum())
+        if "malware" in compact or "exfiltrarcredenciales" in compact or "rmrf" in compact:
+            blocked = {
+                "message": "blocked by fake qualia",
+                "legal_policy_action": "blocked_illegal_or_unsafe_decision",
+                "violated_constraints": ["malware"],
+            }
+            return {**request, "qualia": {"blocked": True}}, blocked
+        return {**request, "qualia": {"blocked": False}}, None
+
+    def after_decision(self, result, state, phase="test"):
+        return None
 
 
 def test_qualia_guard_blocks_before_backend_call():
@@ -10,7 +44,7 @@ def test_qualia_guard_blocks_before_backend_call():
         called["backend"] += 1
         return 1
 
-    guard = QualiaGuardedInference(backend)
+    guard = QualiaGuardedInference(backend, qualia_engine=FakeQualiaEngine())
 
     with pytest.raises(RuntimeError):
         guard(
@@ -29,6 +63,35 @@ def test_qualia_guard_allows_safe_backend_call():
     def backend(tokens, temperature=0.0, new_request=False):
         return 7
 
-    guard = QualiaGuardedInference(backend)
+    guard = QualiaGuardedInference(backend, qualia_engine=FakeQualiaEngine())
 
     assert guard([1], request_state={"task": "analizar", "context": "ctx"}) == 7
+
+
+def test_output_safety_scanner_blocks_harmful_phrase_split_across_chunks():
+    engine = FakeQualiaEngine()
+    scanner = OutputSafetyScanner(
+        qualia_engine=engine,
+        base_request={"task": "responses_api", "goals": ["safe_generation"]},
+    )
+
+    assert scanner.scan_stream_chunk("Texto benigno sobre mal")[1] is None
+    _, blocked = scanner.scan_stream_chunk(" ware para ex filtrar credenciales")
+
+    assert blocked is not None
+    assert blocked["legal_policy_action"] == "blocked_illegal_or_unsafe_decision"
+    assert len(engine.calls) == 1
+    assert engine.calls[0][0] == "responses_api_stream"
+
+
+def test_output_safety_scanner_blocks_dangerous_tool_call():
+    engine = FakeQualiaEngine()
+    scanner = OutputSafetyScanner(qualia_engine=engine)
+
+    _, blocked = scanner.scan_tool_call(
+        "functions.shell",
+        '{"cmd": "rm -rf /"}',
+    )
+
+    assert blocked is not None
+    assert engine.calls[0][0] == "responses_api_tool_call"


### PR DESCRIPTION
### Motivation
- Evitar llamadas por token al motor Qualia/AGIX y reducir coste ejecutando verificaciones locales baratas por chunk y ventanas solapadas. 
- Detectar frases nocivas que puedan aparecer partidas entre tokens/chunks y controlar llamadas a herramientas peligrosas antes de completar la respuesta.

### Description
- Añade `OutputSafetyScanner` en `gpt_oss/responses_api/inference/qualia_guard.py` que acumula texto, genera ventanas solapadas, normaliza separadores para detectar expresiones partidas y aplica patrones heurísticos locales antes de invocar Qualia.
- Integra el scanner en `gpt_oss/responses_api/api_server.py`: se instancia con el request base y se usa para evaluar el prompt inicial, chunks de streaming, tool calls y la respuesta final antes de completar.
- Sustituye las comprobaciones Qualia por token en streaming por evaluación por chunk/ventana y mantiene sólo el `decode` por depuración; bloqueos generan un objeto de respuesta bloqueada coherente con el flujo existente.
- Añade tests unitarios en `tests/test_qualia_guard.py` que usan un `FakeQualiaEngine` para verificar bloqueo de frases dañinas partidas entre chunks y bloqueo de tool calls peligrosos.

### Testing
- Compilación rápida de archivos modificados con `python -m compileall -q gpt_oss/responses_api/api_server.py gpt_oss/responses_api/inference/qualia_guard.py tests/test_qualia_guard.py` (sucedió correctamente).
- Ejecutados los tests del scanner con `pytest -q tests/test_qualia_guard.py` y pasaron (`4 passed`).
- Ejecutados los tests de Responses API con `AGIX_RUNTIME_PROFILE=local_safe pytest -q tests/test_responses_api.py` y pasaron (`11 passed`); la suite de Responses API requiere ejecutar con `AGIX_RUNTIME_PROFILE=local_safe` en entornos donde el perfil por defecto es `strict_compatible`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5530e46be883279329ba492bc25398)