### PR TITLE
Use timezone-aware UTC datetimes

### DIFF
--- a/agicore_core/reasoning_kernel.py
+++ b/agicore_core/reasoning_kernel.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterator, List
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 import ast
 import operator as op
 import logging
@@ -266,7 +266,7 @@ class ReasoningKernel:
             )
             self._record_memory_episode(
                 Episode(
-                    timestamp=datetime.utcnow(),
+                    timestamp=datetime.now(timezone.utc),
                     input=step,
                     action="blocked_by_qualia",
                     outcome=result,
@@ -299,7 +299,7 @@ class ReasoningKernel:
 
         if self.memory is not None:
             episodio = Episode(
-                timestamp=datetime.utcnow(),
+                timestamp=datetime.now(timezone.utc),
                 input=step,
                 action="step",
                 outcome=result,
@@ -373,7 +373,7 @@ class ReasoningKernel:
                 self.qualia_engine.after_decision(blocked, self._state, phase="token")
                 self._record_memory_episode(
                     Episode(
-                        timestamp=datetime.utcnow(),
+                        timestamp=datetime.now(timezone.utc),
                         input=token,
                         action="blocked_by_qualia",
                         outcome=blocked,
@@ -387,7 +387,7 @@ class ReasoningKernel:
                 break
             if self.memory is not None:
                 episodio = Episode(
-                    timestamp=datetime.utcnow(),
+                    timestamp=datetime.now(timezone.utc),
                     input=token,
                     action="token",
                     outcome=siguiente,

--- a/agicore_core/training_bridge.py
+++ b/agicore_core/training_bridge.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Mapping
 
 from gpt_oss.strategic_memory import Episode
@@ -89,7 +89,7 @@ class QualiaTrainingBridge:
     def to_memory_episode(feedback: TrainingFeedback) -> Episode:
         signal = (feedback.accepted_signals or feedback.rejected_signals)[0]
         return Episode(
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             input=signal.sample,
             action="training_signal",
             outcome=feedback.reason,

--- a/gpt_oss/strategic_memory.py
+++ b/gpt_oss/strategic_memory.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterator, List
 
@@ -34,7 +34,7 @@ class InferenceHypothesis:
     evidence: List[Episode]
     confidence: float
     ethical_constraints: List[str] = field(default_factory=list)
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 @dataclass
@@ -132,7 +132,7 @@ class InMemoryMemoryBackend(MemoryBackend):
         self._purge_expired()
         if key in self._storage:
             raise ValueError(f"La clave '{key}' ya existe en la memoria.")
-        self._storage[key] = (datetime.utcnow(), SecretRedactor.redact(value))
+        self._storage[key] = (datetime.now(timezone.utc), SecretRedactor.redact(value))
 
     def get(self, key: str, default: Any | None = None) -> Any:
         self._purge_expired()
@@ -142,7 +142,7 @@ class InMemoryMemoryBackend(MemoryBackend):
         self._purge_expired()
         if key not in self._storage:
             raise KeyError(f"La clave '{key}' no se encuentra en la memoria.")
-        self._storage[key] = (datetime.utcnow(), SecretRedactor.redact(value))
+        self._storage[key] = (datetime.now(timezone.utc), SecretRedactor.redact(value))
 
     def append_episode(self, collection: str, episode: Episode) -> None:
         self._purge_expired()
@@ -173,7 +173,7 @@ class InMemoryMemoryBackend(MemoryBackend):
     def _purge_expired(self) -> None:
         if self._ttl is None:
             return
-        cutoff = datetime.utcnow() - self._ttl
+        cutoff = datetime.now(timezone.utc) - self._ttl
         self._storage = {key: item for key, item in self._storage.items() if item[0] >= cutoff}
         for name, episodes in self._collections.items():
             self._collections[name] = [episode for episode in episodes if episode.timestamp >= cutoff]
@@ -209,7 +209,7 @@ class SQLiteMemoryBackend(InMemoryMemoryBackend):
         try:
             self._conn.execute(
                 "INSERT INTO kv(key, created_at, value) VALUES (?, ?, ?)",
-                (key, datetime.utcnow().isoformat(), sqlite3.Binary(pickle.dumps(SecretRedactor.redact(value)))),
+                (key, datetime.now(timezone.utc).isoformat(), sqlite3.Binary(pickle.dumps(SecretRedactor.redact(value)))),
             )
         except sqlite3.IntegrityError as exc:
             raise ValueError(f"La clave '{key}' ya existe en la memoria.") from exc
@@ -224,7 +224,7 @@ class SQLiteMemoryBackend(InMemoryMemoryBackend):
         self._purge_expired()
         cur = self._conn.execute(
             "UPDATE kv SET created_at = ?, value = ? WHERE key = ?",
-            (datetime.utcnow().isoformat(), sqlite3.Binary(pickle.dumps(SecretRedactor.redact(value))), key),
+            (datetime.now(timezone.utc).isoformat(), sqlite3.Binary(pickle.dumps(SecretRedactor.redact(value))), key),
         )
         if cur.rowcount == 0:
             raise KeyError(f"La clave '{key}' no se encuentra en la memoria.")
@@ -274,7 +274,7 @@ class SQLiteMemoryBackend(InMemoryMemoryBackend):
     def _purge_expired(self) -> None:
         if self._ttl is None:
             return
-        cutoff = (datetime.utcnow() - self._ttl).isoformat()
+        cutoff = (datetime.now(timezone.utc) - self._ttl).isoformat()
         self._conn.execute("DELETE FROM kv WHERE created_at < ?", (cutoff,))
         self._conn.execute("DELETE FROM episodes WHERE timestamp < ?", (cutoff,))
         self.persist()

--- a/tests/test_reasoning_kernel_memory_integration.py
+++ b/tests/test_reasoning_kernel_memory_integration.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from agicore_core.reasoning_kernel import ReasoningKernel
 from gpt_oss.strategic_memory import Episode, StrategicMemory
@@ -16,7 +16,7 @@ def test_token_cycle_uses_memory_and_records_episode():
     memory = StrategicMemory()
     memory.add_episode(
         Episode(
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             input="",  # contenido irrelevante
             action="token",
             outcome="",
@@ -38,7 +38,7 @@ def test_token_cycle_filters_disallowed_keys():
     memory = StrategicMemory()
     memory.add_episode(
         Episode(
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             input="",
             action="token",
             outcome="",
@@ -69,7 +69,7 @@ def test_token_cycle_restores_allowed_qualia_metadata():
     memory = StrategicMemory()
     memory.add_episode(
         Episode(
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             input="",
             action="token",
             outcome="",

--- a/tests/test_strategic_memory.py
+++ b/tests/test_strategic_memory.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from gpt_oss.strategic_memory import Episode, StrategicMemory
 
@@ -34,7 +34,7 @@ def test_update_missing_key_raises():
 def test_add_and_query_episode():
     memoria = StrategicMemory()
     ep = Episode(
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
         input="hola",
         action="saludo",
         outcome="ok",
@@ -49,7 +49,7 @@ def test_summarize_episodes():
     memoria = StrategicMemory()
     memoria.add_episode(
         Episode(
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             input="uno",
             action="a",
             outcome="exito",
@@ -57,7 +57,7 @@ def test_summarize_episodes():
     )
     memoria.add_episode(
         Episode(
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             input="dos",
             action="a",
             outcome="fracaso",
@@ -71,14 +71,14 @@ def test_summarize_episodes():
 def test_add_episode_query_and_summarize_multiple():
     memoria = StrategicMemory()
     ep1 = Episode(
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
         input="i1",
         action="alpha",
         outcome="ok",
         metadata={"tag": 1},
     )
     ep2 = Episode(
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
         input="i2",
         action="beta",
         outcome="fail",
@@ -99,19 +99,19 @@ def test_add_episode_query_and_summarize_multiple():
 def test_max_episodes_fifo():
     memoria = StrategicMemory(max_episodes=2)
     ep1 = Episode(
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
         input="i1",
         action="a1",
         outcome="o1",
     )
     ep2 = Episode(
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
         input="i2",
         action="a2",
         outcome="o2",
     )
     ep3 = Episode(
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
         input="i3",
         action="a3",
         outcome="o3",
@@ -129,7 +129,7 @@ def test_max_episodes_fifo():
 def test_blocked_episode_goes_to_audit_and_rejected_memory():
     memoria = StrategicMemory()
     ep = Episode(
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
         input="bad",
         action="blocked_by_qualia",
         outcome={"blocked": True},
@@ -148,7 +148,7 @@ def test_consolidate_from_safe_episodes_creates_inferred_hypothesis():
     for idx in range(2):
         memoria.add_episode(
             Episode(
-                timestamp=datetime.utcnow(),
+                timestamp=datetime.now(timezone.utc),
                 input=f"i{idx}",
                 action="expert_a",
                 outcome="ok",
@@ -177,8 +177,8 @@ from gpt_oss.strategic_memory import InMemoryMemoryBackend, MemoryBackend, SQLit
 def test_ram_backend_with_collection_limits():
     backend = InMemoryMemoryBackend(collection_limits={MemoryBackend.LEARNING: 1, MemoryBackend.AUDIT: 2})
     memoria = StrategicMemory(backend=backend)
-    ep1 = Episode(datetime.utcnow(), "i1", "a1", "o1")
-    ep2 = Episode(datetime.utcnow(), "i2", "a2", "o2")
+    ep1 = Episode(datetime.now(timezone.utc), "i1", "a1", "o1")
+    ep2 = Episode(datetime.now(timezone.utc), "i2", "a2", "o2")
 
     memoria.add_episode(ep1)
     memoria.add_episode(ep2)
@@ -192,7 +192,7 @@ def test_ram_backend_with_collection_limits():
 def test_sqlite_backend_persists_with_temp_file(tmp_path):
     db_path = tmp_path / "memory.sqlite"
     memoria = StrategicMemory(backend=SQLiteMemoryBackend(db_path))
-    ep = Episode(datetime.utcnow(), "hola", "saludo", "ok", {"tema": "sqlite"})
+    ep = Episode(datetime.now(timezone.utc), "hola", "saludo", "ok", {"tema": "sqlite"})
 
     memoria.save("plan", {"step": 1})
     memoria.add_episode(ep)
@@ -204,7 +204,7 @@ def test_sqlite_backend_persists_with_temp_file(tmp_path):
 
 
 def test_ttl_expiration_removes_old_episodes_and_keys():
-    old = datetime.utcnow() - timedelta(seconds=60)
+    old = datetime.now(timezone.utc) - timedelta(seconds=60)
     memoria = StrategicMemory(backend=InMemoryMemoryBackend(ttl=timedelta(seconds=1)))
     memoria.save("token_info", "visible")
     memoria.add_episode(Episode(old, "old", "expired", "no"))
@@ -218,7 +218,7 @@ def test_transaction_rollback_discards_changes():
     with pytest.raises(RuntimeError):
         with memoria.transaction():
             memoria.save("plan", "temporal")
-            memoria.add_episode(Episode(datetime.utcnow(), "i", "a", "o"))
+            memoria.add_episode(Episode(datetime.now(timezone.utc), "i", "a", "o"))
             raise RuntimeError("rollback")
 
     assert memoria.get("plan") is None
@@ -231,7 +231,7 @@ def test_sqlite_transaction_rollback_discards_changes(tmp_path):
     with pytest.raises(RuntimeError):
         with memoria.transaction():
             memoria.save("plan", "temporal")
-            memoria.add_episode(Episode(datetime.utcnow(), "i", "a", "o"))
+            memoria.add_episode(Episode(datetime.now(timezone.utc), "i", "a", "o"))
             raise RuntimeError("rollback")
 
     assert memoria.get("plan") is None
@@ -250,7 +250,7 @@ def test_secret_redaction_in_prompts_tokens_credentials_and_api_keys():
     )
     memoria.add_episode(
         Episode(
-            datetime.utcnow(),
+            datetime.now(timezone.utc),
             "prompt con sk-abcdefghijklmnop123456",
             "call",
             {"credential": "abcdef"},
@@ -272,9 +272,9 @@ def test_secret_redaction_in_prompts_tokens_credentials_and_api_keys():
 
 def test_learning_audit_and_rejected_collections_remain_separated():
     memoria = StrategicMemory()
-    learned = Episode(datetime.utcnow(), "learn", "learn_action", "ok", {"kind": "learned"})
-    audit = Episode(datetime.utcnow(), "audit", "audit_action", "ok", {"kind": "audit"})
-    rejected = Episode(datetime.utcnow(), "reject", "reject_action", {"blocked": True}, {"kind": "rejected"})
+    learned = Episode(datetime.now(timezone.utc), "learn", "learn_action", "ok", {"kind": "learned"})
+    audit = Episode(datetime.now(timezone.utc), "audit", "audit_action", "ok", {"kind": "audit"})
+    rejected = Episode(datetime.now(timezone.utc), "reject", "reject_action", {"blocked": True}, {"kind": "rejected"})
 
     memoria.add_episode(learned)
     memoria.add_audit_episode(audit)


### PR DESCRIPTION
### Motivation
- Evitar datetimes "naive" y garantizar timestamps en UTC con información de zona horaria al almacenar y comparar episodios y metadatos.
- Alinear creación y persistencia de timestamps en memoria RAM y SQLite con datetimes timezone-aware para evitar errores en comparaciones y TTL.

### Description
- Reemplacé `datetime.utcnow()` por `datetime.now(timezone.utc)` e importé `timezone` en `gpt_oss/strategic_memory.py`, `agicore_core/training_bridge.py` y `agicore_core/reasoning_kernel.py`.
- Actualicé el `default_factory` de `InferenceHypothesis.created_at` para usar `lambda: datetime.now(timezone.utc)` y así producir datetimes aware al instanciar.
- Ajusté las escrituras a SQLite para almacenar `created_at` y `timestamp` usando `isoformat()` de datetimes timezone-aware, y adapté el cálculo de `cutoff` para TTL con datetimes aware.
- Actualicé tests que creaban episodios con `datetime.utcnow()` para usar `datetime.now(timezone.utc)` en `tests/test_strategic_memory.py` y `tests/test_reasoning_kernel_memory_integration.py`.

### Testing
- Ejecuté `pytest tests/test_strategic_memory.py` y todos los tests unitarios de ese archivo pasaron (17 passed).
- Ejecuté `pytest tests/test_strategic_memory.py tests/test_reasoning_kernel_memory_integration.py`; `tests/test_strategic_memory.py` pasó y `tests/test_reasoning_kernel_memory_integration.py` falló en 4 pruebas debido a una excepción de compatibilidad AGIX/Qualia (`AgixStrictCompatibilityError`) provocada por componentes de runtime ausentes antes de llegar a las aserciones de timestamps.
- Compilé los módulos modificados con `python -m compileall -q gpt_oss/strategic_memory.py agicore_core/training_bridge.py agicore_core/reasoning_kernel.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55d47546908327a9b69aa2825d0d66)