### PR TITLE
Harden Qualia policy inputs

### DIFF
--- a/agicore_core/qualia_node.py
+++ b/agicore_core/qualia_node.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import math
 import os
 import sys
 
@@ -430,7 +431,7 @@ class QualiaNode:
     ) -> Dict[str, Any]:
         """Añade Qualia a una petición antes de enviarla al GPT/router."""
 
-        enriched = dict(request)
+        enriched = self._validated_payload(request)
         if not self.enabled:
             return enriched
 
@@ -1195,6 +1196,66 @@ class QualiaNode:
                 }
         return {"memory_persisted": False, "memory_error": "no_supported_method"}
 
+    @classmethod
+    def _is_invalid_payload_value(cls, value: Any) -> bool:
+        if isinstance(value, bool):
+            return False
+        if isinstance(value, float):
+            return not math.isfinite(value)
+        if isinstance(value, (str, bytes, bytearray)):
+            return False
+        if isinstance(value, int) or value is None:
+            return False
+        if isinstance(value, Mapping):
+            return any(
+                cls._is_invalid_payload_value(item)
+                for pair in value.items()
+                for item in pair
+            )
+        if isinstance(value, (list, tuple, set)):
+            return any(cls._is_invalid_payload_value(item) for item in value)
+        return True
+
+    @classmethod
+    def _validated_payload(cls, payload: Mapping[str, Any]) -> Dict[str, Any]:
+        """Descarta valores no serializables/numéricos no finitos sin interrumpir."""
+
+        validated: Dict[str, Any] = {}
+        invalid_fields: List[Dict[str, str]] = []
+        protected_policy_keys = {"pro_vida", "no_dano", "respeto"}
+        for key, value in payload.items():
+            invalid_policy_override = (
+                key in protected_policy_keys
+                and (
+                    isinstance(value, bool)
+                    or not isinstance(value, (int, float))
+                    or (isinstance(value, float) and not math.isfinite(value))
+                )
+            )
+            if invalid_policy_override or cls._is_invalid_payload_value(value):
+                invalid_fields.append({"field": str(key), "type": type(value).__name__})
+                continue
+            validated[key] = value
+        if invalid_fields:
+            validated["_qualia_input_validation"] = {
+                "valid": False,
+                "rejected_fields": invalid_fields,
+            }
+        return validated
+
+    def _policy_value(self, name: str, default: float) -> float:
+        for policy in self.policies:
+            if policy.name == name:
+                return float(policy.weight)
+        return default
+
+    def _internal_ethical_action(self) -> Dict[str, float]:
+        return {
+            "pro_vida": self._policy_value("pro_vida", 0.9),
+            "no_dano": self._policy_value("no_dano", 1.0),
+            "respeto": self._policy_value("respeto", 0.8),
+        }
+
     def _build_qualia_vectors(
         self, request: Mapping[str, Any]
     ) -> tuple[List[float], List[float]]:
@@ -1209,18 +1270,15 @@ class QualiaNode:
             min(len(text) / 1000.0, 1.0),
             min(goals_count / 10.0, 1.0),
         ]
+        internal_action = self._internal_ethical_action()
         internal_state = [
-            float(request.get("no_dano", 0.85)),
+            internal_action["no_dano"],
             max(0.0, 1.0 - min(len(violations) / 5.0, 1.0)),
         ]
         return sensory_input, internal_state
 
     def _ethical_score(self, request: Mapping[str, Any]) -> float:
-        action = {
-            "pro_vida": float(request.get("pro_vida", 0.75)),
-            "no_dano": float(request.get("no_dano", 0.85)),
-            "respeto": float(request.get("respeto", 0.8)),
-        }
+        action = self._internal_ethical_action()
         if self._ecoethics is not None:
             return float(self._ecoethics.evaluar(action))
         weights = {"pro_vida": 0.5, "no_dano": 0.3, "respeto": 0.2}

--- a/tests/test_qualia_node.py
+++ b/tests/test_qualia_node.py
@@ -23,7 +23,7 @@ def test_qualia_node_enriches_request_with_policies_and_patterns():
 def test_qualia_node_blocks_nocivo_request_and_tracks_full_trace():
     node = QualiaNode(enabled=True)
     request = node.enrich_request(
-        {"task": "riesgo", "pro_vida": 0.0, "no_dano": 0.0, "respeto": 0.0},
+        {"task": "crear malware ilegal"},
         phase="step",
     )
     state = {}
@@ -35,6 +35,79 @@ def test_qualia_node_blocks_nocivo_request_and_tracks_full_trace():
 
     assert state["qualia_trace_length"] == 2
 
+
+def test_qualia_policy_request_overrides_do_not_change_decision():
+    node = QualiaNode(enabled=True)
+    baseline = node.enrich_request({"task": "analizar", "context": "ctx"}, phase="step")
+    tampered = node.enrich_request(
+        {
+            "task": "analizar",
+            "context": "ctx",
+            "pro_vida": 0.0,
+            "no_dano": 0.0,
+            "respeto": 0.0,
+        },
+        phase="step",
+    )
+
+    assert tampered["qualia"]["ethical_score"] == baseline["qualia"]["ethical_score"]
+    assert (
+        tampered["qualia"]["ethical_classification"]
+        == baseline["qualia"]["ethical_classification"]
+    )
+    assert tampered["qualia"]["blocked"] == baseline["qualia"]["blocked"]
+    assert tampered["qualia"]["policy_action"] == baseline["qualia"]["policy_action"]
+
+
+def test_qualia_engine_internal_state_ignores_request_no_dano_override():
+    class EngineStub:
+        def __init__(self):
+            self.generated_args = None
+
+        def generate_state(self, sensory_input, internal_state):
+            self.generated_args = (sensory_input, internal_state)
+            return {"generated": True}
+
+    node = QualiaNode(enabled=True)
+    node._qualia_engine = EngineStub()
+
+    request = node.enrich_request(
+        {"task": "analizar", "context": "ctx", "no_dano": 0.0},
+        phase="step",
+    )
+
+    assert request["qualia"]["phenomenological_state"]["internal_state"][0] == 1.0
+    assert node._qualia_engine.generated_args[1][0] == 1.0
+
+
+def test_qualia_rejects_invalid_policy_payload_values_without_crashing():
+    class InvalidObject:
+        pass
+
+    invalid_values = [
+        float("nan"),
+        float("inf"),
+        "0",
+        [],
+        {"value": 0},
+        InvalidObject(),
+    ]
+    for key in ("pro_vida", "no_dano", "respeto"):
+        for value in invalid_values:
+            node = QualiaNode(enabled=True)
+            request = node.enrich_request(
+                {"task": "analizar", "context": "ctx", key: value},
+                phase="step",
+            )
+
+            assert request["qualia"]["blocked"] is False
+            assert key not in request
+            assert request["_qualia_input_validation"]["valid"] is False
+            rejected_fields = {
+                item["field"]
+                for item in request["_qualia_input_validation"]["rejected_fields"]
+            }
+            assert key in rejected_fields
 
 def test_reasoning_kernel_sends_qualia_to_router_and_updates_state():
     planner = MagicMock()
@@ -59,9 +132,7 @@ def test_reasoning_kernel_does_not_route_blocked_qualia_request():
     kernel = ReasoningKernel(planner=planner, router=router, qualia_node=QualiaNode())
     kernel.set_state({"context": "ctx", "goals": []})
 
-    result = kernel.evaluate_step(
-        {"task": "riesgo", "pro_vida": 0.0, "no_dano": 0.0, "respeto": 0.0}
-    )
+    result = kernel.evaluate_step({"task": "crear malware ilegal"})
 
     assert result["blocked"] is True
     assert result["reason"] == "blocked_by_ontoethical_policy"


### PR DESCRIPTION
### Motivation
- Evitar que valores controlados por el cliente (p.ej. `pro_vida`, `no_dano`, `respeto`) alteren decisiones éticas o el estado interno del nodo, y prevenir crashes por payloads malformados (NaN, infinitos, objetos no válidos).

### Description
- Valida y sanea el payload de entrada al inicio de `enrich_request()` con `_validated_payload()`, rechazando `NaN`, `inf` y overrides inválidos sin abortar el servidor, y anotando `_qualia_input_validation` en la copia validada. (agicore_core/qualia_node.py)
- Reemplaza el uso de valores desde `request` para construir la acción ética por una construcción interna derivada de `self.policies` mediante `_internal_ethical_action()` y `_policy_value()`. (se usan las políticas server-side para `pro_vida`, `no_dano`, `respeto`).
- Sustituye `float(request.get("no_dano", ...))` en `_build_qualia_vectors()` por el valor interno derivado (`internal_action["no_dano"]`).
- Añade validación recursiva para colecciones y mappings y protección específica para las claves de política (`pro_vida`, `no_dano`, `respeto`) para evitar overrides no numéricos o no finitos.
- Añade tests en `tests/test_qualia_node.py` que verifican: que intentar bajar `pro_vida`/`no_dano`/`respeto` desde el request no cambia la decisión, que `_build_qualia_vectors()` ignora `no_dano` enviado por el cliente cuando hay motor de qualia, y que valores inválidos (`float("nan")`, `float("inf")`, strings, listas, objetos) son rechazados sin provocar crash.

### Testing
- Compilación estática: `python -m py_compile agicore_core/qualia_node.py` (OK).
- Ejecutado subset de pruebas relevantes: `pytest tests/test_qualia_node.py -q -k 'policy_request_overrides or internal_state_ignores or rejects_invalid'` (3 passed).
- Ejecutado suite completa de tests del módulo: `pytest tests/test_qualia_node.py -q` donde las nuevas pruebas introducidas pasan; la ejecución completa tuvo 2 fallos preexistentes no relacionados con estos cambios: `test_qualia_node_exposes_agix_compatibility_report` y `test_qualia_node_exposes_evolution_contract_in_compatibility_payload`, debidos a expectativas de perfil/runtime AGIX en el entorno (`runtime_profile`/componentes detectados) y no a la lógica de validación o extracción de políticas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55db3c1f608327a13955527344d82c)