### PR TITLE
docs: document AGIX fork architecture, security, memory, and upstream sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,25 @@ La API de Responses y los backends de inferencia pueden gobernarse con `CoreQual
 La integración continua está documentada en [`docs/ci.md`](docs/ci.md). El workflow principal de CI valida pruebas sin AGIX, pruebas con `agix==1.9.0`, Harmony/Responses API reales, lint con Ruff, type checking con Pyright, build de wheel/sdist, instalación limpia de artefactos y auditoría con `pip-audit`.
 
 La publicación a PyPI está separada en un workflow dedicado de release/manual con entorno protegido `release`; no se publica nunca desde un `push` normal a `main`.
+
+## Arquitectura, seguridad y memoria del fork
+
+Documentación ampliada:
+
+- [`docs/architecture.md`](docs/architecture.md): base upstream, módulos preservados, capas Qualia/AGIX, perfiles AGIX, flujo de decisión y estado PyPI.
+- [`docs/security.md`](docs/security.md): SafetyGate contextual, validación de entradas, redacción de secretos, filtrado de salida y recomendaciones operativas.
+- [`docs/strategic_memory.md`](docs/strategic_memory.md): backends RAM/SQLite, colecciones de auditoría/rechazo y consolidación inferencial segura.
+- [`docs/benchmarks.md`](docs/benchmarks.md): resultados registrados de Responses + Qualia y cómo reproducirlos.
+
+### Resumen operativo del fork
+
+- **Commit upstream usado como base común:** `4931694686fadfa74a80554473d32f7dd4d059f3`; último `upstream/main` observado en la sincronización documental: `d21f34ec3c1ede813adfbd83f07d2ad2eec7ff02`.
+- **Módulos del fork a preservar:** `agicore_core/`, `gpt_oss/planner.py`, `meta_router.py`, `gpt_oss/strategic_memory.py`, `agicore_core/reasoning_kernel.py` y `gpt_oss/responses_api/inference/qualia_guard.py`.
+- **Perfiles AGIX:** instalación base con `agix==1.9.0`; extras `agix-neuro`, `agix-ml`, `agix-data` y `agix-full`; perfiles runtime `local_safe`, `degraded` y `strict_compatible`.
+- **SafetyGate contextual:** `CoreQualiaEngine`/`SafetyGate` evalúa solicitudes antes de GPT, router o backend, y devuelve bloqueos auditables con alternativa segura.
+- **Validación y secretos:** la memoria estratégica redacta claves y patrones sensibles antes de almacenar en RAM o SQLite.
+- **Filtrado de salida:** `OutputSafetyScanner` inspecciona prompt, tool calls, chunks de streaming y respuesta final mediante ventanas solapadas y Qualia.
+- **Memoria:** `StrategicMemory` usa RAM por defecto y puede persistir en SQLite; separa aprendizaje, auditoría y señales rechazadas.
+- **Benchmarks:** la última ejecución registrada midió `none`, `local_safe` y `strict_compatible`; el modo estricto quedó no disponible si faltan componentes AGIX completos.
+- **PyPI:** el paquete se declara como `gpt-oss-agi` versión `0.0.1`; la publicación está separada en workflow protegido y no ocurre desde pushes normales a `main`.
+- **Advertencia:** este fork es experimental, comunitario y no oficial; no representa a OpenAI, no redistribuye pesos y no garantiza AGI.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,70 @@
+# Arquitectura del fork gpt-oss-AGI
+
+> **Estado:** fork comunitario experimental y no oficial de OpenAI. Esta documentación describe las capas añadidas por el fork; no implica soporte, aval ni compatibilidad garantizada con el repositorio upstream `openai/gpt-oss`.
+
+## Base upstream y alcance
+
+- **Upstream oficial:** `https://github.com/openai/gpt-oss`.
+- **Commit base común usado para comparar el fork:** `4931694686fadfa74a80554473d32f7dd4d059f3`.
+- **Último `upstream/main` observado durante la sincronización documental:** `d21f34ec3c1ede813adfbd83f07d2ad2eec7ff02`.
+- **Fecha registrada:** `2026-07-13` UTC.
+
+El fork conserva los backends y utilidades principales de gpt-oss, pero añade una capa AGIX/Qualia para gobierno contextual, memoria estratégica, planificación y auditoría. No modifica ni redistribuye pesos de los modelos `gpt-oss`.
+
+## Módulos preservados del fork
+
+Durante rebases, merges o comparaciones con upstream deben preservarse estos módulos y puntos de integración:
+
+- `agicore_core/`: núcleo Qualia/AGIX, configuración, compatibilidad, SafetyGate, motor Qualia y adaptadores.
+- `gpt_oss/planner.py`: planificación de modos con señales de memoria.
+- `meta_router.py`: enrutado de expertos con memoria episódica y señales Qualia.
+- `gpt_oss/strategic_memory.py`: memoria RAM/SQLite, redacción de secretos, auditoría y consolidación de hipótesis.
+- `agicore_core/reasoning_kernel.py`: kernel de razonamiento preservado para el fork.
+- `gpt_oss/responses_api/inference/qualia_guard.py`: preflight y filtrado incremental de salidas para Responses API.
+
+## Capas principales
+
+1. **Capa upstream gpt-oss**: modelos, tokenizer, Harmony, backends Triton/Metal/Transformers/vLLM/Ollama y servidor Responses API.
+2. **Core Qualia/AGIX (`agicore_core`)**: `CoreQualiaEngine` centraliza `before_decision`, `govern_decision` y `after_decision`; `QualiaNode` enriquece solicitudes con políticas, patrones y decisiones.
+3. **SafetyGate contextual**: bloquea antes de invocar GPT, router o backend cuando Qualia marca riesgo moral, legal, ontoético o inseguro.
+4. **Responses API guardada**: `QualiaGuardedInference` ejecuta preflight antes de tokens y post-check por token; `OutputSafetyScanner` inspecciona prompts, tool calls, chunks de streaming y respuesta final.
+5. **Memoria estratégica**: `StrategicMemory` usa un backend en RAM por defecto o `SQLiteMemoryBackend` para persistencia transaccional.
+6. **Planner/MetaRouter**: consumen memoria episódica para ajustar modos, rutas y expertos sin aprender de episodios bloqueados por Qualia.
+
+## Perfiles AGIX
+
+El paquete fija `agix==1.9.0` y define extras opcionales:
+
+```bash
+pip install -e .[agix-neuro]
+pip install -e .[agix-ml]
+pip install -e .[agix-data]
+pip install -e .[agix-full]
+```
+
+La configuración `agicore_core/config/qualia_profile.json` permite alternar entre:
+
+- `local_safe`: AGIX no disponible; se aplican políticas locales.
+- `degraded`: versión AGIX no compatible; se desactivan capacidades avanzadas.
+- `strict_compatible`: AGIX requerido y compatible activo.
+
+Variables relevantes:
+
+- `AGICORE_QUALIA_PROFILE`: ruta a un perfil alternativo.
+- `AGIX_REQUIRE_RUNTIME=true`: exige runtime real.
+- `AGIX_RUNTIME_PROFILE=strict_compatible`: selecciona modo estricto.
+
+## Flujo de decisión seguro
+
+1. La entrada se normaliza como payload con tarea, contexto, prompt, tokens o tool call.
+2. `CoreQualiaEngine.govern_decision()` llama a Qualia antes de ejecutar la decisión.
+3. `SafetyGate.must_block()` evalúa señales `blocked`, decisión moral, acción legal y clasificación ética.
+4. Si hay bloqueo, se devuelve un objeto auditable con razón, restricciones, alternativa segura y trazas; no se invoca el backend.
+5. Si se permite, la decisión se ejecuta y `after_decision()` integra resultado y feedback.
+6. En streaming, la salida se revisa por ventanas solapadas y evaluación final obligatoria.
+
+## Estado PyPI
+
+- El nombre de distribución declarado es `gpt-oss-agi` y la versión local actual es `0.0.1`.
+- La publicación a PyPI está aislada en `.github/workflows/publish.yml` y solo se ejecuta por release publicada o `workflow_dispatch` confirmado con `publish`.
+- El workflow usa entorno protegido `release` y Trusted Publishing; no se publica desde pushes normales a `main`.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -19,6 +19,14 @@ Resultados reproducibles generados por `benchmarks/bench_responses_qualia.py`.
 | local_safe | sí | 0.119 | 0.139 | 0.015 | 0.052 | 738088.24 | 824535.07 | ok |
 | strict_compatible | no | — | — | — | — | — | — | Contrato AGIX/Qualia estricto incumplido: strict_minimum_component_missing=qualia_engine; strict_minimum_component_missing=moral_evaluator; qualia_engine_not_available |
 
+## Interpretación de resultados
+
+- `none` mide el coste base sin gobierno Qualia y sirve solo como referencia técnica.
+- `local_safe` añade preflight y escaneo local; en la ejecución registrada mantuvo latencias de preflight sub-milisegundo y chunk mediano de `0.015 ms` en el entorno indicado.
+- `strict_compatible` quedó como no disponible porque el contrato estricto de componentes AGIX/Qualia no se cumplió en esa máquina (`qualia_engine`, `moral_evaluator` y disponibilidad de engine). Esto es esperado cuando no se instala o configura el runtime AGIX completo.
+
+Estos números miden sobrecarga de la capa de seguridad con tokens deterministas; no son throughput real de un modelo gpt-oss con GPU.
+
 ## Reproducibilidad
 
 Ejecutar localmente:

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,83 @@
+# Seguridad, validación y filtrado
+
+> **Aviso:** este fork es experimental, comunitario y no oficial. Sus controles de seguridad son una capa adicional de defensa, no una garantía formal de ausencia de riesgo.
+
+## SafetyGate contextual
+
+`agicore_core.safety_gate.SafetyGate` es la puerta central para decisiones GPT. Se ejecuta antes de tocar GPT, `MetaRouter` o un backend de inferencia, y evalúa el payload enriquecido por Qualia en la fase correspondiente.
+
+Categorías contempladas por la puerta:
+
+- ilegalidad;
+- daño físico;
+- malware;
+- privacidad;
+- manipulación;
+- robo de credenciales;
+- exfiltración;
+- señal ontoética AGIX.
+
+Intenciones consideradas:
+
+- dañina;
+- prevención;
+- educación;
+- ficción;
+- análisis defensivo;
+- benigna;
+- desconocida.
+
+Una solicitud se bloquea si Qualia marca `blocked`, si la decisión moral no permite continuar o si la acción legal es `blocked_illegal_or_unsafe_decision`.
+
+## Validación de entradas
+
+Los puntos de entrada deben construir payloads explícitos con, como mínimo, tarea, contexto/fase y contenido a evaluar. Para Responses API, `OutputSafetyScanner` valida:
+
+- prompt inicial;
+- ventanas de streaming;
+- tool calls con nombre y argumentos;
+- respuesta final.
+
+Las ventanas se normalizan para detectar términos peligrosos aunque estén divididos por espacios, saltos de línea, guiones o fragmentación de tokens.
+
+## Redacción de secretos
+
+`SecretRedactor` redacta secretos antes de guardar claves, valores o episodios en memoria estratégica. Redacta:
+
+- claves que parezcan `api_key`, `authorization`, `bearer`, `credential`, `password`, `secret` o `token`;
+- patrones tipo `sk-...`;
+- pares `api_key=...`, `token: ...`, `password=...` y equivalentes;
+- cabeceras o textos `Bearer ...`.
+
+La redacción se aplica recursivamente a cadenas, diccionarios, listas y tuplas antes de almacenar en RAM o SQLite.
+
+## Filtrado de salida
+
+`OutputSafetyScanner` implementa filtrado incremental para salida de Responses API:
+
+1. acumula texto de prompt, chunks, tool calls y final;
+2. revisa ventanas solapadas para evitar evasión por fragmentación;
+3. ejecuta heurísticas locales para patrones de malware, phishing, exfiltración, robo de credenciales y comandos destructivos;
+4. llama a Qualia cuando una ventana es riesgosa o cuando se revisa una tool call;
+5. ejecuta una revisión final obligatoria aunque el streaming no haya disparado heurísticas.
+
+Si se bloquea, `format_blocked_response()` devuelve un formato uniforme con `blocked`, `channel`, `reason`, `ethical_classification`, `violated_constraints`, `legal_policy_action`, `safe_alternative`, `decision_audit`, políticas y patrones cognitivos.
+
+## Memoria segura: RAM y SQLite
+
+`StrategicMemory` usa `InMemoryMemoryBackend` por defecto y puede recibir `SQLiteMemoryBackend` para persistencia. Ambos backends soportan:
+
+- límites por colección;
+- TTL opcional;
+- colecciones separadas para aprendizaje, auditoría y señales rechazadas;
+- transacciones con rollback;
+- redacción de secretos antes de persistir.
+
+Los episodios bloqueados o rechazados por Qualia no alimentan aprendizaje inferencial: se guardan como señales rechazadas y de auditoría.
+
+## Recomendaciones operativas
+
+- Usar `strict_compatible` y `AGIX_REQUIRE_RUNTIME=true` en entornos donde se requiera bloquear arranque sin AGIX compatible.
+- Tratar `local_safe` como modo defensivo mínimo, no como equivalencia completa con AGIX real.
+- Revisar logs de auditoría antes de consolidar memoria.
+- No publicar trazas que puedan contener datos sensibles, aunque el redactor esté activo.

--- a/docs/strategic_memory.md
+++ b/docs/strategic_memory.md
@@ -1,13 +1,31 @@
 # Memoria episódica estratégica
 
-La memoria estratégica permite al agente recordar episodios pasados y
-usar esa información para tomar mejores decisiones. Cada episodio incluye
-el momento en el que ocurrió, la entrada procesada, la acción realizada,
-el resultado obtenido y metadatos asociados.
+La memoria estratégica permite al agente recordar episodios pasados y usar esa información para tomar mejores decisiones. Cada episodio incluye momento, entrada, acción, resultado y metadatos. En este fork, la memoria está diseñada para ser segura por defecto: redacta secretos y evita que episodios bloqueados por Qualia alimenten aprendizaje inferencial.
+
+## Backends disponibles
+
+### RAM por defecto
+
+`StrategicMemory()` crea un `InMemoryMemoryBackend`. Es útil para pruebas, ejecución local y agentes efímeros. Soporta TTL, límites por colección y transacciones con rollback mediante copia interna.
+
+### SQLite persistente
+
+`SQLiteMemoryBackend` persiste claves y episodios en dos tablas (`kv` y `episodes`). Mantiene la misma interfaz que el backend RAM, añade persistencia transaccional y permite cerrar la conexión con `close()`.
+
+```python
+from gpt_oss.strategic_memory import SQLiteMemoryBackend, StrategicMemory
+
+backend = SQLiteMemoryBackend("memory.sqlite", max_episodes=1000)
+mem = StrategicMemory(backend=backend)
+mem.save("plan", {"estado": "inicial"})
+mem.persist()
+backend.close()
+```
 
 ## API básica
 
 ### Almacenamiento de claves
+
 ```python
 from gpt_oss.strategic_memory import StrategicMemory
 
@@ -18,6 +36,7 @@ print(mem.get("plan"))
 ```
 
 ### Episodios
+
 ```python
 from datetime import datetime
 from gpt_oss.strategic_memory import Episode, StrategicMemory
@@ -36,10 +55,33 @@ print(mem.query({"tema": "demo"}))
 print(mem.summarize())
 ```
 
+## Redacción de secretos
+
+Antes de guardar datos, `SecretRedactor` redacta valores sensibles en cadenas y estructuras anidadas. Cubre claves tipo `api_key`, `authorization`, `bearer`, `credential`, `password`, `secret` y `token`, además de patrones comunes como `sk-...`, `Bearer ...` y pares `token=...`.
+
+```python
+from gpt_oss.strategic_memory import StrategicMemory
+
+mem = StrategicMemory()
+mem.save("cred", {"api_key": "sk-1234567890abcdef"})
+assert mem.get("cred")["api_key"] == "[REDACTED]"
+```
+
+## Colecciones de aprendizaje, auditoría y rechazo
+
+- `add_episode()` añade episodios a aprendizaje solo si no fueron bloqueados o rechazados por Qualia.
+- `add_audit_episode()` registra trazabilidad sin alimentar inferencia.
+- `add_rejected_learning()` guarda señales rechazadas y también las audita.
+
+Un episodio se rechaza para aprendizaje si su estado es `blocked_by_qualia` o `rejected_learning`, si la acción de política Qualia indica bloqueo, o si el resultado contiene `blocked: true`.
+
+## Consolidación inferencial segura
+
+`consolidate_from_episodes()` agrupa episodios seguros por tarea, contexto y metas; exige soporte mínimo; calcula confianza por éxitos; y adjunta restricciones éticas observadas. Las señales bloqueadas quedan en `discarded_signals` y no se convierten en hipótesis.
+
 ## Integración con `MetaRouter`
 
-`MetaRouter` puede consultar los episodios almacenados para ajustar la
-puntuación de cada experto según su historial.
+`MetaRouter` puede consultar los episodios almacenados para ajustar la puntuación de cada experto según su historial.
 
 ```python
 from datetime import datetime
@@ -50,7 +92,6 @@ memory = StrategicMemory()
 router = MetaRouter(memory=memory)
 router.register("traductor", Translator(), tasks=["translate"], contexts=["cli"], goals=["en-es"])
 
-# Registrar un fallo previo del experto "traductor"
 memory.add_episode(
     Episode(
         timestamp=datetime.now(),
@@ -73,8 +114,7 @@ router.route({"task": "translate", "context": "cli", "goals": ["en-es"], "text":
 
 ## Integración con `Planner`
 
-El `Planner` consulta la memoria para ajustar automáticamente los
-parámetros del modo activo en función de episodios previos.
+El `Planner` consulta la memoria para ajustar automáticamente los parámetros del modo activo en función de episodios previos.
 
 ```python
 from datetime import datetime

--- a/docs/upstream_sync.md
+++ b/docs/upstream_sync.md
@@ -20,11 +20,16 @@ Al sincronizar en el futuro, deben preservarse explícitamente las extensiones A
 
 Las siguientes extensiones del fork deben conservarse durante comparaciones, rebases o fusiones contra upstream:
 
-- `agicore_core`
-- `gpt_oss/planner.py`
-- `meta_router.py`
-- `gpt_oss/strategic_memory.py`
-- `agicore_core/reasoning_kernel.py`
+- `agicore_core/`: configuración AGIX/Qualia, `QualiaNode`, `CoreQualiaEngine`, `SafetyGate`, adaptadores AGIX y kernel de razonamiento.
+- `gpt_oss/planner.py`: modos de planificación que pueden ajustarse mediante memoria.
+- `meta_router.py`: enrutado de expertos con memoria episódica y señales Qualia.
+- `gpt_oss/strategic_memory.py`: memoria RAM/SQLite, redacción de secretos, auditoría y aprendizaje inferencial seguro.
+- `agicore_core/reasoning_kernel.py`: kernel de razonamiento preservado para el fork.
+- `gpt_oss/responses_api/inference/qualia_guard.py`: preflight contextual y filtrado de salida de Responses API.
+
+## Advertencia de fork experimental
+
+`gpt-oss-AGI` es un fork comunitario experimental y no oficial. No modifica ni redistribuye pesos de OpenAI, no afirma alcanzar AGI y puede divergir del diseño upstream. Toda sincronización debe revisar manualmente los cambios de seguridad, memoria y perfiles AGIX antes de publicar artefactos.
 
 ## Comando recomendado para comparar contra upstream
 


### PR DESCRIPTION
### Motivation

- Registrar y exponer la postura arquitectónica y de seguridad del fork `gpt-oss-AGI` frente al upstream oficial, incluyendo el commit base usado y advertencias sobre el estado experimental del fork. 
- Documentar las extensiones AGIX/Qualia que deben preservarse al sincronizar con `openai/gpt-oss` y explicar perfiles runtime, validación y filtrado para proteger inferencias y memoria.

### Description

- Se añadieron los nuevos archivos `docs/architecture.md` y `docs/security.md` y se ampliaron `README.md`, `docs/upstream_sync.md`, `docs/strategic_memory.md` y `docs/benchmarks.md` para reflejar la arquitectura y medidas de seguridad del fork. 
- El documento registra el `commit` upstream usado como base común (`4931694686fadfa74a80554473d32f7dd4d059f3`) y el `upstream/main` observado (`d21f34ec3c1ede813adfbd83f07d2ad2eec7ff02`) y añade una advertencia explícita de fork experimental/no oficial. 
- Se listan los módulos a preservar durante sincronizaciones: `agicore_core/` (incluyendo `QualiaNode`, `CoreQualiaEngine`, `SafetyGate` y kernel), `gpt_oss/planner.py`, `meta_router.py`, `gpt_oss/strategic_memory.py`, `agicore_core/reasoning_kernel.py` y `gpt_oss/responses_api/inference/qualia_guard.py`. 
- Se documentan perfiles AGIX (`agix==1.9.0` y extras `agix-neuro`, `agix-ml`, `agix-data`, `agix-full`), el `SafetyGate` contextual, la validación de entradas y el `SecretRedactor` para redactar secretos antes de persistir, el `OutputSafetyScanner` para filtrado incremental de salidas, y los backends de memoria (`InMemoryMemoryBackend` y `SQLiteMemoryBackend`) incluyendo límites, TTL y transacciones. 
- Se explica el estado y la política de publicación en PyPI (nombre de distribución `gpt-oss-agi`, versión `0.0.1`, workflow de publicación protegido en `.github/workflows/publish.yml`) y se añadió interpretación de los resultados reproducibles del benchmark Responses+Qualia (modos `none`, `local_safe`, `strict_compatible`).

### Testing

- Se verificó que los archivos de documentación existen y no están vacíos con el script de comprobación: `python - <<'PY' ...` y la comprobación pasó exitosamente. 
- Se ejecutó `git diff --check` y no se detectaron problemas de formato ni advertencias, y la verificación pasó. 
- Se comprobó el estado del índice de trabajo con `git status --short` y se confirmó que los cambios estaban listos (archivos añadidos/actualizados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55d7de156c8327949d796c72bce1d7)