### PR TITLE
Documentar punto base de sincronización con upstream

### DIFF
--- a/docs/upstream_sync.md
+++ b/docs/upstream_sync.md
@@ -6,13 +6,33 @@ Este documento registra el punto de referencia usado para comparar este fork con
 
 - **URL upstream:** `https://github.com/openai/gpt-oss`
 - **Remoto Git local:** `upstream`
-- **Commit exacto de `openai/gpt-oss` usado como base común:** `4931694686fadfa74a80554473d32f7dd4d059f3`
-- **Commit actual observado en `upstream/main` durante la sincronización:** `d21f34ec3c1ede813adfbd83f07d2ad2eec7ff02`
-- **Fecha de sincronización:** `2026-07-13` (UTC)
+- **Commit exacto de `openai/gpt-oss` usado como base del fork:** `4931694686fadfa74a80554473d32f7dd4d059f3`
+- **Fecha del commit base upstream:** `2025-08-05T17:52:43-07:00`
+- **Asunto del commit base upstream:** `fix build`
+- **Commit observado en `upstream/main` tras `git fetch upstream --prune`:** `d21f34ec3c1ede813adfbd83f07d2ad2eec7ff02`
+- **Fecha del commit observado en `upstream/main`:** `2026-06-09T15:51:19-07:00`
+- **Fecha de esta sincronización:** `2026-07-14` (UTC)
 
-## Resumen de conflictos resueltos
+## Ramas y referencias comparadas
 
-No se realizó una fusión automática de `upstream/main` en esta actualización documental. Por tanto, no hubo conflictos de Git que resolver en este paso. El fork mantiene sus cambios locales sobre el punto base indicado y deja documentado el remoto upstream para futuras sincronizaciones controladas.
+- **Rama local sincronizada:** `work`
+- **HEAD local durante la auditoría:** `40fffb28f73226ec6c953aa31fe1fb988d928d23`
+- **Rama upstream comparada:** `upstream/main`
+- **Comparación de preservación local:** `4931694686fadfa74a80554473d32f7dd4d059f3..HEAD`
+- **Comparación recomendada contra upstream actual:** `upstream/main...HEAD`
+
+Git no devolvió un `merge-base` directo entre `HEAD` local y `upstream/main`, por lo que el punto base se registra de forma explícita con el SHA completo anterior. Ese commit sí existe en los objetos descargados desde upstream y está contenido en `upstream/main`.
+
+## Resumen de conflictos y resoluciones
+
+No se realizó una fusión automática ni un rebase de `upstream/main` sobre la rama local en esta sincronización. Por tanto, no hubo conflictos de Git que resolver en archivos de código.
+
+Resoluciones aplicadas en esta actualización:
+
+- Se añadió/configuró el remoto local `upstream` apuntando a `https://github.com/openai/gpt-oss`.
+- Se ejecutó `git fetch upstream --prune` para actualizar las referencias remotas.
+- Se seleccionó y verificó el commit base exacto `4931694686fadfa74a80554473d32f7dd4d059f3`.
+- Se conservan las extensiones locales del fork y se añade una auditoría automatizada para exigir que este SHA base permanezca documentado.
 
 Al sincronizar en el futuro, deben preservarse explícitamente las extensiones AGI/AGIX añadidas en este fork y revisar cualquier conflicto que afecte a los módulos listados abajo.
 
@@ -23,9 +43,14 @@ Las siguientes extensiones del fork deben conservarse durante comparaciones, reb
 - `agicore_core/`: configuración AGIX/Qualia, `QualiaNode`, `CoreQualiaEngine`, `SafetyGate`, adaptadores AGIX y kernel de razonamiento.
 - `gpt_oss/planner.py`: modos de planificación que pueden ajustarse mediante memoria.
 - `meta_router.py`: enrutado de expertos con memoria episódica y señales Qualia.
-- `gpt_oss/strategic_memory.py`: memoria RAM/SQLite, redacción de secretos, auditoría y aprendizaje inferencial seguro.
 - `agicore_core/reasoning_kernel.py`: kernel de razonamiento preservado para el fork.
+- `gpt_oss/strategic_memory.py`: memoria RAM/SQLite, redacción de secretos, auditoría y aprendizaje inferencial seguro.
+- `ReasoningKernel`: extensión local disponible en `agicore_core/reasoning_kernel.py` y reexportada desde `agicore_core`.
 - `gpt_oss/responses_api/inference/qualia_guard.py`: preflight contextual y filtrado de salida de Responses API.
+
+## Auditoría obligatoria
+
+La prueba `tests/test_upstream_sync_audit.py` y el script independiente `scripts/audit_upstream_sync.py` fallan si `docs/upstream_sync.md` deja de contener el SHA upstream base completo `4931694686fadfa74a80554473d32f7dd4d059f3` o si el documento ya no menciona las ramas/referencias comparadas.
 
 ## Advertencia de fork experimental
 

--- a/scripts/audit_upstream_sync.py
+++ b/scripts/audit_upstream_sync.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Audit the documented upstream synchronization base SHA."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+UPSTREAM_BASE_SHA = "4931694686fadfa74a80554473d32f7dd4d059f3"
+REQUIRED_MARKERS = (
+    UPSTREAM_BASE_SHA,
+    "upstream/main",
+    "work",
+    "git fetch upstream --prune",
+)
+
+
+def main() -> int:
+    sync_doc = Path("docs/upstream_sync.md")
+    content = sync_doc.read_text(encoding="utf-8")
+    missing = [marker for marker in REQUIRED_MARKERS if marker not in content]
+    if missing:
+        print("docs/upstream_sync.md is missing required upstream sync markers:")
+        for marker in missing:
+            print(f"- {marker}")
+        return 1
+
+    print(f"Upstream sync audit passed for base SHA {UPSTREAM_BASE_SHA}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_upstream_sync_audit.py
+++ b/tests/test_upstream_sync_audit.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+UPSTREAM_BASE_SHA = "4931694686fadfa74a80554473d32f7dd4d059f3"
+
+
+def test_upstream_sync_documents_exact_base_sha():
+    sync_doc = Path("docs/upstream_sync.md")
+
+    content = sync_doc.read_text(encoding="utf-8")
+
+    assert UPSTREAM_BASE_SHA in content
+    assert "upstream/main" in content
+    assert "work" in content
+    assert "git fetch upstream --prune" in content


### PR DESCRIPTION
### Motivation
- Registrar de forma explícita el punto base usado para comparar este fork con `openai/gpt-oss` y dejar trazabilidad de la sincronización upstream. 
- Asegurar que las extensiones locales críticas (AGIX/Qualia, MetaRouter, ReasoningKernel, memoria estratégica, planner) se preserven/enumeren para fusiones futuras. 

### Description
- Se actualiza `docs/upstream_sync.md` para incluir el SHA upstream base `4931694686fadfa74a80554473d32f7dd4d059f3`, la fecha y asunto del commit base, el SHA observado en `upstream/main`, la rama local comparada (`work`) y un resumen de conflictos/resoluciones. 
- Se añade un script de auditoría ejecutable `scripts/audit_upstream_sync.py` que falla si `docs/upstream_sync.md` deja de contener el SHA base u otros marcadores requeridos. 
- Se añade una prueba pytest `tests/test_upstream_sync_audit.py` con la misma verificación para integración en CI. 
- Se verificó la presencia de las extensiones locales listadas en la documentación (`agicore_core/`, `gpt_oss/planner.py`, `meta_router.py`, `agicore_core/reasoning_kernel.py`, `gpt_oss/strategic_memory.py`, y `gpt_oss/responses_api/inference/qualia_guard.py`). 

### Testing
- Se ejecutó el script de auditoría local con `python scripts/audit_upstream_sync.py` y devolvió éxito (audit passed). 
- La prueba `pytest` añadida no pudo ejecutarse completamente en este entorno porque la carga de `tests/conftest.py` requiere la dependencia `openai_harmony`, que no está instalada; por tanto `pytest` quedó bloqueado por la dependencia del entorno. 
- Se verificó que el remoto upstream está configurado y que `upstream/main` y el SHA base documentado existen en las referencias remotas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a565953f0248327b53a8eb9609e0fc3)