### PR TITLE
Refactor: backend de memoria (InMemory, SQLite), TTL, transacciones y redacción de secretos

### DIFF
--- a/gpt_oss/strategic_memory.py
+++ b/gpt_oss/strategic_memory.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import copy
+import pickle
+import re
+import sqlite3
+from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
+from contextlib import contextmanager
 from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Any, Dict, List
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Iterator, List
 
 
 @dataclass
@@ -40,29 +47,263 @@ class MemoryConsolidationResult:
     discarded_signals: List[Dict[str, Any]] = field(default_factory=list)
 
 
+class SecretRedactor:
+    """Redacta secretos antes de almacenar memoria estratégica."""
+
+    REDACTED = "[REDACTED]"
+    SECRET_KEYS = re.compile(r"(api[_-]?key|authorization|bearer|credential(?!s)|password|secret|token)", re.IGNORECASE)
+    SECRET_PATTERNS = (
+        re.compile(r"sk-[A-Za-z0-9_-]{12,}"),
+        re.compile(r"(?i)(api[_-]?key|token|credential(?!s)|password|secret)\s*[:=]\s*[^\s,;]+"),
+        re.compile(r"(?i)bearer\s+[A-Za-z0-9._~+/=-]{12,}"),
+    )
+
+    @classmethod
+    def redact(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            redacted = value
+            for pattern in cls.SECRET_PATTERNS:
+                redacted = pattern.sub(lambda match: cls._redact_match(match), redacted)
+            return redacted
+        if isinstance(value, dict):
+            return {
+                key: cls.REDACTED if cls.SECRET_KEYS.search(str(key)) else cls.redact(item)
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [cls.redact(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(cls.redact(item) for item in value)
+        return value
+
+    @classmethod
+    def _redact_match(cls, match: re.Match[str]) -> str:
+        text = match.group(0)
+        if text.lower().startswith("bearer "):
+            return "Bearer " + cls.REDACTED
+        if ":" in text:
+            return text.split(":", 1)[0] + ": " + cls.REDACTED
+        if "=" in text:
+            return text.split("=", 1)[0] + "=" + cls.REDACTED
+        return cls.REDACTED
+
+
+class MemoryBackend(ABC):
+    """Interfaz de backend para memoria estratégica persistente y transaccional."""
+
+    LEARNING = "learning"
+    AUDIT = "audit"
+    REJECTED = "rejected"
+
+    @abstractmethod
+    def save(self, key: str, value: Any) -> None: ...
+
+    @abstractmethod
+    def get(self, key: str, default: Any | None = None) -> Any: ...
+
+    @abstractmethod
+    def update(self, key: str, value: Any) -> None: ...
+
+    @abstractmethod
+    def append_episode(self, collection: str, episode: Episode) -> None: ...
+
+    @abstractmethod
+    def list_episodes(self, collection: str) -> List[Episode]: ...
+
+    @abstractmethod
+    def persist(self) -> None: ...
+
+    @abstractmethod
+    @contextmanager
+    def transaction(self) -> Iterator[None]: ...
+
+
+class InMemoryMemoryBackend(MemoryBackend):
+    """Backend RAM con límites por colección, TTL opcional y rollback transaccional."""
+
+    def __init__(self, max_episodes: int | None = None, collection_limits: Dict[str, int] | None = None, ttl: timedelta | None = None) -> None:
+        self._storage: Dict[str, tuple[datetime, Any]] = {}
+        self._collections: Dict[str, List[Episode]] = {self.LEARNING: [], self.AUDIT: [], self.REJECTED: []}
+        self._max_episodes = max_episodes
+        self._collection_limits = collection_limits or {}
+        self._ttl = ttl
+
+    def save(self, key: str, value: Any) -> None:
+        self._purge_expired()
+        if key in self._storage:
+            raise ValueError(f"La clave '{key}' ya existe en la memoria.")
+        self._storage[key] = (datetime.utcnow(), SecretRedactor.redact(value))
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        self._purge_expired()
+        return self._storage.get(key, (None, default))[1]
+
+    def update(self, key: str, value: Any) -> None:
+        self._purge_expired()
+        if key not in self._storage:
+            raise KeyError(f"La clave '{key}' no se encuentra en la memoria.")
+        self._storage[key] = (datetime.utcnow(), SecretRedactor.redact(value))
+
+    def append_episode(self, collection: str, episode: Episode) -> None:
+        self._purge_expired()
+        redacted = self._redact_episode(episode)
+        target = self._collections.setdefault(collection, [])
+        limit = self._collection_limits.get(collection, self._max_episodes)
+        if limit is not None:
+            while len(target) >= limit:
+                target.pop(0)
+        target.append(redacted)
+
+    def list_episodes(self, collection: str) -> List[Episode]:
+        self._purge_expired()
+        return list(self._collections.setdefault(collection, []))
+
+    def persist(self) -> None:
+        return None
+
+    @contextmanager
+    def transaction(self) -> Iterator[None]:
+        snapshot = (copy.deepcopy(self._storage), copy.deepcopy(self._collections))
+        try:
+            yield
+        except Exception:
+            self._storage, self._collections = snapshot
+            raise
+
+    def _purge_expired(self) -> None:
+        if self._ttl is None:
+            return
+        cutoff = datetime.utcnow() - self._ttl
+        self._storage = {key: item for key, item in self._storage.items() if item[0] >= cutoff}
+        for name, episodes in self._collections.items():
+            self._collections[name] = [episode for episode in episodes if episode.timestamp >= cutoff]
+
+    @staticmethod
+    def _redact_episode(episode: Episode) -> Episode:
+        clone = copy.deepcopy(episode)
+        clone.input = SecretRedactor.redact(clone.input)
+        clone.action = SecretRedactor.redact(clone.action)
+        clone.outcome = SecretRedactor.redact(clone.outcome)
+        clone.metadata = SecretRedactor.redact(clone.metadata)
+        return clone
+
+
+class SQLiteMemoryBackend(InMemoryMemoryBackend):
+    """Backend SQLite persistente compatible con la interfaz de memoria."""
+
+    def __init__(self, path: str | Path, max_episodes: int | None = None, collection_limits: Dict[str, int] | None = None, ttl: timedelta | None = None) -> None:
+        self.path = Path(path)
+        self._conn = sqlite3.connect(self.path)
+        self._transaction_depth = 0
+        self._conn.execute("CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, created_at TEXT NOT NULL, value BLOB NOT NULL)")
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS episodes (id INTEGER PRIMARY KEY AUTOINCREMENT, collection TEXT NOT NULL, timestamp TEXT NOT NULL, episode BLOB NOT NULL)"
+        )
+        self._conn.commit()
+        self._max_episodes = max_episodes
+        self._collection_limits = collection_limits or {}
+        self._ttl = ttl
+
+    def save(self, key: str, value: Any) -> None:
+        self._purge_expired()
+        try:
+            self._conn.execute(
+                "INSERT INTO kv(key, created_at, value) VALUES (?, ?, ?)",
+                (key, datetime.utcnow().isoformat(), sqlite3.Binary(pickle.dumps(SecretRedactor.redact(value)))),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise ValueError(f"La clave '{key}' ya existe en la memoria.") from exc
+        self.persist()
+
+    def get(self, key: str, default: Any | None = None) -> Any:
+        self._purge_expired()
+        row = self._conn.execute("SELECT value FROM kv WHERE key = ?", (key,)).fetchone()
+        return default if row is None else pickle.loads(row[0])
+
+    def update(self, key: str, value: Any) -> None:
+        self._purge_expired()
+        cur = self._conn.execute(
+            "UPDATE kv SET created_at = ?, value = ? WHERE key = ?",
+            (datetime.utcnow().isoformat(), sqlite3.Binary(pickle.dumps(SecretRedactor.redact(value))), key),
+        )
+        if cur.rowcount == 0:
+            raise KeyError(f"La clave '{key}' no se encuentra en la memoria.")
+        self.persist()
+
+    def append_episode(self, collection: str, episode: Episode) -> None:
+        self._purge_expired()
+        redacted = self._redact_episode(episode)
+        self._conn.execute(
+            "INSERT INTO episodes(collection, timestamp, episode) VALUES (?, ?, ?)",
+            (collection, redacted.timestamp.isoformat(), sqlite3.Binary(pickle.dumps(redacted))),
+        )
+        limit = self._collection_limits.get(collection, self._max_episodes)
+        if limit is not None:
+            self._conn.execute(
+                "DELETE FROM episodes WHERE id IN (SELECT id FROM episodes WHERE collection = ? ORDER BY id ASC LIMIT max((SELECT COUNT(*) FROM episodes WHERE collection = ?) - ?, 0))",
+                (collection, collection, limit),
+            )
+        self.persist()
+
+    def list_episodes(self, collection: str) -> List[Episode]:
+        self._purge_expired()
+        rows = self._conn.execute("SELECT episode FROM episodes WHERE collection = ? ORDER BY id ASC", (collection,)).fetchall()
+        return [pickle.loads(row[0]) for row in rows]
+
+    def persist(self) -> None:
+        if self._transaction_depth == 0:
+            self._conn.commit()
+
+    @contextmanager
+    def transaction(self) -> Iterator[None]:
+        self._transaction_depth += 1
+        if self._transaction_depth == 1:
+            self._conn.execute("BEGIN")
+        try:
+            yield
+        except Exception:
+            self._transaction_depth -= 1
+            if self._transaction_depth == 0:
+                self._conn.rollback()
+            raise
+        else:
+            self._transaction_depth -= 1
+            if self._transaction_depth == 0:
+                self._conn.commit()
+
+    def _purge_expired(self) -> None:
+        if self._ttl is None:
+            return
+        cutoff = (datetime.utcnow() - self._ttl).isoformat()
+        self._conn.execute("DELETE FROM kv WHERE created_at < ?", (cutoff,))
+        self._conn.execute("DELETE FROM episodes WHERE timestamp < ?", (cutoff,))
+        self.persist()
+
+    def close(self) -> None:
+        self._conn.close()
+
+
 class StrategicMemory:
     """Almacena memoria estratégica, auditoría y aprendizaje inferencial seguro."""
 
-    def __init__(self, max_episodes: int | None = None) -> None:
-        self._storage: Dict[str, Any] = {}
-        self._episodes: List[Episode] = []
-        self._audit_episodes: List[Episode] = []
-        self._rejected_learning: List[Episode] = []
+    def __init__(self, max_episodes: int | None = None, backend: MemoryBackend | None = None, ttl: timedelta | None = None) -> None:
+        self._backend = backend or InMemoryMemoryBackend(max_episodes=max_episodes, ttl=ttl)
         self._hypotheses: List[InferenceHypothesis] = []
-        self._max_episodes = max_episodes
 
     def save(self, key: str, value: Any) -> None:
-        if key in self._storage:
-            raise ValueError(f"La clave '{key}' ya existe en la memoria.")
-        self._storage[key] = value
+        self._backend.save(key, value)
 
     def get(self, key: str, default: Any | None = None) -> Any:
-        return self._storage.get(key, default)
+        return self._backend.get(key, default)
 
     def update(self, key: str, value: Any) -> None:
-        if key not in self._storage:
-            raise KeyError(f"La clave '{key}' no se encuentra en la memoria.")
-        self._storage[key] = value
+        self._backend.update(key, value)
+
+    def persist(self) -> None:
+        self._backend.persist()
+
+    def transaction(self) -> Iterator[None]:
+        return self._backend.transaction()
 
     def add_episode(self, data: Episode) -> None:
         """Añade un episodio utilizable solo si no fue bloqueado por Qualia."""
@@ -70,28 +311,28 @@ class StrategicMemory:
         if self._is_blocked_or_rejected(data):
             self.add_rejected_learning(data, reason="blocked_or_rejected_by_qualia")
             return
-        self._append_bounded(self._episodes, data)
+        self._backend.append_episode(MemoryBackend.LEARNING, data)
 
     def add_audit_episode(self, data: Episode) -> None:
         """Registra trazabilidad sin alimentar aprendizaje inferencial."""
 
-        self._audit_episodes.append(data)
+        self._backend.append_episode(MemoryBackend.AUDIT, data)
 
     def add_rejected_learning(self, data: Episode, reason: str) -> None:
         """Registra una señal que no debe consolidarse como conocimiento."""
 
         data.metadata = {**data.metadata, "rejection_reason": reason, "status": data.metadata.get("status", "rejected_learning")}
-        self._rejected_learning.append(data)
-        self._audit_episodes.append(data)
+        self._backend.append_episode(MemoryBackend.REJECTED, data)
+        self._backend.append_episode(MemoryBackend.AUDIT, data)
 
     def query(self, pattern: Dict[str, Any]) -> List[Episode]:
-        return self._query_collection(self._episodes, pattern)
+        return self._query_collection(self._backend.list_episodes(MemoryBackend.LEARNING), pattern)
 
     def query_audit(self, pattern: Dict[str, Any]) -> List[Episode]:
-        return self._query_collection(self._audit_episodes, pattern)
+        return self._query_collection(self._backend.list_episodes(MemoryBackend.AUDIT), pattern)
 
     def query_rejected(self, pattern: Dict[str, Any]) -> List[Episode]:
-        return self._query_collection(self._rejected_learning, pattern)
+        return self._query_collection(self._backend.list_episodes(MemoryBackend.REJECTED), pattern)
 
     def infer_patterns(self, criteria: Dict[str, Any] | None = None) -> List[InferenceHypothesis]:
         if criteria:
@@ -103,7 +344,7 @@ class StrategicMemory:
     def consolidate_from_episodes(self, min_support: int = 2, max_hypotheses: int = 20) -> MemoryConsolidationResult:
         groups: dict[tuple[Any, Any, Any], list[Episode]] = defaultdict(list)
         discarded: list[dict[str, Any]] = []
-        for episode in self._episodes:
+        for episode in self._backend.list_episodes(MemoryBackend.LEARNING):
             if self._is_blocked_or_rejected(episode):
                 discarded.append({"reason": "blocked_or_rejected", "episode": episode})
                 continue
@@ -147,29 +388,20 @@ class StrategicMemory:
         )
 
     def query_inferred(self, pattern: Dict[str, Any]) -> List[InferenceHypothesis]:
-        results: list[InferenceHypothesis] = []
-        for hypothesis in self._hypotheses:
-            if all(hypothesis.pattern.get(key) == value for key, value in pattern.items()):
-                results.append(hypothesis)
-        return results
+        return [hypothesis for hypothesis in self._hypotheses if all(hypothesis.pattern.get(key) == value for key, value in pattern.items())]
 
     def summarize(self) -> Dict[str, Any]:
-        acciones = Counter(ep.action for ep in self._episodes)
-        resultados = Counter(ep.outcome for ep in self._episodes)
+        episodes = self._backend.list_episodes(MemoryBackend.LEARNING)
+        acciones = Counter(ep.action for ep in episodes)
+        resultados = Counter(ep.outcome for ep in episodes)
         return {
-            "total": len(self._episodes),
-            "audit_total": len(self._audit_episodes),
-            "rejected_total": len(self._rejected_learning),
+            "total": len(episodes),
+            "audit_total": len(self._backend.list_episodes(MemoryBackend.AUDIT)),
+            "rejected_total": len(self._backend.list_episodes(MemoryBackend.REJECTED)),
             "hypotheses_total": len(self._hypotheses),
             "actions": acciones.most_common(),
             "outcomes": resultados.most_common(),
         }
-
-    def _append_bounded(self, collection: List[Episode], data: Episode) -> None:
-        if self._max_episodes is not None:
-            while len(collection) >= self._max_episodes:
-                collection.pop(0)
-        collection.append(data)
 
     @staticmethod
     def _query_collection(collection: List[Episode], pattern: Dict[str, Any]) -> List[Episode]:

--- a/tests/test_strategic_memory.py
+++ b/tests/test_strategic_memory.py
@@ -168,3 +168,120 @@ def test_consolidate_from_safe_episodes_creates_inferred_hypothesis():
     assert inferred
     assert inferred[0].confidence == 1.0
     assert inferred[0].pattern["recommended_action"] == "expert_a"
+
+from datetime import timedelta
+
+from gpt_oss.strategic_memory import InMemoryMemoryBackend, MemoryBackend, SQLiteMemoryBackend
+
+
+def test_ram_backend_with_collection_limits():
+    backend = InMemoryMemoryBackend(collection_limits={MemoryBackend.LEARNING: 1, MemoryBackend.AUDIT: 2})
+    memoria = StrategicMemory(backend=backend)
+    ep1 = Episode(datetime.utcnow(), "i1", "a1", "o1")
+    ep2 = Episode(datetime.utcnow(), "i2", "a2", "o2")
+
+    memoria.add_episode(ep1)
+    memoria.add_episode(ep2)
+    memoria.add_audit_episode(ep1)
+    memoria.add_audit_episode(ep2)
+
+    assert memoria.query({}) == [ep2]
+    assert memoria.query_audit({}) == [ep1, ep2]
+
+
+def test_sqlite_backend_persists_with_temp_file(tmp_path):
+    db_path = tmp_path / "memory.sqlite"
+    memoria = StrategicMemory(backend=SQLiteMemoryBackend(db_path))
+    ep = Episode(datetime.utcnow(), "hola", "saludo", "ok", {"tema": "sqlite"})
+
+    memoria.save("plan", {"step": 1})
+    memoria.add_episode(ep)
+    memoria.persist()
+
+    reloaded = StrategicMemory(backend=SQLiteMemoryBackend(db_path))
+    assert reloaded.get("plan") == {"step": 1}
+    assert reloaded.query({"tema": "sqlite"})[0].action == "saludo"
+
+
+def test_ttl_expiration_removes_old_episodes_and_keys():
+    old = datetime.utcnow() - timedelta(seconds=60)
+    memoria = StrategicMemory(backend=InMemoryMemoryBackend(ttl=timedelta(seconds=1)))
+    memoria.save("token_info", "visible")
+    memoria.add_episode(Episode(old, "old", "expired", "no"))
+
+    assert memoria.query({"action": "expired"}) == []
+
+
+def test_transaction_rollback_discards_changes():
+    memoria = StrategicMemory(backend=InMemoryMemoryBackend())
+
+    with pytest.raises(RuntimeError):
+        with memoria.transaction():
+            memoria.save("plan", "temporal")
+            memoria.add_episode(Episode(datetime.utcnow(), "i", "a", "o"))
+            raise RuntimeError("rollback")
+
+    assert memoria.get("plan") is None
+    assert memoria.query({}) == []
+
+
+def test_sqlite_transaction_rollback_discards_changes(tmp_path):
+    memoria = StrategicMemory(backend=SQLiteMemoryBackend(tmp_path / "tx.sqlite"))
+
+    with pytest.raises(RuntimeError):
+        with memoria.transaction():
+            memoria.save("plan", "temporal")
+            memoria.add_episode(Episode(datetime.utcnow(), "i", "a", "o"))
+            raise RuntimeError("rollback")
+
+    assert memoria.get("plan") is None
+    assert memoria.query({}) == []
+
+
+def test_secret_redaction_in_prompts_tokens_credentials_and_api_keys():
+    memoria = StrategicMemory()
+    memoria.save(
+        "secrets",
+        {
+            "prompt": "usa token=tok_123456789012345 y api_key: abcdefghijklmnop",
+            "credentials": {"password": "super-secret", "nested": "Bearer abcdefghijklmnop"},
+            "openai_api_key": "sk-abcdefghijklmnop123456",
+        },
+    )
+    memoria.add_episode(
+        Episode(
+            datetime.utcnow(),
+            "prompt con sk-abcdefghijklmnop123456",
+            "call",
+            {"credential": "abcdef"},
+            {"api_key": "secret", "token_hint": "Bearer abcdefghijklmnop"},
+        )
+    )
+
+    stored = memoria.get("secrets")
+    episode = memoria.query({"action": "call"})[0]
+
+    assert "tok_123456789012345" not in str(stored)
+    assert "abcdefghijklmnop" not in str(stored)
+    assert stored["credentials"]["password"] == "[REDACTED]"
+    assert stored["openai_api_key"] == "[REDACTED]"
+    assert "sk-abcdefghijklmnop123456" not in episode.input
+    assert episode.outcome["credential"] == "[REDACTED]"
+    assert episode.metadata["api_key"] == "[REDACTED]"
+
+
+def test_learning_audit_and_rejected_collections_remain_separated():
+    memoria = StrategicMemory()
+    learned = Episode(datetime.utcnow(), "learn", "learn_action", "ok", {"kind": "learned"})
+    audit = Episode(datetime.utcnow(), "audit", "audit_action", "ok", {"kind": "audit"})
+    rejected = Episode(datetime.utcnow(), "reject", "reject_action", {"blocked": True}, {"kind": "rejected"})
+
+    memoria.add_episode(learned)
+    memoria.add_audit_episode(audit)
+    memoria.add_episode(rejected)
+
+    assert memoria.query({"kind": "learned"}) == [learned]
+    assert memoria.query({"kind": "audit"}) == []
+    assert memoria.query({"kind": "rejected"}) == []
+    assert [ep.metadata["kind"] for ep in memoria.query_audit({})] == ["audit", "rejected"]
+    assert memoria.query_rejected({})[0].metadata["kind"] == "rejected"


### PR DESCRIPTION
### Motivation
- Modernizar el almacenamiento de memoria estratégica separando responsabilidades entre una interfaz de backend y múltiples implementaciones persistentes para soportar persistencia, límites y transacciones.
- Añadir redacción automática de secretos y TTL para evitar fugas de credenciales y permitir vencimiento de datos.
- Garantizar separación persistente entre episodios para aprendizaje, auditoría y señales rechazadas.
- Proveer tests que cubran los nuevos comportamientos (RAM, SQLite, TTL, transacciones, redacción y separación de colecciones).

### Description
- Se introdujo la interfaz `MemoryBackend` con colecciones `LEARNING`, `AUDIT` y `REJECTED` y métodos `save`, `get`, `update`, `append_episode`, `list_episodes`, `persist` y `transaction`.
- Se añadió `InMemoryMemoryBackend` que implementa límites por colección, TTL opcional, snapshots para rollback transaccional y redacción previa (`SecretRedactor`) de valores y episodios.
- Se añadió `SQLiteMemoryBackend` que persiste pares clave/valor y episodios serializados en SQLite, soporta límites por colección, TTL, commits controlados y rollback anidado mediante contador de profundidad transaccional.
- Se creó `SecretRedactor` para redacción de `api_key`, `token`, `Bearer`, `sk-` claves, `password`, `credential` y patrones similares antes de almacenar valores o episodios.
- `StrategicMemory` delega en el backend elegido, expone `persist()` y `transaction()` y mantiene la consolidación inferencial sólo desde la colección `LEARNING`, mientras que `AUDIT` y `REJECTED` permanecen separados y persistentes.
- Se agregaron tests en `tests/test_strategic_memory.py` que cubren backend RAM con límites, backend SQLite con archivo temporal, expiración TTL, rollback de transacción (RAM y SQLite), redacción de secretos en prompts/tokens/credenciales/API keys y la separación entre episodios aprendibles, auditoría y rechazos.

### Testing
- Se compiló el código modificado con `python -m py_compile gpt_oss/strategic_memory.py tests/test_strategic_memory.py` y pasó sin errores.
- Se ejecutó `pytest -q tests/test_strategic_memory.py` y los tests añadidos y existentes para este módulo pasaron (`17 passed`).
- Al ejecutar la suite completa `pytest -q` la colección se interrumpió por dependencias de entorno ausentes (módulos opcionales `tiktoken`, `docker`), por lo que la ejecución completa de todos los tests del repositorio no se completó en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55c514838083279dafdc462baae5b5)