### PR TITLE
Default AGIX Qualia profile to local_safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pip install -e .[agix-data]    # integración de datos
 pip install -e .[agix-full]    # perfil completo ml+data+neuro
 ```
 
-`agicore_core/config/qualia_profile.json` permite alternar entre modo seguro local, modo degradado y modo estricto (`require_agix_runtime`) cuando se requiere bloquear el arranque si AGIX 1.9.0 no está disponible. También se puede apuntar a un perfil alternativo con `AGICORE_QUALIA_PROFILE`, exigir runtime real con `AGIX_REQUIRE_RUNTIME=true` y seleccionar el modo con `AGIX_RUNTIME_PROFILE=strict_compatible`.
+Por defecto, `agicore_core/config/qualia_profile.json` arranca en modo seguro local (`runtime_profile=local_safe`) con `require_agix_runtime=false`, por lo que una instalación limpia funciona sin AGIX y mantiene políticas locales, auditoría y restricciones morales/legales con adaptadores avanzados desactivados. El modo degradado y el modo estricto siguen disponibles: se puede apuntar a un perfil alternativo con `AGICORE_QUALIA_PROFILE`, exigir runtime real con `AGIX_REQUIRE_RUNTIME=true` y seleccionar explícitamente el modo estricto con `AGIX_RUNTIME_PROFILE=strict_compatible`.
 
 La API de Responses y los backends de inferencia pueden gobernarse con `CoreQualiaEngine`: cada petición se evalúa antes de invocar al GPT, y los tokens/chunks generados vuelven a pasar por Qualia para bloquear contenido ilegal o inseguro antes de emitirse. Las respuestas bloqueadas comparten un formato auditable con `reason`, `legal_policy_action`, `violated_constraints`, `safe_alternative` y `decision_audit`.
 

--- a/agicore_core/config/qualia_profile.json
+++ b/agicore_core/config/qualia_profile.json
@@ -152,12 +152,12 @@
     "input_size": 4,
     "output_size": 2
   },
-  "require_agix_runtime": true,
+  "require_agix_runtime": false,
   "agix_runtime_modes": {
     "local_safe": "AGIX no disponible; se aplican políticas locales.",
     "degraded": "Versión AGIX no compatible; se desactivan capacidades avanzadas.",
     "strict_compatible": "AGIX requerido y compatible activo."
   },
-  "runtime_profile": "strict_compatible",
+  "runtime_profile": "local_safe",
   "enforce_strict_component_contract": false
 }

--- a/docs/agix_qualia_core.md
+++ b/docs/agix_qualia_core.md
@@ -38,11 +38,18 @@ señales genéticas y las señales neuromórficas.
 
 ### Modos AGIX 1.9.0
 
-- `strict_compatible`: AGIX 1.9.0 está instalado y sus componentes avanzados se
-  pueden usar.
+El perfil empaquetado arranca por defecto en `local_safe` con
+`require_agix_runtime=false`, de modo que una instalación limpia del fork puede
+crear `QualiaNode` sin AGIX instalado. El modo estricto sigue disponible, pero
+debe solicitarse de forma explícita con un perfil alternativo o con
+`AGIX_RUNTIME_PROFILE=strict_compatible` y, si se quiere bloquear el arranque
+cuando falte AGIX, `AGIX_REQUIRE_RUNTIME=true`.
+
 - `local_safe`: AGIX no está disponible; se mantienen restricciones morales,
   políticas locales y auditoría, pero se desactivan algoritmos genéticos y
   patrones neuromórficos cuando la política es `block_advanced`.
+- `strict_compatible`: AGIX 1.9.0 está instalado y sus componentes avanzados se
+  pueden usar.
 - `degraded` o `advanced_blocked`: la versión instalada no coincide con la
   validada; se bloquean capacidades avanzadas salvo política explícita `warn`.
 - `version_warn`: permite operar con advertencia cuando el perfil lo solicita.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,7 +42,11 @@ pip install -e .[agix-data]
 pip install -e .[agix-full]
 ```
 
-La configuración `agicore_core/config/qualia_profile.json` permite alternar entre:
+La configuración empaquetada `agicore_core/config/qualia_profile.json` usa
+`runtime_profile=local_safe` y `require_agix_runtime=false` por defecto. Por
+ello, una carga limpia del paquete arranca sin AGIX y conserva políticas
+locales, auditoría y restricciones morales/legales mientras deja desactivados
+los adaptadores avanzados. El mismo archivo permite alternar entre:
 
 - `local_safe`: AGIX no disponible; se aplican políticas locales.
 - `degraded`: versión AGIX no compatible; se desactivan capacidades avanzadas.
@@ -51,8 +55,8 @@ La configuración `agicore_core/config/qualia_profile.json` permite alternar ent
 Variables relevantes:
 
 - `AGICORE_QUALIA_PROFILE`: ruta a un perfil alternativo.
-- `AGIX_REQUIRE_RUNTIME=true`: exige runtime real.
-- `AGIX_RUNTIME_PROFILE=strict_compatible`: selecciona modo estricto.
+- `AGIX_REQUIRE_RUNTIME=true`: exige runtime real y bloquea el arranque si AGIX falta o no es compatible.
+- `AGIX_RUNTIME_PROFILE=strict_compatible`: selecciona modo estricto de forma explícita.
 
 ## Flujo de decisión seguro
 

--- a/tests/test_agix_qualia_config.py
+++ b/tests/test_agix_qualia_config.py
@@ -43,6 +43,8 @@ def _write_profile(tmp_path, monkeypatch, payload):
     profile_path = tmp_path / "qualia_profile.json"
     profile_path.write_text(json.dumps(payload), encoding="utf-8")
     monkeypatch.setenv("AGICORE_QUALIA_PROFILE", str(profile_path))
+    monkeypatch.delenv("AGIX_REQUIRE_RUNTIME", raising=False)
+    monkeypatch.delenv("AGIX_RUNTIME_PROFILE", raising=False)
     return profile_path
 
 
@@ -155,6 +157,33 @@ def test_local_safe_starts_without_agix_and_keeps_advanced_adapters_disabled(
     assert node._cognition.enabled is False
     assert enriched["qualia"]["version_policy_action"] == "local_safe_no_agix_adapters"
 
+
+
+def test_packaged_profile_clean_load_starts_local_safe_without_agix(monkeypatch):
+    from agicore_core import agix_compat
+    from agicore_core.qualia_node import QualiaNode
+
+    _purge_fake_agix(monkeypatch)
+    monkeypatch.delenv("AGICORE_QUALIA_PROFILE", raising=False)
+    monkeypatch.delenv("AGIX_REQUIRE_RUNTIME", raising=False)
+    monkeypatch.delenv("AGIX_RUNTIME_PROFILE", raising=False)
+    monkeypatch.setattr(
+        agix_compat.metadata,
+        "version",
+        lambda name: (_ for _ in ()).throw(
+            agix_compat.metadata.PackageNotFoundError(name)
+        ),
+    )
+
+    node = QualiaNode()
+    enriched = node.enrich_request({"task": "arranque limpio local"}, phase="test")
+
+    assert node.profile["require_agix_runtime"] is False
+    assert node.runtime_profile == "local_safe"
+    assert node.compatibility_report.mode == "local_safe"
+    assert node._evolution.genetic_agent is None
+    assert node._cognition.enabled is False
+    assert enriched["qualia"]["version_policy_action"] == "local_safe_no_agix_adapters"
 
 def test_degraded_allows_partial_incompatible_agix_and_reports_degradation(
     tmp_path, monkeypatch


### PR DESCRIPTION
### Motivation
- Permitir que una instalación limpia del paquete inicie sin depender de AGIX por defecto, evitando que el arranque falle en entornos donde no se haya instalado el runtime AGIX.
- Mantener disponible el modo estricto pero exigir activación explícita mediante variable de entorno o un perfil alternativo para despliegues que deseen bloquear el arranque sin AGIX.

### Description
- Cambiado el perfil empaquetado en `agicore_core/config/qualia_profile.json` para usar `"runtime_profile": "local_safe"` y `"require_agix_runtime": false` por defecto, de modo que el Core no requiera AGIX en una carga limpia.
- Ajustadas pruebas en `tests/test_agix_qualia_config.py`: el helper `_write_profile` ahora limpia `AGIX_REQUIRE_RUNTIME` y `AGIX_RUNTIME_PROFILE` del entorno para evitar que el fixture global los sobreescriba, y se añadió `test_packaged_profile_clean_load_starts_local_safe_without_agix` que verifica la carga limpia del perfil empaquetado sin AGIX.
- Actualizada la documentación en `docs/agix_qualia_core.md`, `docs/architecture.md` y `README.md` para aclarar que el perfil empaquetado arranca en `local_safe` por defecto y que el modo estricto debe activarse explícitamente con `AGIX_RUNTIME_PROFILE=strict_compatible` y/o `AGIX_REQUIRE_RUNTIME=true`.
- Ajustada la interacción entre pruebas y el fixture global para mantener las pruebas de `degraded`/`strict_compatible` aisladas y reproducibles cuando se usan perfiles temporales.

### Testing
- Instalado el extra de testing con `python -m pip install -e '.[test]'` para resolver la dependencia `openai_harmony` requerida por `tests/conftest.py`.
- Ejecutado `pytest tests/test_agix_qualia_config.py -q` y validado que todas las pruebas del archivo pasan; resultado final: `7 passed, 1 warning`.
- Se documentó que la ejecución inicial falló por falta de la dependencia mencionada y que la instalación del extra de test la resolvió, tras lo cual las pruebas completas pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55d9f771b8832787bb4cf3326cfc04)