### PR TITLE
Update packaging metadata for AGI community fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 <br>
 
+> **Aviso sobre este fork:** `gpt-oss-agi` es un fork comunitario experimental y **no oficial** de OpenAI. No modifica ni redistribuye pesos de los modelos `gpt-oss`, no demuestra ni afirma alcanzar AGI, e integra una capa experimental de gobierno AGIX/Qualia para evaluación, planificación y control de seguridad. El nombre de distribución Python cambia a `gpt-oss-agi`, pero los imports públicos se mantienen como `gpt_oss` y `agicore_core`.
+
 Bienvenido a la serie gpt-oss, [los modelos de pesos abiertos de OpenAI](https://openai.com/open-models/) diseñados para un razonamiento potente, tareas agénticas y una amplia variedad de casos de uso para desarrolladores.
 
 Estamos liberando dos variantes de estos modelos abiertos:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "gpt-oss"
-description = "A collection of reference inference implementations for gpt-oss by OpenAI"
+name = "gpt-oss-agi"
+description = "Experimental unofficial community fork of gpt-oss with AGIX/Qualia governance integrations"
 
 dependencies = [
   "openai-harmony",
@@ -22,6 +22,21 @@ dependencies = [
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
 version = "0.0.1"
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+[project.urls]
+Homepage = "https://github.com/inteligencIA-AGI/gpt-oss-AGI"
+Repository = "https://github.com/inteligencIA-AGI/gpt-oss-AGI"
+Documentation = "https://github.com/inteligencIA-AGI/gpt-oss-AGI#readme"
+Issues = "https://github.com/inteligencIA-AGI/gpt-oss-AGI/issues"
+"OpenAI gpt-oss upstream" = "https://github.com/openai/gpt-oss"
 
 [project.optional-dependencies]
 triton = ["triton", "safetensors>=0.5.3", "torch>=2.7.0"]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,0 +1,21 @@
+import importlib
+import pathlib
+import tomllib
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_distribution_name_and_package_discovery_metadata():
+    metadata = tomllib.loads((ROOT / "pyproject.toml").read_text())
+
+    assert metadata["project"]["name"] == "gpt-oss-agi"
+    assert metadata["tool"]["setuptools"]["packages"]["find"]["include"] == [
+        "gpt_oss*",
+        "agicore_core*",
+    ]
+
+
+def test_public_import_packages_remain_importable():
+    assert importlib.import_module("gpt_oss").__name__ == "gpt_oss"
+    assert importlib.import_module("agicore_core").__name__ == "agicore_core"


### PR DESCRIPTION
### Motivation
- Renombrar la distribución Python a `gpt-oss-agi` y dejar claro que es un fork comunitario experimental no oficial con integraciones de gobierno AGIX/Qualia. 
- Mantener la estructura de paquetes pública para que los imports existentes `gpt_oss` y `agicore_core` sigan funcionando. 
- Añadir metadatos PyPI útiles (`classifiers`, `project.urls`) para mejorar visibilidad y procedencia del fork. 
- Añadir una comprobación automática que valide la metadata de empaquetado y la importabilidad pública.

### Description
- Cambiado `[project].name` a `gpt-oss-agi` y actualizado `[project].description` en `pyproject.toml`. 
- Añadidos `classifiers` y la sección `[project.urls]` en `pyproject.toml` y preservado `include = ["gpt_oss*", "agicore_core*"]` bajo `tool.setuptools.packages.find`. 
- Insertado en `README.md` un aviso explícito que declara: no es oficial de OpenAI, no modifica pesos, no afirma AGI, que integra AGIX/Qualia y que los imports públicos permanecen `gpt_oss`/`agicore_core`. 
- Añadido el test `tests/test_packaging_metadata.py` que valida `pyproject.toml` (`project.name` y patrones de paquetes) y que los paquetes públicos importables siguen disponibles.

### Testing
- Ejecutado `python -m pip install -e '.[test]'` contra el entorno del repositorio y la instalación completó correctamente aunque `pip` reportó un conflicto ambiental entre `sse-starlette` y la versión instalada de `starlette` (advertencia de entorno). 
- Ejecutado `pytest -q tests/test_packaging_metadata.py` y los tests automatizados pasaron: `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55c6725844832791f251213df64460)