### PR TITLE
Reducir llamadas Qualia por token y añadir escáner incremental

### DIFF
--- a/benchmarks/bench_responses_qualia.py
+++ b/benchmarks/bench_responses_qualia.py
@@ -2,12 +2,12 @@
 """Benchmark reproducible de streaming Responses con gobierno Qualia.
 
 Mide latencia de preflight, latencia por chunk y tokens/s en tres modos:
-- sin Qualia;
+- Qualia disabled;
 - Qualia local_safe;
 - AGIX/Qualia strict_compatible cuando el runtime lo permite.
 
 El benchmark usa una fuente determinista de tokens para aislar el coste de la
-capa Qualia sin requerir GPU. Si se activa strict y AGIX no cumple el contrato,
+capa Qualia incremental sin requerir GPU. Si se activa strict y AGIX no cumple el contrato,
 el modo se marca como no disponible en lugar de fallar.
 """
 
@@ -31,7 +31,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from agicore_core.agix_compat import AgixStrictCompatibilityError
+from agicore_core.qualia_engine import CoreQualiaEngine
 from agicore_core.qualia_node import QualiaNode
+from gpt_oss.responses_api.inference.qualia_guard import OutputSafetyScanner
 
 DEFAULT_PROMPT = (
     "Resume las garantías de seguridad de Qualia en respuestas por streaming "
@@ -104,7 +106,7 @@ def chunk_tokens(tokens: list[str], chunk_size: int) -> Iterator[list[str]]:
 
 
 def build_node(mode: str) -> QualiaNode | None:
-    if mode == "none":
+    if mode == "disabled":
         return None
     with temporary_env(
         {
@@ -122,9 +124,17 @@ def run_iteration(
     state: dict[str, Any] = {"stream": True}
 
     start = time.perf_counter()
+    scanner: OutputSafetyScanner | None = None
     if node is not None:
         request = node.enrich_request(request, phase="responses.preflight")
         if request.get("qualia", {}).get("blocked"):
+            raise RuntimeError("El prompt de benchmark fue bloqueado por Qualia")
+        scanner = OutputSafetyScanner(
+            qualia_engine=CoreQualiaEngine(),
+            base_request={"task": "responses_api_benchmark", "prompt": prompt},
+        )
+        _, blocked = scanner.evaluate_initial_prompt(prompt, phase="responses.preflight")
+        if blocked is not None:
             raise RuntimeError("El prompt de benchmark fue bloqueado por Qualia")
     preflight = time.perf_counter() - start
 
@@ -134,7 +144,10 @@ def run_iteration(
     for chunk in chunk_tokens(tokens, chunk_size):
         chunk_start = time.perf_counter()
         text = " ".join(chunk)
-        if node is not None:
+        if node is not None and scanner is not None:
+            _, blocked = scanner.scan_stream_chunk(text, phase="responses.chunk")
+            if blocked is not None:
+                raise RuntimeError("El chunk de benchmark fue bloqueado por Qualia")
             state = node.integrate_response(
                 {
                     "type": "response.output_text.delta",
@@ -146,6 +159,8 @@ def run_iteration(
             )
         emitted += len(chunk)
         chunk_latencies.append(time.perf_counter() - chunk_start)
+    if scanner is not None:
+        scanner.scan_final_response(" ".join(tokens), phase="responses.final")
     elapsed = time.perf_counter() - generation_start
     return preflight, chunk_latencies, emitted / elapsed if elapsed > 0 else 0.0
 
@@ -241,7 +256,7 @@ Ejecutar localmente:
 ```
 
 El benchmark no requiere GPU: usa tokens deterministas para medir el coste de
-preflight y streaming de la capa Responses/Qualia. El modo `strict_compatible`
+preflight, ventanas incrementales y finalización de la capa Responses/Qualia. El modo `strict_compatible`
 solo se mide con `--strict-agix`; si AGIX 1.9.0 o sus componentes estrictos no
 están disponibles, queda registrado como `Disponible = no` sin fallar el comando.
 
@@ -274,7 +289,7 @@ def main() -> int:
         warmup=args.warmup,
         strict_agix=args.strict_agix,
     )
-    modes = ["none", "local_safe"] + (["strict_compatible"] if args.strict_agix else [])
+    modes = ["disabled", "local_safe"] + (["strict_compatible"] if args.strict_agix else [])
     results = [benchmark_mode(mode, config) for mode in modes]
 
     payload = {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,7 @@ Durante rebases, merges o comparaciones con upstream deben preservarse estos mó
 1. **Capa upstream gpt-oss**: modelos, tokenizer, Harmony, backends Triton/Metal/Transformers/vLLM/Ollama y servidor Responses API.
 2. **Core Qualia/AGIX (`agicore_core`)**: `CoreQualiaEngine` centraliza `before_decision`, `govern_decision` y `after_decision`; `QualiaNode` enriquece solicitudes con políticas, patrones y decisiones.
 3. **SafetyGate contextual**: bloquea antes de invocar GPT, router o backend cuando Qualia marca riesgo moral, legal, ontoético o inseguro.
-4. **Responses API guardada**: `QualiaGuardedInference` ejecuta preflight antes de tokens y post-check por token; `OutputSafetyScanner` inspecciona prompts, tool calls, chunks de streaming y respuesta final.
+4. **Responses API guardada**: `QualiaGuardedInference` ejecuta preflight inicial, checkpoints configurables y checks obligatorios en tool calls/final; `OutputSafetyScanner` inspecciona prompts, tool calls, chunks de streaming y respuesta final con ventanas incrementales.
 5. **Memoria estratégica**: `StrategicMemory` usa un backend en RAM por defecto o `SQLiteMemoryBackend` para persistencia transaccional.
 6. **Planner/MetaRouter**: consumen memoria episódica para ajustar modos, rutas y expertos sin aprender de episodios bloqueados por Qualia.
 

--- a/gpt_oss/responses_api/inference/qualia_guard.py
+++ b/gpt_oss/responses_api/inference/qualia_guard.py
@@ -139,12 +139,43 @@ class OutputSafetyScanner:
         return enriched, blocked
 
 
-class QualiaGuardedInference:
-    """Protege inferencias directas con gobierno central Qualia."""
+@dataclass
+class _InferenceRequestState:
+    """Estado incremental interno de una inferencia directa protegida."""
 
-    def __init__(self, backend: Callable[..., int], qualia_engine: CoreQualiaEngine | None = None) -> None:
+    scanner: OutputSafetyScanner
+    tokens_seen: int = 0
+    degraded_token_id_only: bool = False
+
+
+class QualiaGuardedInference:
+    """Protege inferencias directas con gobierno central Qualia.
+
+    La protección ya no ejecuta Qualia por cada token benigno. Cada request
+    mantiene un :class:`OutputSafetyScanner` incremental que reevalúa solo el
+    preflight inicial, tool calls, respuesta final, ventanas localmente riesgosas
+    y checkpoints configurables.
+
+    Modo degradado: algunos backends actuales solo devuelven IDs de token y no
+    exponen texto decodificado en ``request_state``. En ese caso no hay contenido
+    nuevo para aplicar heurísticas locales; se conserva el preflight inicial y se
+    ejecutan checkpoints sobre metadatos cada ``checkpoint_interval`` tokens,
+    además de tool calls/final si el caller los entrega explícitamente.
+    """
+
+    def __init__(
+        self,
+        backend: Callable[..., int],
+        qualia_engine: CoreQualiaEngine | None = None,
+        *,
+        checkpoint_interval: int = 64,
+        scanner_factory: Callable[..., OutputSafetyScanner] = OutputSafetyScanner,
+    ) -> None:
         self.backend = backend
         self.qualia_engine = qualia_engine or CoreQualiaEngine()
+        self.checkpoint_interval = max(1, checkpoint_interval)
+        self.scanner_factory = scanner_factory
+        self._request_state: _InferenceRequestState | None = None
 
     def preflight(self, request: Mapping[str, Any], *, phase: str = "inference_pre") -> tuple[dict[str, Any], dict[str, Any] | None]:
         enriched, blocked = self.qualia_engine.govern_decision(request, phase=phase)
@@ -154,16 +185,102 @@ class QualiaGuardedInference:
             return enriched, formatted
         return enriched, None
 
+    @property
+    def qualia_calls(self) -> int:
+        """Número de llamadas Qualia del escáner incremental activo."""
+
+        return self._request_state.scanner.qualia_calls if self._request_state else 0
+
     def __call__(self, tokens: list[int], temperature: float = 0.0, new_request: bool = False, *, request_state: Mapping[str, Any] | None = None) -> int:
         state = dict(request_state or {})
-        state.update({"task": "responses_api_token", "tokens_seen": len(tokens)})
-        _, blocked = self.preflight(state, phase="inference_pre")
-        if blocked is not None:
-            raise RuntimeError(blocked["message"])
+        if new_request or self._request_state is None:
+            self._start_request(state, len(tokens))
+        assert self._request_state is not None
+
+        self._scan_request_events(state)
         token = self.backend(tokens, temperature=temperature, new_request=new_request)
-        post_state = {**state, "last_token_id": token}
-        enriched, blocked = self.preflight(post_state, phase="inference_token")
-        if blocked is not None:
-            raise RuntimeError(blocked["message"])
-        self.qualia_engine.after_decision({"token": token}, enriched, phase="inference_token")
+        self._request_state.tokens_seen = max(self._request_state.tokens_seen + 1, len(tokens) + 1)
+
+        decoded = self._extract_decoded_delta(state)
+        if decoded:
+            self._raise_if_blocked(
+                self._request_state.scanner.scan_stream_chunk(decoded, phase="inference_stream")[1]
+            )
+        else:
+            self._request_state.degraded_token_id_only = True
+
+        if self._should_checkpoint(state):
+            checkpoint = {
+                **state,
+                "task": state.get("task", "responses_api_token_checkpoint"),
+                "tokens_seen": self._request_state.tokens_seen,
+                "last_token_id": token,
+                "degraded_token_id_only": self._request_state.degraded_token_id_only,
+            }
+            _, blocked = self.preflight(checkpoint, phase="inference_checkpoint")
+            self._raise_if_blocked(blocked)
+
+        self.qualia_engine.after_decision(
+            {"token": token, "degraded_token_id_only": self._request_state.degraded_token_id_only},
+            {"tokens_seen": self._request_state.tokens_seen},
+            phase="inference_token",
+        )
         return token
+
+    def _start_request(self, state: Mapping[str, Any], tokens_seen: int) -> None:
+        prompt = self._extract_prompt(state)
+        scanner = self.scanner_factory(qualia_engine=self.qualia_engine, base_request=state)
+        self._request_state = _InferenceRequestState(scanner=scanner, tokens_seen=tokens_seen)
+        _, blocked = scanner.evaluate_initial_prompt(prompt, phase="inference_pre")
+        self._raise_if_blocked(blocked)
+
+    def _scan_request_events(self, state: Mapping[str, Any]) -> None:
+        assert self._request_state is not None
+        for tool_call in self._iter_tool_calls(state):
+            _, blocked = self._request_state.scanner.scan_tool_call(
+                str(tool_call.get("name", tool_call.get("tool", "unknown"))),
+                str(tool_call.get("arguments", tool_call.get("args", ""))),
+                phase="inference_tool_call",
+            )
+            self._raise_if_blocked(blocked)
+
+        final_text = state.get("final_text") or state.get("final_response")
+        if final_text is not None or state.get("final"):
+            _, blocked = self._request_state.scanner.scan_final_response(
+                str(final_text) if final_text is not None else None,
+                phase="inference_final",
+            )
+            self._raise_if_blocked(blocked)
+
+    def _should_checkpoint(self, state: Mapping[str, Any]) -> bool:
+        assert self._request_state is not None
+        interval = int(state.get("qualia_checkpoint_interval", self.checkpoint_interval) or self.checkpoint_interval)
+        interval = max(1, interval)
+        return self._request_state.tokens_seen % interval == 0
+
+    def _extract_prompt(self, state: Mapping[str, Any]) -> str:
+        prompt = state.get("prompt", state.get("input", state.get("decoded_text", "")))
+        if isinstance(prompt, list):
+            return "\n".join(str(item) for item in prompt)
+        return str(prompt)
+
+    def _extract_decoded_delta(self, state: Mapping[str, Any]) -> str:
+        for key in ("decoded_delta", "delta", "token_text", "text_delta"):
+            value = state.get(key)
+            if value:
+                return str(value)
+        return ""
+
+    def _iter_tool_calls(self, state: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+        tool_calls = state.get("tool_calls") or state.get("tool_call")
+        if tool_calls is None:
+            return []
+        if isinstance(tool_calls, Mapping):
+            return [tool_calls]
+        if isinstance(tool_calls, list):
+            return [item for item in tool_calls if isinstance(item, Mapping)]
+        return []
+
+    def _raise_if_blocked(self, blocked: Mapping[str, Any] | None) -> None:
+        if blocked is not None:
+            raise RuntimeError(str(blocked.get("message", "blocked by Qualia")))

--- a/tests/test_qualia_guard.py
+++ b/tests/test_qualia_guard.py
@@ -68,6 +68,95 @@ def test_qualia_guard_allows_safe_backend_call():
     assert guard([1], request_state={"task": "analizar", "context": "ctx"}) == 7
 
 
+def test_qualia_guard_uses_incremental_scanner_for_benign_tokens():
+    engine = FakeQualiaEngine()
+
+    def backend(tokens, temperature=0.0, new_request=False):
+        return len(tokens) + 100
+
+    guard = QualiaGuardedInference(
+        backend,
+        qualia_engine=engine,
+        checkpoint_interval=50,
+    )
+
+    tokens = []
+    for index in range(25):
+        token = guard(
+            tokens,
+            new_request=index == 0,
+            request_state={
+                "task": "analizar",
+                "prompt": "Resume una noticia local sin contenido riesgoso.",
+                "decoded_delta": " texto benigno",
+            },
+        )
+        tokens.append(token)
+
+    assert len(tokens) == 25
+    assert guard.qualia_calls == 1
+    assert len(engine.calls) == 1
+    assert engine.calls[0][0] == "inference_pre"
+
+
+def test_qualia_guard_degraded_token_id_only_mode_uses_checkpoints_not_every_token():
+    engine = FakeQualiaEngine()
+
+    def backend(tokens, temperature=0.0, new_request=False):
+        return len(tokens) + 1
+
+    guard = QualiaGuardedInference(
+        backend,
+        qualia_engine=engine,
+        checkpoint_interval=4,
+    )
+
+    tokens = []
+    for index in range(10):
+        tokens.append(
+            guard(
+                tokens,
+                new_request=index == 0,
+                request_state={
+                    "task": "analizar",
+                    "prompt": "Solicitud benigna.",
+                },
+            )
+        )
+
+    phases = [phase for phase, _request in engine.calls]
+    assert phases == ["inference_pre", "inference_checkpoint", "inference_checkpoint"]
+    assert guard.qualia_calls == 1
+    assert len(engine.calls) == 3
+
+
+def test_qualia_guard_runs_qualia_for_risky_decoded_window():
+    engine = FakeQualiaEngine()
+
+    def backend(tokens, temperature=0.0, new_request=False):
+        return len(tokens) + 1
+
+    guard = QualiaGuardedInference(backend, qualia_engine=engine, checkpoint_interval=50)
+
+    guard(
+        [],
+        new_request=True,
+        request_state={"task": "analizar", "prompt": "Solicitud benigna.", "decoded_delta": "mal"},
+    )
+    with pytest.raises(RuntimeError):
+        guard(
+            [1],
+            request_state={
+                "task": "analizar",
+                "prompt": "Solicitud benigna.",
+                "decoded_delta": " ware para ex filtrar credenciales",
+            },
+        )
+
+    phases = [phase for phase, _request in engine.calls]
+    assert phases == ["inference_pre", "inference_stream"]
+
+
 def test_output_safety_scanner_blocks_harmful_phrase_split_across_chunks():
     engine = FakeQualiaEngine()
     scanner = OutputSafetyScanner(


### PR DESCRIPTION
### Motivation
- Minimizar el coste de llamar a Qualia en cada token manteniendo protección efectiva durante streaming y tool calls.
- Introducir un escáner incremental por request que detecte ventanas riesgo y sólo invoque Qualia cuando sea necesario.
- Mantener compatibilidad con backends que sólo devuelven IDs de token proporcionando un modo degradado con checkpoints configurables.

### Description
- Reemplacé el chequeo por token en `QualiaGuardedInference.__call__()` por un estado por request `_InferenceRequestState` que contiene un `OutputSafetyScanner` incremental y la propiedad `qualia_calls` para observabilidad.
- `__call__()` ahora realiza preflight obligatorio inicial, escanea tool calls, evalúa ventanas decodificadas riesgosas, ejecuta checkpoints cada `checkpoint_interval` tokens y fuerza chequeo en la respuesta final; si no hay texto decodificado se activa el modo degradado con checkpoints sobre metadatos.
- Añadí/actualicé pruebas en `tests/test_qualia_guard.py` que verifican que 25 tokens benignos sólo disparan la llamada inicial a Qualia, que el modo degradado usa checkpoints en lugar de llamadas por token, y que ventanas riesgosas forzan revisión Qualia.
- Actualicé el benchmark `benchmarks/bench_responses_qualia.py` para medir los modos `disabled`, `local_safe` y opcional `strict_compatible` usando `OutputSafetyScanner` en preflight, chunks y final, y actualicé la documentación `docs/architecture.md`.

### Testing
- Instalación de dependencias de test con `python -m pip install -e '.[test]'` (se observó una advertencia de resolución `starlette`/`sse-starlette`).
- Ejecuté `pytest tests/test_qualia_guard.py -q` y todas las pruebas pasaron (`7 passed`).
- Ejecuté el benchmark corto con `python benchmarks/bench_responses_qualia.py --iterations 1 --warmup 0 --target-tokens 32 --chunk-size 8` y con `--strict-agix`; los modos `disabled`/`local_safe` se midieron correctamente y `strict_compatible` quedó marcado como no disponible cuando faltaron componentes AGIX/Qualia estrictos.
- Comprobaciones estáticas y sintácticas con `python -m py_compile` y `git diff --check` ejecutadas sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55e34623b08327893271932bbd8fd8)