### PR TITLE
Hacer AGIX opcional por defecto y ajustar CI/ejemplos

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,8 +32,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  tests-without-agix:
-    name: Tests without AGIX
+  local_safe:
+    name: local_safe without AGIX
     runs-on: ubuntu-latest
 
     steps:
@@ -65,8 +65,8 @@ jobs:
         run: |
           pytest -m "not external_resource"
 
-  tests-with-agix:
-    name: Tests with agix==1.9.0
+  strict_compatible:
+    name: strict_compatible with AGIX 1.9.0
     runs-on: ubuntu-latest
 
     steps:
@@ -79,11 +79,10 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install package, tests, and pinned AGIX
+      - name: Install package, tests, and AGIX extra
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[test]"
-          python -m pip install "agix==1.9.0"
+          python -m pip install -e ".[test,agix]"
 
       - name: Verify AGIX version
         run: |
@@ -92,9 +91,9 @@ jobs:
           assert metadata.version("agix") == "1.9.0"
           PY
 
-      - name: Run tests with AGIX available
+      - name: Run strict-compatible tests with AGIX available
         env:
-          AGIX_RUNTIME_PROFILE: degraded
+          AGIX_RUNTIME_PROFILE: strict_compatible
         run: |
           pytest -m "not external_resource"
 

--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ Consulta [`docs/upstream_sync.md`](docs/upstream_sync.md) para ver el remoto ups
 
 ## Integración AGIX/Qualia
 
-El Core fija `agix==1.9.0` y usa `agicore_core.QualiaNode` como capa rectora de planificación, enrutado y ciclo de tokens. Qualia aplica políticas ontoéticas, restricciones morales/legales, patrones cognitivos y señales evolutivas antes de que una solicitud llegue al GPT o al `MetaRouter`.
+El Core mantiene `agix==1.9.0` como extra opcional explícito y usa `agicore_core.QualiaNode` como capa rectora de planificación, enrutado y ciclo de tokens. Qualia aplica políticas ontoéticas, restricciones morales/legales, patrones cognitivos y señales evolutivas antes de que una solicitud llegue al GPT o al `MetaRouter`.
 
 Perfiles opcionales para capacidades avanzadas de AGIX:
 
 ```bash
+pip install -e .[agix]         # runtime AGIX estricto 1.9.0
 pip install -e .[agix-neuro]   # módulos neuroinspirados de AGIX
 pip install -e .[agix-ml]      # módulos ML de AGIX
 pip install -e .[agix-data]    # integración de datos
@@ -98,7 +99,7 @@ La API de Responses y los backends de inferencia pueden gobernarse con `CoreQual
 
 ## CI y publicación
 
-La integración continua está documentada en [`docs/ci.md`](docs/ci.md). El workflow principal de CI valida pruebas sin AGIX, pruebas con `agix==1.9.0`, Harmony/Responses API reales, lint con Ruff, type checking con Pyright, build de wheel/sdist, instalación limpia de artefactos y auditoría con `pip-audit`.
+La integración continua está documentada en [`docs/ci.md`](docs/ci.md). El workflow principal de CI valida el job `local_safe` sin AGIX, el job `strict_compatible` con `agix==1.9.0`, Harmony/Responses API reales, lint con Ruff, type checking con Pyright, build de wheel/sdist, instalación limpia de artefactos y auditoría con `pip-audit`.
 
 La publicación a PyPI está separada en un workflow dedicado de release/manual con entorno protegido `release`; no se publica nunca desde un `push` normal a `main`.
 
@@ -115,7 +116,7 @@ Documentación ampliada:
 
 - **Commit upstream usado como base común:** `4931694686fadfa74a80554473d32f7dd4d059f3`; último `upstream/main` observado en la sincronización documental: `d21f34ec3c1ede813adfbd83f07d2ad2eec7ff02`.
 - **Módulos del fork a preservar:** `agicore_core/`, `gpt_oss/planner.py`, `meta_router.py`, `gpt_oss/strategic_memory.py`, `agicore_core/reasoning_kernel.py` y `gpt_oss/responses_api/inference/qualia_guard.py`.
-- **Perfiles AGIX:** instalación base con `agix==1.9.0`; extras `agix-neuro`, `agix-ml`, `agix-data` y `agix-full`; perfiles runtime `local_safe`, `degraded` y `strict_compatible`.
+- **Perfiles AGIX:** instalación base sin AGIX; extras explícitos `agix`, `agix-neuro`, `agix-ml`, `agix-data` y `agix-full`; perfiles runtime `local_safe`, `degraded` y `strict_compatible`.
 - **SafetyGate contextual:** `CoreQualiaEngine`/`SafetyGate` evalúa solicitudes antes de GPT, router o backend, y devuelve bloqueos auditables con alternativa segura.
 - **Validación y secretos:** la memoria estratégica redacta claves y patrones sensibles antes de almacenar en RAM o SQLite.
 - **Filtrado de salida:** `OutputSafetyScanner` inspecciona prompt, tool calls, chunks de streaming y respuesta final mediante ventanas solapadas y Qualia.

--- a/docs/agix_qualia_core.md
+++ b/docs/agix_qualia_core.md
@@ -1,6 +1,6 @@
 # Arquitectura AGIX/Qualia en GPT-OSS
 
-Este proyecto fija la integración con `agix==1.9.0` y expone extras opcionales para capacidades `ml`, `data` y `neuro`. El objetivo del núcleo es que toda decisión relevante del GPT pase por un ciclo Qualia común antes y después de ejecutarse.
+Este proyecto fija la integración estricta con `agix==1.9.0` mediante extras opcionales explícitos y expone capacidades `ml`, `data` y `neuro`. El objetivo del núcleo es que toda decisión relevante del GPT pase por un ciclo Qualia común antes y después de ejecutarse.
 
 ## Flujo central
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,9 +33,10 @@ Durante rebases, merges o comparaciones con upstream deben preservarse estos mó
 
 ## Perfiles AGIX
 
-El paquete fija `agix==1.9.0` y define extras opcionales:
+La instalación base del paquete no instala AGIX. El runtime `agix==1.9.0` queda fijado en extras explícitos:
 
 ```bash
+pip install -e .[agix]
 pip install -e .[agix-neuro]
 pip install -e .[agix-ml]
 pip install -e .[agix-data]
@@ -48,9 +49,9 @@ ello, una carga limpia del paquete arranca sin AGIX y conserva políticas
 locales, auditoría y restricciones morales/legales mientras deja desactivados
 los adaptadores avanzados. El mismo archivo permite alternar entre:
 
-- `local_safe`: AGIX no disponible; se aplican políticas locales.
-- `degraded`: versión AGIX no compatible; se desactivan capacidades avanzadas.
-- `strict_compatible`: AGIX requerido y compatible activo.
+- `local_safe`: no requiere AGIX; se aplican políticas locales.
+- `degraded`: AGIX ausente, parcial o no compatible; se desactivan capacidades avanzadas.
+- `strict_compatible`: exige AGIX 1.9.0 y contratos mínimos compatibles activos.
 
 Variables relevantes:
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,8 +8,8 @@ El workflow `CI` se ejecuta en `pull_request`, en cualquier `push` de rama y man
 
 Jobs principales:
 
-1. **Tests without AGIX**: instala el proyecto con dependencias de test, desinstala `agix` y ejecuta la suite local con `AGIX_RUNTIME_PROFILE=local_safe`. Esto valida que el modo seguro/fallback funciona sin el runtime AGIX instalado.
-2. **Tests with `agix==1.9.0`**: instala explícitamente `agix==1.9.0`, comprueba la versión instalada y ejecuta la suite local con el perfil degradado.
+1. **`local_safe` without AGIX**: instala el proyecto con dependencias de test, desinstala `agix` si aparece transitivamente y ejecuta la suite local con `AGIX_RUNTIME_PROFILE=local_safe`. Este job no requiere AGIX y valida que el modo seguro/fallback funciona sin el runtime instalado.
+2. **`strict_compatible` with AGIX 1.9.0**: instala el paquete con `.[test,agix]`, comprueba que la versión instalada sea exactamente `agix==1.9.0` y ejecuta la suite local con `AGIX_RUNTIME_PROFILE=strict_compatible`. Este job sí exige AGIX 1.9.0.
 3. **Real Harmony and Responses API**: ejecuta `tests/test_responses_api.py` usando el paquete real `openai-harmony` y el servidor Responses API del repositorio.
 4. **Ruff check**: ejecuta `ruff check .`.
 5. **Type checking with pyright**: instala el paquete en modo editable y ejecuta `pyright`.
@@ -30,6 +30,6 @@ El job usa el entorno protegido `release` y Trusted Publishing mediante OIDC (`i
 
 ## Recomendaciones de mantenimiento
 
-- Mantener la versión de AGIX sincronizada con `pyproject.toml`, `requirements.txt` y `agicore_core/config/qualia_profile.json`.
+- Mantener la versión de AGIX sincronizada entre los extras de `pyproject.toml`, `requirements.txt` cuando se use como lock/runtime estricto, y `agicore_core/config/qualia_profile.json`.
 - Si `ruff`, `pyright` o `pip-audit` empiezan a fallar por deuda técnica existente, corregir la configuración o las exclusiones en un cambio separado antes de hacerlos obligatorios para protección de rama.
 - Revisar periódicamente que `publish.yml` siga apuntando al entorno protegido `release` y que el proyecto en PyPI tenga Trusted Publishing configurado para este repositorio.

--- a/docs/qualia_node.md
+++ b/docs/qualia_node.md
@@ -2,7 +2,7 @@
 
 ## Tareas estructuradas implementadas
 
-1. **Actualizar AGIX a PyPI 1.9.0**: fijar la dependencia `agix==1.9.0` en los scripts de instalación y en las dependencias del paquete.
+1. **Actualizar AGIX a PyPI 1.9.0**: fijar `agix==1.9.0` en extras explícitos y scripts de instalación estricta, no en la instalación base.
 2. **Crear el nodo Qualia**: añadir una capa `QualiaNode` en `agicore_core` con políticas ontoéticas, patrones cognitivos y detección de versión AGIX.
 3. **Integrar el nodo en el engine GPT**: enriquecer todas las llamadas del `ReasoningKernel` y del kernel secuencial antes de pasar por `MetaRouter`.
 4. **Aplicar respuesta al estado**: registrar la huella Qualia tras cada paso o token para que el estado interno del GPT quede afectado por el nodo.

--- a/examples/meta_router_moe_demo.py
+++ b/examples/meta_router_moe_demo.py
@@ -17,8 +17,24 @@ import sys
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from agicore_core import Planner, ReasoningKernel
-from agix.orchestrator import VirtualQualia
+from agicore_core.agix_compat import AgixStrictCompatibilityError, load_first_component
+from agicore_core.config import AGIX_REQUIRED_VERSION
 from meta_router import MetaRouter
+
+
+def _load_virtual_qualia():
+    """Carga VirtualQualia mediante la capa compat para evitar imports directos de AGIX."""
+
+    component, status = load_first_component(
+        "virtual_qualia", (("agix.orchestrator", "VirtualQualia"),)
+    )
+    if component is None:
+        detail = f" Detalle: {status.error}" if status.error else ""
+        raise AgixStrictCompatibilityError(
+            f"Este ejemplo requiere instalar AGIX {AGIX_REQUIRED_VERSION} con "
+            f"`pip install -e .[agix]`.{detail}"
+        )
+    return component
 
 
 class DummyExpert:
@@ -76,6 +92,7 @@ def main() -> None:  # pragma: no cover - ejemplo interactivo
         "goals": ["multiply"],
         "data": {"a": 2, "b": 3},
     }
+    VirtualQualia = _load_virtual_qualia()
     orchestrator = VirtualQualia(clients=[PlanClient(step_sum), PlanClient(step_mul)])
     planner = Planner(orchestrator)
     plan = planner.plan({"objective": "demo"})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
   "uvicorn>=0.34,<0.35",
   "requests>=2.31.0",
   "termcolor",
-  "agix==1.9.0",
 ]
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
@@ -39,6 +38,7 @@ Issues = "https://github.com/inteligencIA-AGI/gpt-oss-AGI/issues"
 "OpenAI gpt-oss upstream" = "https://github.com/openai/gpt-oss"
 
 [project.optional-dependencies]
+agix = ["agix==1.9.0"]
 triton = ["triton", "safetensors>=0.5.3", "torch>=2.7.0"]
 torch = ["safetensors>=0.5.3", "torch>=2.7.0"]
 metal = ["numpy", "tqdm", "safetensors", "torch"]

--- a/tests/test_agix_qualia_config.py
+++ b/tests/test_agix_qualia_config.py
@@ -14,7 +14,7 @@ def test_agix_version_is_consistent_across_project_files():
         )
     )
 
-    assert f"agix=={AGIX_REQUIRED_VERSION}" in pyproject
+    assert f'agix = ["agix=={AGIX_REQUIRED_VERSION}"]' in pyproject
     assert f"agix=={AGIX_REQUIRED_VERSION}" in requirements
     assert profile["agix_required_version"] == AGIX_REQUIRED_VERSION
 


### PR DESCRIPTION
### Motivation
- Quitar la dependencia rígida de AGIX de la instalación base para que la instalación por defecto no arrastre el runtime AGIX.
- Permitir perfiles explícitos (extras) para instalar AGIX 1.9.0 cuando sea necesario y mantener compatibilidad con los sub-perfiles `agix-neuro`, `agix-ml`, `agix-data` y `agix-full`.
- Asegurar que CI tenga dos flujos claros: uno que valida el modo seguro local sin AGIX y otro que valida el modo estricto con AGIX 1.9.0.

### Description
- Eliminado `agix==1.9.0` de `[project].dependencies` y añadido el extra `agix = ["agix==1.9.0"]` en `[project.optional-dependencies]` en `pyproject.toml`.
- Ajustado el workflow de CI (`.github/workflows/CI.yml`) para usar el job `local_safe` que instala `.[test]`, desinstala/verifica ausencia de AGIX y ejecuta con `AGIX_RUNTIME_PROFILE=local_safe`, y el job `strict_compatible` que instala `.[test,agix]`, verifica `agix==1.9.0` y ejecuta con `AGIX_RUNTIME_PROFILE=strict_compatible`.
- Protegido el import directo de AGIX en `examples/meta_router_moe_demo.py` usando la capa de compatibilidad `agicore_core.agix_compat.load_first_component` y lanzando un `AgixStrictCompatibilityError` con mensaje claro si falta AGIX; así se evita `from agix...` directo.
- Actualizada la documentación (`README.md`, `docs/ci.md`, `docs/architecture.md`, `docs/agix_qualia_core.md`, `docs/qualia_node.md`) para dejar constancia de que la instalación base no requiere AGIX, cómo instalar `.[agix]`, y que `local_safe` no requiere AGIX mientras `strict_compatible` sí exige AGIX 1.9.0.
- Ajustada la prueba de consistencia `tests/test_agix_qualia_config.py` para comprobar la presencia del extra `agix` en `pyproject.toml` en lugar de la dependencia fija en la lista base.

### Testing
- Ejecuté `python -m pip install -e ".[test]"` y verifiqué que la instalación base no arrastra AGIX; local-safe tests se ejecutaron con `AGIX_RUNTIME_PROFILE=local_safe` y `pytest tests/test_agix_qualia_config.py tests/test_planner_agent_profile.py` resultando en tests verdes.
- Probé `ruff` sobre los ficheros Python cambiados con `ruff check examples/meta_router_moe_demo.py tests/test_agix_qualia_config.py` y confirmó que pasó (`All checks passed!`).
- Instalé el extra AGIX con `python -m pip install -e ".[agix]"`, comprobé la versión con `from importlib import metadata; assert metadata.version('agix') == '1.9.0'`, y ejecuté `AGIX_RUNTIME_PROFILE=strict_compatible pytest tests/test_agix_qualia_config.py`, con la suite de compatibilidad pasando (tests verdes, una advertencia esperada de AGIX sobre token de entorno).
- Validé la sintaxis del workflow YAML tras instalar `PyYAML` usando `yaml.safe_load(Path('.github/workflows/CI.yml').read_text())` y ejecuté `git diff --check`; ambas comprobaciones pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55e61e72648327a1ac203ae9be46d8)