### PR TITLE
Agregar errores de dominio y logging estructurado seguro

### DIFF
--- a/agicore_core/__init__.py
+++ b/agicore_core/__init__.py
@@ -9,6 +9,13 @@ from .safety_gate import SafetyGate
 from .training_bridge import QualiaTrainingBridge, TrainingSignal, TrainingFeedback
 from .neuro_symbolic_bridge import CoreNeuroSymbolicBridge
 from .config import AGIX_REQUIRED_VERSION
+from .domain_errors import (
+    DomainError,
+    HarmonyParseError,
+    ToolCallValidationError,
+    QualiaPolicyError,
+    UnsafeOutputBlocked,
+)
 
 __all__ = [
     "Planner",
@@ -22,4 +29,9 @@ __all__ = [
     "TrainingFeedback",
     "CoreNeuroSymbolicBridge",
     "AGIX_REQUIRED_VERSION",
+    "DomainError",
+    "HarmonyParseError",
+    "ToolCallValidationError",
+    "QualiaPolicyError",
+    "UnsafeOutputBlocked",
 ]

--- a/agicore_core/domain_errors.py
+++ b/agicore_core/domain_errors.py
@@ -1,0 +1,47 @@
+"""Errores de dominio para rutas Responses y gobierno Qualia."""
+
+from __future__ import annotations
+
+
+class DomainError(RuntimeError):
+    """Base para errores controlados sin exponer datos sensibles."""
+
+    code = "domain_error"
+    safe_message = "Error controlado del dominio."
+    status_code = 400
+
+    def __init__(self, message: str | None = None, *, detail: str | None = None) -> None:
+        super().__init__(message or self.safe_message)
+        self.detail = detail
+
+
+class HarmonyParseError(DomainError):
+    """Fallo controlado al parsear o renderizar mensajes Harmony."""
+
+    code = "harmony_parse_error"
+    safe_message = "No se pudo procesar la conversación Harmony de forma segura."
+    status_code = 400
+
+
+class ToolCallValidationError(DomainError):
+    """Fallo controlado al validar una llamada de herramienta."""
+
+    code = "tool_call_validation_error"
+    safe_message = "La llamada de herramienta no supera la validación de seguridad."
+    status_code = 400
+
+
+class QualiaPolicyError(DomainError):
+    """Fallo crítico o vinculante en una política Qualia."""
+
+    code = "qualia_policy_error"
+    safe_message = "La política Qualia no pudo aplicarse de forma segura."
+    status_code = 500
+
+
+class UnsafeOutputBlocked(DomainError):
+    """Salida bloqueada por seguridad antes de exponer contenido no redactado."""
+
+    code = "unsafe_output_blocked"
+    safe_message = "La salida fue bloqueada por las políticas de seguridad."
+    status_code = 400

--- a/agicore_core/qualia_node.py
+++ b/agicore_core/qualia_node.py
@@ -6,6 +6,8 @@ import importlib
 import json
 import os
 import sys
+
+import structlog
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Mapping
@@ -19,7 +21,15 @@ from .agix_compat import (
     module_available,
 )
 from .config import AGIX_REQUIRED_VERSION
+from .domain_errors import QualiaPolicyError
 from .safety_gate import SafetyCategory, SafetyDecision, SafetyEvidence, SafetyIntent
+
+
+LOGGER = structlog.get_logger(__name__)
+
+
+def _safe_error_context(exc: BaseException) -> Dict[str, str]:
+    return {"error_type": type(exc).__name__}
 
 
 @dataclass(frozen=True)
@@ -342,7 +352,12 @@ class QualiaNode:
         if eco_cls is not None:
             try:
                 self._ecoethics = eco_cls()
-            except Exception:
+            except Exception as exc:
+                LOGGER.warning(
+                    "qualia.component_unavailable",
+                    component="ecoethics",
+                    **_safe_error_context(exc),
+                )
                 self._ecoethics = None
         moral_cls, _ = load_first_component(
             "moral_evaluator",
@@ -356,7 +371,12 @@ class QualiaNode:
         if moral_cls is not None:
             try:
                 self._moral_evaluator = moral_cls()
-            except Exception:
+            except Exception as exc:
+                LOGGER.warning(
+                    "qualia.component_unavailable",
+                    component="moral_evaluator",
+                    **_safe_error_context(exc),
+                )
                 self._moral_evaluator = None
         spirit_cls, _ = load_first_component(
             "qualia_spirit",
@@ -368,7 +388,12 @@ class QualiaNode:
         if spirit_cls is not None:
             try:
                 self._spirit = spirit_cls("GPT-OSS-Qualia")
-            except Exception:
+            except Exception as exc:
+                LOGGER.warning(
+                    "qualia.component_unavailable",
+                    component="qualia_spirit",
+                    **_safe_error_context(exc),
+                )
                 self._spirit = None
         memory_cls, _ = load_first_component(
             "memory_manager", (("agix.memory", "GestorDeMemoria"),)
@@ -376,7 +401,12 @@ class QualiaNode:
         if memory_cls is not None:
             try:
                 self._memory_manager = memory_cls()
-            except Exception:
+            except Exception as exc:
+                LOGGER.warning(
+                    "qualia.component_unavailable",
+                    component="memory_manager",
+                    **_safe_error_context(exc),
+                )
                 self._memory_manager = None
         engine_cls, _ = load_first_component(
             "qualia_engine", (("agix.qualia", "QualiaEngine"),)
@@ -387,7 +417,12 @@ class QualiaNode:
                     self._qualia_engine = engine_cls(self._memory_manager)
                 else:
                     self._qualia_engine = engine_cls()
-            except Exception:
+            except Exception as exc:
+                LOGGER.warning(
+                    "qualia.component_unavailable",
+                    component="qualia_engine",
+                    **_safe_error_context(exc),
+                )
                 self._qualia_engine = None
 
     def enrich_request(
@@ -913,8 +948,13 @@ class QualiaNode:
                 result = method(dict(request))
             except TypeError:
                 result = method(text)
-            except Exception:
-                break
+            except Exception as exc:
+                LOGGER.error(
+                    "qualia.moral_evaluator_failed",
+                    method=method_name,
+                    **_safe_error_context(exc),
+                )
+                raise QualiaPolicyError(detail=type(exc).__name__) from exc
             agix_violation = self._normalize_agix_moral_result(result, text)
             return [agix_violation] if agix_violation else []
         return []

--- a/gpt_oss/responses_api/api_server.py
+++ b/gpt_oss/responses_api/api_server.py
@@ -7,6 +7,7 @@ import uuid
 from typing import Callable, Literal, Optional
 import json
 
+import structlog
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -24,6 +25,11 @@ from openai_harmony import (
     ToolDescription,
 )
 
+from agicore_core.domain_errors import (
+    DomainError,
+    HarmonyParseError,
+    ToolCallValidationError,
+)
 from agicore_core.qualia_engine import CoreQualiaEngine
 from agicore_core.qualia_responses import format_blocked_response
 from gpt_oss.responses_api.inference.qualia_guard import OutputSafetyScanner
@@ -66,6 +72,38 @@ from .types import (
 )
 
 DEFAULT_TEMPERATURE = 0.0
+LOGGER = structlog.get_logger(__name__)
+SENSITIVE_LOG_KEYS = {
+    "prompt",
+    "instruction",
+    "instructions",
+    "arguments",
+    "output",
+    "decoded_text",
+    "accumulated_output_tail",
+    "api_key",
+    "authorization",
+    "password",
+    "token",
+    "secret",
+}
+
+
+def _redact_for_log(value):
+    if isinstance(value, dict):
+        return {
+            key: (
+                "[REDACTED]"
+                if str(key).lower() in SENSITIVE_LOG_KEYS
+                else _redact_for_log(child)
+            )
+            for key, child in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_redact_for_log(item) for item in value]
+    if isinstance(value, str):
+        return f"[REDACTED:{len(value)} chars]" if len(value) > 48 else value
+    return value
 
 
 def get_reasoning_effort(effort: Literal["low", "medium", "high"]) -> ReasoningEffort:
@@ -106,6 +144,20 @@ def create_api_server(
             status_code=422,
             content={"detail": _sanitize_validation_detail(exc.errors())},
         )
+    @app.exception_handler(DomainError)
+    async def domain_error_handler(request: Request, exc: DomainError):
+        LOGGER.warning(
+            "responses_api.domain_error",
+            error_code=exc.code,
+            error_type=type(exc).__name__,
+            path=request.url.path,
+            detail="[REDACTED]" if exc.detail else None,
+        )
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"error": {"code": exc.code, "message": exc.safe_message}},
+        )
+
     responses_store: dict[str, tuple[ResponsesRequest, ResponseObject]] = {}
     qualia_engine = CoreQualiaEngine()
 
@@ -211,10 +263,13 @@ def create_api_server(
                         output_tokens, Role.ASSISTANT
                     )
                 except Exception as e:
-                    print(f"Error parsing tokens: {e}")
+                    LOGGER.warning(
+                        "responses_api.harmony_parse_failed",
+                        error_type=type(e).__name__,
+                    )
                     error = Error(
                         code="invalid_function_call",
-                        message=f"{e}",
+                        message=HarmonyParseError.safe_message,
                     )
                     entries = []
             else:
@@ -284,8 +339,12 @@ def create_api_server(
                                 url=parsed_args["url"],
                             )
                     except Exception as e:
-                        print(f"Error processing browser tool arguments: {e}")
-                        action = None
+                        LOGGER.warning(
+                            "responses_api.tool_call_validation_failed",
+                            tool=function_name,
+                            error_type=type(e).__name__,
+                        )
+                        raise ToolCallValidationError(detail=type(e).__name__) from e
 
                     if action is not None:
                         if browser_call_ids and browser_tool_index < len(browser_call_ids):
@@ -357,16 +416,31 @@ def create_api_server(
 
         try:
             debug_str = encoding.decode_utf8(input_tokens + output_tokens)
-        except Exception:
-            debug_str = input_tokens + output_tokens
+        except Exception as exc:
+            LOGGER.warning(
+                "responses_api.debug_decode_failed",
+                field="combined",
+                error_type=type(exc).__name__,
+            )
+            debug_str = "[UNDECODABLE_TOKENS]"
         try:
             debug_input_str = encoding.decode_utf8(input_tokens)
-        except Exception:
-            debug_input_str = input_tokens
+        except Exception as exc:
+            LOGGER.warning(
+                "responses_api.debug_decode_failed",
+                field="input",
+                error_type=type(exc).__name__,
+            )
+            debug_input_str = "[UNDECODABLE_TOKENS]"
         try:
             debug_output_str = encoding.decode_utf8(output_tokens)
-        except Exception:
-            debug_output_str = output_tokens
+        except Exception as exc:
+            LOGGER.warning(
+                "responses_api.debug_decode_failed",
+                field="output",
+                error_type=type(exc).__name__,
+            )
+            debug_output_str = "[UNDECODABLE_TOKENS]"
 
         metadata = (
             {
@@ -497,7 +571,7 @@ def create_api_server(
             while True:
                 # Comprobar si el cliente se desconectó
                 if self.request is not None and await self.request.is_disconnected():
-                    print("Client disconnected, stopping token generation.")
+                    LOGGER.info("responses_api.client_disconnected")
                     break
                 next_tok = infer_next_token(
                     self.tokens,
@@ -509,7 +583,11 @@ def create_api_server(
                 try:
                     self.parser.process(next_tok)
                 except Exception as e:
-                    pass
+                    LOGGER.error(
+                        "responses_api.harmony_stream_parse_failed",
+                        error_type=type(e).__name__,
+                    )
+                    raise HarmonyParseError(detail=type(e).__name__) from e
 
                 if self.parser.state == StreamState.EXPECT_START:
                     current_output_index += 1
@@ -768,9 +846,16 @@ def create_api_server(
                     # por chunks/ventanas solapadas para evitar ejecutar Qualia por token.
                     output_token_text = encoding.decode_utf8([next_tok])
                     self.output_text += output_token_text
-                    print(output_token_text, end="", flush=True)
-                except RuntimeError:
-                    pass
+                    LOGGER.debug(
+                        "responses_api.output_token_decoded",
+                        token_chars=len(output_token_text),
+                    )
+                except RuntimeError as exc:
+                    LOGGER.error(
+                        "responses_api.output_token_decode_failed",
+                        error_type=type(exc).__name__,
+                    )
+                    raise HarmonyParseError(detail=type(exc).__name__) from exc
 
                 if next_tok in encoding.stop_tokens_for_assistant_actions():
                     if len(self.parser.messages) > 0:
@@ -860,7 +945,7 @@ def create_api_server(
                                 Conversation.from_messages(result), Role.ASSISTANT
                             )
                             
-                            print(encoding.decode_utf8(new_tokens))
+                            LOGGER.debug("responses_api.browser_tool_tokens_rendered", token_count=len(new_tokens))
                             self.output_tokens.append(next_tok)
                             self.tokens.append(encoding.encode('<|end|>', allowed_special="all")[0])
 
@@ -934,7 +1019,12 @@ def create_api_server(
 
     @app.post("/v1/responses", response_model=ResponseObject)
     async def generate(body: ResponsesRequest, request: Request):
-        print("request received")
+        LOGGER.info(
+            "responses_api.request_received",
+            model=body.model,
+            stream=body.stream,
+            tool_types=[getattr(tool, "type", None) for tool in (body.tools or [])],
+        )
 
         use_browser_tool = any(
             getattr(tool, "type", None) == "browser_search"
@@ -1127,7 +1217,7 @@ def create_api_server(
         initial_tokens = encoding.render_conversation_for_completion(
             conversation, Role.ASSISTANT
         )
-        print(encoding.decode_utf8(initial_tokens))
+        LOGGER.debug("responses_api.initial_tokens_rendered", token_count=len(initial_tokens))
 
         def store_callback(rid: str, req: ResponsesRequest, resp: ResponseObject):
             responses_store[rid] = (req, resp)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,18 +108,26 @@ def mock_python_tool():
 
 @pytest.fixture(autouse=True)
 def reset_test_environment():
-    test_env_vars = ['OPENAI_API_KEY', 'GPT_OSS_MODEL_PATH']
-    original_values = {}
-    
-    for var in test_env_vars:
-        if var in os.environ:
-            original_values[var] = os.environ[var]
-            del os.environ[var]
-    
+    test_env_vars = [
+        'OPENAI_API_KEY',
+        'GPT_OSS_MODEL_PATH',
+        'AGIX_RUNTIME_PROFILE',
+        'AGIX_REQUIRE_RUNTIME',
+    ]
+    original_values = {var: os.environ.get(var) for var in test_env_vars}
+
+    os.environ["AGIX_RUNTIME_PROFILE"] = "local_safe"
+    os.environ["AGIX_REQUIRE_RUNTIME"] = "0"
+    for var in ('OPENAI_API_KEY', 'GPT_OSS_MODEL_PATH'):
+        os.environ.pop(var, None)
+
     yield
-    
+
     for var, value in original_values.items():
-        os.environ[var] = value
+        if value is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = value
 
 
 @pytest.fixture

--- a/tests/test_domain_errors_logging.py
+++ b/tests/test_domain_errors_logging.py
@@ -1,0 +1,74 @@
+import pytest
+import structlog
+from fastapi.testclient import TestClient
+
+from agicore_core.domain_errors import HarmonyParseError, QualiaPolicyError
+from agicore_core.qualia_node import QualiaNode
+from gpt_oss.responses_api.api_server import create_api_server
+
+pytestmark = pytest.mark.unit
+
+
+def test_domain_error_returns_safe_http_response(harmony_encoding):
+    def infer_next_token(tokens, temperature=0.0, new_request=False):
+        return 0
+
+    app = create_api_server(infer_next_token=infer_next_token, encoding=harmony_encoding)
+
+    @app.get("/raise-harmony-for-test")
+    async def raise_harmony_for_test():
+        raise HarmonyParseError("raw secret sk-test-123 in internal exception", detail="secret detail")
+
+    client = TestClient(app)
+    response = client.get("/raise-harmony-for-test")
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload == {
+        "error": {
+            "code": "harmony_parse_error",
+            "message": HarmonyParseError.safe_message,
+        }
+    }
+    assert "sk-test-123" not in response.text
+    assert "secret detail" not in response.text
+
+
+def test_structured_logs_do_not_include_prompt_or_secrets(harmony_encoding):
+    events = []
+
+    def capture(_, __, event_dict):
+        events.append(dict(event_dict))
+        return event_dict
+
+    structlog.configure(processors=[capture, structlog.processors.JSONRenderer()])
+
+    def infer_next_token(tokens, temperature=0.0, new_request=False):
+        return 0
+
+    app = create_api_server(infer_next_token=infer_next_token, encoding=harmony_encoding)
+
+    @app.get("/raise-domain-for-log-test")
+    async def raise_domain_for_log_test():
+        raise HarmonyParseError("prompt=super-secret password=hunter2", detail="hunter2")
+
+    client = TestClient(app)
+    response = client.get("/raise-domain-for-log-test")
+
+    assert response.status_code == 400
+    rendered = repr(events)
+    assert "hunter2" not in rendered
+    assert "super-secret" not in rendered
+    assert any(event.get("event") == "responses_api.domain_error" for event in events)
+
+
+def test_qualia_moral_evaluator_failure_is_not_hidden():
+    class BrokenEvaluator:
+        def evaluate(self, request):
+            raise RuntimeError("critical qualia failure with secret")
+
+    node = QualiaNode(enabled=True)
+    node._moral_evaluator = BrokenEvaluator()
+
+    with pytest.raises(QualiaPolicyError):
+        node.enrich_request({"task": "x", "prompt": "benign"}, phase="unit")


### PR DESCRIPTION
### Motivation

- Evitar impresiones y silencios que ocultan fallos y prevenir la filtración de prompts, credenciales o argumentos sensibles en logs o respuestas HTTP. 
- Proveer errores de dominio claros y seguros para manejar fallos de parsing Harmony, validación de llamadas a herramientas y errores críticos de políticas Qualia. 

### Description

- Añadido módulo de errores de dominio `agicore_core/domain_errors.py` con `DomainError`, `HarmonyParseError`, `ToolCallValidationError`, `QualiaPolicyError` y `UnsafeOutputBlocked` y exportados desde `agicore_core`. 
- Sustituido `print(...)` y `except ...: pass` en `gpt_oss/responses_api/api_server.py` por logging estructurado con `structlog`, redacción de campos sensibles (`SENSITIVE_LOG_KEYS`) y elevación de errores controlados (`HarmonyParseError`, `ToolCallValidationError`). 
- Integrado `structlog` en `agicore_core/qualia_node.py` para registrar solo metadatos no sensibles y elevar `QualiaPolicyError` cuando el evaluador moral falla en vez de silenciar la excepción. 
- Añadidos tests `tests/test_domain_errors_logging.py` que verifican respuestas HTTP seguras, logs sin secretos y que fallos críticos de Qualia no quedan ocultos, y ajuste en `tests/conftest.py` para forzar `AGIX_RUNTIME_PROFILE=local_safe` durante las pruebas unitarias. 

### Testing

- Compilación estática de módulos con `python -m py_compile agicore_core/domain_errors.py agicore_core/qualia_node.py gpt_oss/responses_api/api_server.py tests/conftest.py tests/test_domain_errors_logging.py` se completó sin errores. 
- Se ejecutaron los tests focalizados con `pytest -q tests/test_domain_errors_logging.py tests/test_responses_api.py` y pasaron (`14 passed`). 
- Se intentó ejecutar la suite completa con `pytest -q` y la recolección falló por una incompatibilidad externa: la versión instalada de `openai_harmony` no exporta `SystemError`, lo que provoca un fallo en `tests/test_simple_browser_encoding.py` (no relacionado con los cambios de este PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55d5c1a3ac8327bb123c347b05fead)